### PR TITLE
Output all available object per days (including optionals) & Introduce `strictMode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Romcal.calendarFor({
   epiphanyOnSunday: true | false,           // Epiphany always a Sunday (between January 2 - 8), or on January 6
   corpusChristiOnSunday: true | false,      // Corpus Christi always a Sunday, or the Thursday after Trinity Sunday
   ascensionOnSunday: true | false,          // Ascension always a Sunday, or the 40th day of Easter (a Thursday)
-  outputOptionalMemorials: true | false,    // also output available optional memorials, in addition of a weedkay
+  strictMode: true | false,                 // if true, only output one object per day ; optional memorials are not outputed
   verbose: true | false,                    // enable logging output from romcal
   prettyPrint: true | false,                // prettify logs printed in the console, for a better experience in development environnements
 }).then(function (calendar) {

--- a/__tests__/calendar_date_overrides.test.ts
+++ b/__tests__/calendar_date_overrides.test.ts
@@ -42,11 +42,10 @@ describe('Testing national calendar overrides', () => {
     let spainDates2020: LiturgicalDay[];
 
     beforeAll(async () => {
-      generalDates2020 = await Romcal.calendarFor({ year: 2020, outputOptionalMemorials: true });
-      generalDates2021 = await Romcal.calendarFor({ year: 2021, outputOptionalMemorials: true });
+      generalDates2020 = await Romcal.calendarFor(2020);
+      generalDates2021 = await Romcal.calendarFor(2021);
       spainDates2020 = await Romcal.calendarFor({
         year: 2020,
-        outputOptionalMemorials: true,
         country: 'spain',
       });
     });
@@ -85,8 +84,8 @@ describe('Testing national calendar overrides', () => {
 
     beforeAll(async () => {
       year = 2008;
-      generalDates = await Romcal.calendarFor({ year, outputOptionalMemorials: true });
-      spainDates = await Romcal.calendarFor({ year, outputOptionalMemorials: true, country: 'spain' });
+      generalDates = await Romcal.calendarFor({ year });
+      spainDates = await Romcal.calendarFor({ year, country: 'spain' });
     });
 
     test('The feast of Saint Isidore of Seville is celebrated on April 4 every year', () => {
@@ -118,7 +117,6 @@ describe('Testing national calendar overrides', () => {
       testDates = await Romcal.calendarFor({
         country: 'test',
         year,
-        outputOptionalMemorials: true,
       });
     });
 
@@ -391,12 +389,10 @@ describe('Testing national calendar overrides', () => {
       const germanyDates = await Romcal.calendarFor({
         year: 2018,
         country: 'germany',
-        outputOptionalMemorials: true,
       });
       const hungaryDates = await Romcal.calendarFor({
         year: 2018,
         country: 'hungary',
-        outputOptionalMemorials: true,
       });
 
       const matthiasApostleGermany = germanyDates.find((d) => d.key === 'matthias_apostle');
@@ -424,7 +420,6 @@ describe('Testing national calendar overrides', () => {
       });
       const dates = await Romcal.calendarFor({
         year: 2019,
-        outputOptionalMemorials: true,
       });
       const christopherMagallanesPriestAndCompanionsMartyrs = dates.find((d) => {
         return d.key === 'christopher_magallanes_priest_and_companions_martyrs';
@@ -442,12 +437,10 @@ describe('Testing national calendar overrides', () => {
       const hungaryDates = await Romcal.calendarFor({
         year: 2018,
         country: 'hungary',
-        outputOptionalMemorials: true,
       });
       const slovakiaDates = await Romcal.calendarFor({
         year: 2018,
         country: 'slovakia',
-        outputOptionalMemorials: true,
       });
       const ladislausIOfHungaryHungary = hungaryDates.find((d) => {
         return d.key === 'ladislaus_i_of_hungary';

--- a/__tests__/use_cases.test.ts
+++ b/__tests__/use_cases.test.ts
@@ -68,7 +68,7 @@ describe('Testing specific feasts and memorials', () => {
 
   describe('The celebrations of Pope Saint John XXIII and Pope Saint John Paul II', () => {
     test('Should be celebrated as optional memorials', async () => {
-      const dates = await Romcal.calendarFor({ year: 2016, outputOptionalMemorials: true });
+      const dates = await Romcal.calendarFor(2016);
 
       const johnXxiiiPope = dates.find((d) => d.key === 'john_xxiii_pope');
       const johnPaulIiPope = dates.find((d) => d.key === 'john_paul_ii_pope');

--- a/docs/general-usage.md
+++ b/docs/general-usage.md
@@ -25,7 +25,7 @@ Romcal.calendarFor({
   epiphanyOnSunday: true | false,
   corpusChristiOnSunday: true | false,
   ascensionOnSunday: true | false,
-  outputOptionalMemorials: true | false,
+  strictMode: true | false,
   verbose: true | false,
   prettyPrint: true | false,
 });
@@ -71,14 +71,14 @@ Romcal.liturgicalDayFor(date, {
   epiphanyOnSunday: true | false,
   corpusChristiOnSunday: true | false,
   ascensionOnSunday: true | false,
-  outputOptionalMemorials: true | false,
+  strictMode: true | false,
   verbose: true | false,
   prettyPrint: true | false,
 });
 ```
 
-This returns an `Array` containing the `LiturgicalDay` object, that match the provided `date` parameter.
-In case the `outputOptionalMemorials` option is set to `true`, romcal will also output optional memorials that could be available the same date.
+This returns an `Array` containing first the relevant `LiturgicalDay` object, followed by optional memorials or commemorations objects that also match the provided `date` parameter.
+If the `strictMode` option is set to `true`, romcal strictly output the more relevant `LiturgicalDay` object, so only one object per day.
 
 e.g. to obtain today's liturgical day:
 
@@ -103,7 +103,7 @@ Note that under the hood, romcal always compute data for a whole liturgical year
 This is necessary to ensure that the right liturgical day is computed for every date:
 each liturgical day is depending on the proper of seasons or the sanctorale, and might be defined according to each other (including all [moveable feast](https://en.wikipedia.org/wiki/Moveable_feast)).
 
-:warning: For performance reasons, if you need to retrieve data from different dates in the same year, it will be highly recommended to compute once a calendar (using the `.calendarFor` method), and then use the filtering methods to get all the desired dates.
+:warning: For performance reasons, if you need to retrieve data from different dates in the same year, it will be highly recommended computing once a calendar (using the `.calendarFor` method), and then use the filtering methods to get all the desired dates.
 
 ## Configuration options
 
@@ -182,10 +182,10 @@ Default:
 - `false` (Ascension is celebrated on Thursday by default).
 - Or if provided, defaults to the setting defined in the particular calendar you are fetching through romcal.
 
-### `outputOptionalMemorials`
+### `strictMode`
 
-- `true`: in the romcal output, also includes optional liturgical days and commemorations that could be celebrated on each day (in addition to the weekday).
-- `false`: romcal output strictly one liturgical day per date, according to the calendar definitions and the missal rules. So you will get exactly 365 liturgical days within a Gregorian scope (366 in leap years).
+- `true`: strictly output one liturgical day per date, according to the calendar definitions and the missal rules. So you will get exactly 365 liturgical days within a Gregorian scope (366 in leap years).
+- `false`: also outputs optional liturgical days and commemorations that could be celebrated on each day (in addition to the weekday). The more relevant liturgical day object is output first in the array.
 
 Default: `false`.
 
@@ -273,8 +273,7 @@ var easterAndDaysBefore = (await Romcal.calendarFor()).getDaysSameOrBefore('east
 
 Get the liturgical day(s) that match the provided criteria.
 
-If the `outputOptionalMemorials` is set to `true`, you might obtain multiple liturgical days for one date:
-the default weekday and the possible optional memorials.
+If the `strictMode` is set to `true`, you will obtain strictly on item per day. Optional memorials or commemorations are not outputted.
 
 ```javascript
 // Types: getLiturgicalDay(dateOrKey: Date | string): RomcalCalendar

--- a/src/lib/calendar-builder.test.ts
+++ b/src/lib/calendar-builder.test.ts
@@ -99,13 +99,13 @@ describe('Testing calendar generation functions', () => {
   });
 
   describe('Testing calendar options', () => {
-    test('Array should be 366 long on leap years', async () => {
-      const calendar = await Romcal.calendarFor({ year: 2020 });
+    test('Array should be exactly 366 long on leap years, when strict mode is enabled', async () => {
+      const calendar = await Romcal.calendarFor({ year: 2020, strictMode: true });
       expect(calendar.length).toBe(366);
     });
 
-    test('Array should be more than 366 long, when output for optional memorials and commemorations is enabled', async () => {
-      const calendar = await Romcal.calendarFor({ year: 2020, outputOptionalMemorials: true });
+    test('Array should be more than 366 long (also containing optional memorials and commemorations)', async () => {
+      const calendar = await Romcal.calendarFor({ year: 2020 });
       expect(calendar.length).toBeGreaterThan(366);
     });
   });

--- a/src/lib/calendar-builder.ts
+++ b/src/lib/calendar-builder.ts
@@ -425,11 +425,11 @@ export class CalendarBuilder {
     const ranks = RANKS.slice(0, RANKS.length - 1);
     ranks.splice(ranks.indexOf(Ranks.MEMORIAL) + 1, 0, RANKS[RANKS.length - 1]);
 
-    // Remove optional memorials and commemorations by default, to keep only
+    // Remove optional memorials and commemorations, to keep only
     // relevant celebrations that exactly match for every days.
-    // This can be disabled by specifying the `outputOptionalMemorials` flag
-    // to `true` in the romcal config.
-    if (!this._config.outputOptionalMemorials) {
+    // This can be enabled by specifying the `strictMode` flag to `true`
+    // in the romcal config.
+    if (this._config.strictMode) {
       // Note: the array is being re-indexed on every .splice()
       // Solution: iterate in reverse, since the indexing affects only the items
       // from the current point to the end of the Array,

--- a/src/models/config/config.model.ts
+++ b/src/models/config/config.model.ts
@@ -47,10 +47,10 @@ export interface BaseRomcalConfig {
    */
   readonly ascensionOnSunday?: boolean;
   /**
-   * If true, available optional memorials or commemorations are also outputted,
-   * in addition to the weekday.
+   * If true, output strictly the relevant liturgical day per date.
+   * Optional memorials or commemorations available for a specific day are not outputted.
    */
-  readonly outputOptionalMemorials?: boolean;
+  readonly strictMode?: boolean;
   /**
    * The calendar scope to query for.
    *
@@ -92,7 +92,7 @@ export class RomcalConfig implements BaseRomcalConfig {
   private readonly _epiphanyOnSunday: boolean;
   private readonly _corpusChristiOnSunday: boolean;
   private readonly _ascensionOnSunday: boolean;
-  private readonly _outputOptionalMemorials: boolean;
+  private readonly _strictMode: boolean;
   private readonly _scope: RomcalCalendarScope;
   private readonly _verbose: boolean;
   private readonly _prettyPrint: boolean;
@@ -108,7 +108,7 @@ export class RomcalConfig implements BaseRomcalConfig {
     epiphanyOnSunday,
     corpusChristiOnSunday,
     ascensionOnSunday,
-    outputOptionalMemorials,
+    strictMode,
     scope,
     verbose,
     prettyPrint,
@@ -119,7 +119,7 @@ export class RomcalConfig implements BaseRomcalConfig {
     this._epiphanyOnSunday = epiphanyOnSunday;
     this._corpusChristiOnSunday = corpusChristiOnSunday;
     this._ascensionOnSunday = ascensionOnSunday;
-    this._outputOptionalMemorials = outputOptionalMemorials;
+    this._strictMode = strictMode;
     this._scope = scope;
     this._verbose = verbose;
     this._prettyPrint = prettyPrint;
@@ -153,8 +153,8 @@ export class RomcalConfig implements BaseRomcalConfig {
     return this._ascensionOnSunday;
   }
 
-  get outputOptionalMemorials(): boolean {
-    return this._outputOptionalMemorials;
+  get strictMode(): boolean {
+    return this._strictMode;
   }
 
   get scope(): RomcalCalendarScope {
@@ -180,7 +180,7 @@ export class RomcalConfig implements BaseRomcalConfig {
       epiphanyOnSunday: this.epiphanyOnSunday,
       corpusChristiOnSunday: this._corpusChristiOnSunday,
       ascensionOnSunday: this._ascensionOnSunday,
-      outputOptionalMemorials: this._outputOptionalMemorials,
+      strictMode: this._strictMode,
       scope: this._scope,
       verbose: this._verbose,
       prettyPrint: this._prettyPrint,
@@ -266,7 +266,7 @@ export class RomcalConfig implements BaseRomcalConfig {
       epiphanyOnSunday: !!config.epiphanyOnSunday, // Will use default if not defined
       corpusChristiOnSunday: !!config.corpusChristiOnSunday, // Will use default if not defined
       ascensionOnSunday: !!config.ascensionOnSunday, // Will use default if not defined
-      outputOptionalMemorials: !!config.outputOptionalMemorials,
+      strictMode: !!config.strictMode,
       scope: config.scope ?? 'gregorian', // Use the default value "gregorian" if scope not specified by user
       verbose: !!config.verbose,
       prettyPrint: !!config.prettyPrint,

--- a/src/models/config/config.test.ts
+++ b/src/models/config/config.test.ts
@@ -6,14 +6,15 @@ describe('getConfig()', () => {
   // eslint-disable-next-line prettier/prettier
   test('should get general config if country doesnt have default configurations', async () => {
     const resolvedConfig = await RomcalConfig.resolveConfig();
-    const { year, scope, locale, epiphanyOnSunday, country, corpusChristiOnSunday, outputOptionalMemorials } =
-      new RomcalConfig(resolvedConfig);
+    const { year, scope, locale, epiphanyOnSunday, country, corpusChristiOnSunday, strictMode } = new RomcalConfig(
+      resolvedConfig,
+    );
     expect(year).toBe(dayjs.utc().year());
     expect(scope).toBe('gregorian');
     expect(locale).toBe('en');
     expect(epiphanyOnSunday).toBeTrue();
     expect(country).toBe('general');
     expect(corpusChristiOnSunday).toBeTrue();
-    expect(outputOptionalMemorials).toBe(false);
+    expect(strictMode).toBe(false);
   });
 });

--- a/src/validators/config.validator.ts
+++ b/src/validators/config.validator.ts
@@ -22,7 +22,7 @@ export const getRomcalConfigJsonSchema = (): Schema => ({
     epiphanyOnSunday: { type: 'boolean' },
     corpusChristiOnSunday: { type: 'boolean' },
     ascensionOnSunday: { type: 'boolean' },
-    outputOptionalMemorials: { type: 'boolean' },
+    strictMode: { type: 'boolean' },
     scope: { type: 'string', enum: ['gregorian', 'liturgical'] },
     verbose: { type: 'boolean' },
     prettyPrint: { type: 'boolean' },


### PR DESCRIPTION
@tukusejssirs we add the discussion (https://github.com/romcal/romcal/pull/250#issuecomment-735299623, and here https://github.com/romcal/romcal/issues/270#issuecomment-814001842) about output by default all available celebrations per day. The more relevant first, followed by all optional memorials or commemorations.

Actually, only one liturgical day object is output per day. To get other optional objects, you need to set `outputOptionalMemorials: true`.

---

This PR proposes to remove `outputOptionalMemorials`, and introduce a new `strictMode` option.

- `false` (default): everything that match a specific day is output. The more relevant first, followed by optional memorials or commemorations.
- `true`: only the relevant liturgical day is output. So only one object per day. Which means exactly 365 objects in non-leap years.

@tukusejssirs: What do you think?
