### PR TITLE
Fix a celebration date and remove a duplicate

### DIFF
--- a/src/calendars/england.js
+++ b/src/calendars/england.js
@@ -404,7 +404,7 @@ let dates = year => {
       "data": {}
     },
     {
-      "key": "saintAndrewApostle",
+      "key": "saintAndrewTheApostle",
       "type": Types.FEAST,
       "moment": moment.utc({ year: year, month: 10, day: 30 }),
       "data": {

--- a/src/calendars/england.js
+++ b/src/calendars/england.js
@@ -91,7 +91,7 @@ let dates = year => {
     {
       "key": "saintAdalbertBishopAndMartyrSaintFidelisOfSigmaringenPriestAndMartyr",
       "type": Types.OPT_MEMORIAL,
-      "moment": moment.utc({ year: year, month: 4, day: 24 }),
+      "moment": moment.utc({ year: year, month: 3, day: 24 }),
       "data": {
         "meta": {
           "liturgicalColor": LiturgicalColors.RED,

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -252,7 +252,6 @@ export default {
     "saintAmandMissionary": "Saint Amand, Missionary",
     "saintAmbroseBishopAndDoctor": "Saint Ambrose, Bishop and Doctor",
     "saintAndreBessetteReligious": "Saint Andre Bessette, Religious",
-    "saintAndrewApostle": "Saint Andrew, Apostle",
     "saintAndrewBobolaPriestAndMartyr": "Saint Andrew Bobola, Priest and Martyr",
     "saintAndrewDungLacAndCompanionsMartyrs": "Saint Andrew Dung-Lac and Companions, Martyrs",
     "saintAndrewKimTaegonPriestAndPaulChongHasangAndCompanionsMartyrs": "Saint Andrew Kim Taegon, Priest, and Paul Chong Hasang and Companions, Martyrs",

--- a/src/locales/sk.js
+++ b/src/locales/sk.js
@@ -245,7 +245,6 @@ export default {
     "saintAmandMissionary": "Svätého Milana, biskupa",
     "saintAmbroseBishopAndDoctor": "Svätého Ambróza, biskupa a učiteľa Cirkvi",
     "saintAndreBessetteReligious": "Svätého Andreja Alfréda Bessetta, rehoľníka",
-    "saintAndrewApostle": "Saint Andrew, Apostle",
     "saintAndrewBobolaPriestAndMartyr": "Svätého Andreja Bobolu, kňaza a mučeníka",
     "saintAndrewDungLacAndCompanionsMartyrs": "Svätého Ondreja Dung-Laka, kňaza, a spoločníkov, mučeníkov",
     "saintAndrewKimTaegonPriestAndPaulChongHasangAndCompanionsMartyrs": "Svätých Ondreja Kima Taegona, kňaza, Pavla Chonga Hasanga a spoločníkov, mučeníkov",


### PR DESCRIPTION
- Fix the date of celebration of St Adalbert and St Fidelis in England;
- Remove `saintAndrewApostle` from `en.js` and `sk.js`;
- Replace `saintAndrewApostle` with `saintAndrewTheApostle` in `england.js`.
