### PR TITLE
Compute correctly the week numbers in Lent

### DIFF
--- a/lib/seasons.js
+++ b/lib/seasons.js
@@ -530,7 +530,7 @@ var _lent = function() {
       name: Utils.localize({
         key: ( _.gt( i, 0 ) && _.lt( i, 4 ) ) ?  'lent.day_after_ash_wed' : 'lent.weekday',
         day: value.format('dddd'),
-        week: Math.floor( i / 7 ) + 1
+        week: Math.floor( (i - 4) / 7 ) + 1
       }),
       data: {
         season: {

--- a/test/02_seasons.js
+++ b/test/02_seasons.js
@@ -100,6 +100,14 @@ describe('Testing date range functions', function() {
         _.last( Dates.sundaysOfLent( i ) ).isSame( Dates.palmSunday( i ) ).should.be.eql(true);
       }
     });
+
+    it('The Saturday in the week after Ash Wednesday should be in the 1st week of Lent', function() {
+      Seasons.lent( 2017 ).filter(d => d.type === 'WEEKDAY')[10].key.toLowerCase().should.be.eql('saturdayofthe1stweekoflent');
+    });
+
+    it('The 2nd Sunday of Lent should be in the 2nd week of Lent', function() {
+      Seasons.lent( 2017 ).filter(d => d.type === 'WEEKDAY')[11].key.toLowerCase().should.be.eql('sundayofthe2ndweekoflent');
+    });
   });
 
   describe('The Octave of Easter', function() {


### PR DESCRIPTION
During lent, weeks was starting on Wednesday instead of Sunday.

This fix remove the first 4 days of lent (Ash Wednesday to Saturday) when computing the week number.