### PR TITLE
Add orderBy dates syntactic sugar

### DIFF
--- a/docs/general-usage.md
+++ b/docs/general-usage.md
@@ -356,13 +356,13 @@ var easterDate = calendar.getDate('easter_sunday'); // "2020-04-12T00:00:00.000Z
 
 romcal offers a convenient way to group data by various criteria. The supported criteria are:
 
-`dates` | `days` | `months` | `daysByMonth` | `weeksByMonth` | `sundayCycles` | `weekdayCycles` | `ranks` | `liturgicalSeasons` | `liturgicalColors` | `psalterWeeks`
+`date` | `day` | `month` | `dayByMonth` | `weekByMonth` | `sundayCycle` | `weekdayCycle` | `rank` | `liturgicalSeason` | `liturgicalColor` | `psalterWeek`
 
 For example:
 
 ```javascript
 Romcal.calendarFor({ year: 2020, locale: 'en' }).then((calendar) => {
-  const byRanks = calendar.groupBy('ranks');
+  const byRanks = calendar.groupBy('rank');
   console.log(byRanks);
 });
 ```

--- a/docs/general-usage.md
+++ b/docs/general-usage.md
@@ -356,7 +356,7 @@ var easterDate = calendar.getDate('easter_sunday'); // "2020-04-12T00:00:00.000Z
 
 romcal offers a convenient way to group data by various criteria. The supported criteria are:
 
-`days` | `months` | `daysByMonth` | `weeksByMonth` | `sundayCycles` | `weekdayCycles` | `ranks` | `liturgicalSeasons` | `liturgicalColors` | `psalterWeeks`
+`dates` | `days` | `months` | `daysByMonth` | `weeksByMonth` | `sundayCycles` | `weekdayCycles` | `ranks` | `liturgicalSeasons` | `liturgicalColors` | `psalterWeeks`
 
 For example:
 

--- a/src/constants/group-by-option/group-by.constant.ts
+++ b/src/constants/group-by-option/group-by.constant.ts
@@ -2,6 +2,7 @@
  * All the possible grouping variants that can be supported by romcal.
  */
 export const GROUP_BY = [
+  'dates',
   'days',
   'months',
   'daysByMonth',

--- a/src/constants/group-by-option/group-by.constant.ts
+++ b/src/constants/group-by-option/group-by.constant.ts
@@ -2,15 +2,15 @@
  * All the possible grouping variants that can be supported by romcal.
  */
 export const GROUP_BY = [
-  'dates',
-  'days',
-  'months',
-  'daysByMonth',
-  'weeksByMonth',
-  'sundayCycles',
-  'weekdayCycles',
-  'ranks',
-  'liturgicalSeasons',
-  'liturgicalColors',
-  'psalterWeeks',
+  'date',
+  'day',
+  'month',
+  'dayByMonth',
+  'weekByMonth',
+  'sundayCycle',
+  'weekdayCycle',
+  'rank',
+  'liturgicalSeason',
+  'liturgicalColor',
+  'psalterWeek',
 ] as const;

--- a/src/lib/calendar-builder.test.ts
+++ b/src/lib/calendar-builder.test.ts
@@ -148,12 +148,12 @@ describe('Testing calendar generation functions', () => {
 
   describe('Testing grouping feature filters', () => {
     test('Should group dates by days in a week', async () => {
-      const calendar = (await Romcal.calendarFor()).groupBy('days');
+      const calendar = (await Romcal.calendarFor()).groupBy('day');
       expect(Object.keys(calendar)).toEqual(['0', '1', '2', '3', '4', '5', '6']);
     });
 
     test('Should group dates by months in the year', async () => {
-      expect(Object.keys((await Romcal.calendarFor()).groupBy('months'))).toEqual([
+      expect(Object.keys((await Romcal.calendarFor()).groupBy('month'))).toEqual([
         '0',
         '1',
         '2',
@@ -170,7 +170,7 @@ describe('Testing calendar generation functions', () => {
     });
 
     test('Should group days of week by the months they belong to', async () => {
-      const dates = (await Romcal.calendarFor()).groupBy('daysByMonth');
+      const dates = (await Romcal.calendarFor()).groupBy('dayByMonth');
       Object.values(dates).forEach((monthGroup: Dictionary<LiturgicalDay[]>, monthIndex: number) => {
         Object.values(monthGroup).forEach((dateItems: LiturgicalDay[], dayIndex: number) => {
           dateItems.forEach((dateItem) => {
@@ -182,7 +182,7 @@ describe('Testing calendar generation functions', () => {
     });
 
     test('Should group weeks of year by the months they belong to', async () => {
-      const items = (await Romcal.calendarFor()).groupBy('weeksByMonth');
+      const items = (await Romcal.calendarFor()).groupBy('weekByMonth');
 
       // First level is months
       Object.keys(items).forEach((monthKey) => {
@@ -200,23 +200,23 @@ describe('Testing calendar generation functions', () => {
 
     test('Should group dates by their respective liturgical sunday cycles', async () => {
       const calendar = await Romcal.calendarFor({ year: 2015 });
-      const items = calendar.groupBy('sundayCycles');
+      const items = calendar.groupBy('sundayCycle');
       expect(Object.keys(items)).toEqual(['YEAR_B', 'YEAR_C']);
     });
 
     test('Should group dates by their respective liturgical weekday cycles', async () => {
       const calendar = await Romcal.calendarFor({ year: 2015 });
-      const items = calendar.groupBy('weekdayCycles');
+      const items = calendar.groupBy('weekdayCycle');
       expect(Object.keys(items)).toEqual(['YEAR_1', 'YEAR_2']);
     });
 
     test('Should group dates by their liturgical day ranks', async () => {
-      const typeKeys = Object.keys((await Romcal.calendarFor()).groupBy('ranks'));
+      const typeKeys = Object.keys((await Romcal.calendarFor()).groupBy('rank'));
       expect(typeKeys.every((typeKey) => Object.values(RANKS).includes(typeKey as RomcalRank))).toBeTrue();
     });
 
     test('Should group dates by their liturgical seasons', async () => {
-      const liturgicalSeasonGroupings = (await Romcal.calendarFor()).groupBy('liturgicalSeasons');
+      const liturgicalSeasonGroupings = (await Romcal.calendarFor()).groupBy('liturgicalSeason');
       expect(
         Object.keys(liturgicalSeasonGroupings).every((liturgicalSeasonKey) =>
           (LITURGICAL_SEASONS as string[]).includes(liturgicalSeasonKey),
@@ -225,14 +225,14 @@ describe('Testing calendar generation functions', () => {
     });
 
     test('Should group dates by their psalter weeks', async () => {
-      const psalterWeekKeys = Object.keys((await Romcal.calendarFor()).groupBy('psalterWeeks'));
+      const psalterWeekKeys = Object.keys((await Romcal.calendarFor()).groupBy('psalterWeek'));
       expect(psalterWeekKeys.sort()).toStrictEqual(PSALTER_WEEKS);
     });
   });
 
   describe('Testing liturgical colors', () => {
     test('The proper color of a Memorial or a Feast is white except for martyrs in which case it is red, and All Souls which is purple', async () => {
-      const calendar = (await Romcal.calendarFor()).groupBy('ranks');
+      const calendar = (await Romcal.calendarFor()).groupBy('rank');
       _.get(calendar, Ranks.FEAST).forEach((d) => {
         if (d.key === 'exaltation_of_the_holy_cross') {
           expect(d.liturgicalColors[0]).toEqual(LiturgicalColors.RED);

--- a/src/lib/seasons.test.ts
+++ b/src/lib/seasons.test.ts
@@ -221,7 +221,7 @@ describe('Testing seasons utility functions', () => {
 
   describe('The liturgical year is divided to a number of seasons', () => {
     test('Groups dates within seasons based on identifiers', async () => {
-      const calendar = (await Romcal.calendarFor()).groupBy('liturgicalSeasons');
+      const calendar = (await Romcal.calendarFor()).groupBy('liturgicalSeason');
       for (const liturgicalSeason in calendar) {
         if (calendar.hasOwnProperty(liturgicalSeason)) {
           const dates = calendar[liturgicalSeason];

--- a/src/models/calendar/calendar.model.ts
+++ b/src/models/calendar/calendar.model.ts
@@ -91,6 +91,9 @@ export class RomcalCalendar extends Array implements BaseRomcalCalendar {
       case 'days':
         return _groupBy((item: LiturgicalDay) => new Date(item.date).getUTCDay());
 
+      case 'dates':
+        return _groupBy((item: LiturgicalDay) => new Date(item.date).toISOString().substr(0, 10));
+
       default:
         return { undefined: liturgicalDays };
     }

--- a/src/models/calendar/calendar.model.ts
+++ b/src/models/calendar/calendar.model.ts
@@ -32,7 +32,7 @@ export class RomcalCalendar extends Array implements BaseRomcalCalendar {
    */
   public groupBy<T extends LiturgicalDayGroupBy>(
     criteria: T,
-  ): T extends 'daysByMonth' | 'weeksByMonth' // when the criteria have one of these values
+  ): T extends 'dayByMonth' | 'weekByMonth' // when the criteria have one of these values
     ? Dictionary<RomcalCalendar>[]
     : Dictionary<RomcalCalendar>;
   public groupBy(criteria: LiturgicalDayGroupBy): Dictionary<RomcalCalendar> | Dictionary<RomcalCalendar>[] {
@@ -47,10 +47,10 @@ export class RomcalCalendar extends Array implements BaseRomcalCalendar {
     };
 
     switch (criteria) {
-      case 'months':
+      case 'month':
         return _groupBy((item: LiturgicalDay) => new Date(item.date).getUTCMonth());
 
-      case 'daysByMonth':
+      case 'dayByMonth':
         return liturgicalDays.reduce((obj: Dictionary<RomcalCalendar>, item) => {
           const month = new Date(item.date).getUTCMonth();
           const days = new Date(item.date).getUTCDay();
@@ -59,7 +59,7 @@ export class RomcalCalendar extends Array implements BaseRomcalCalendar {
           return obj;
         }, {});
 
-      case 'weeksByMonth':
+      case 'weekByMonth':
         return liturgicalDays.reduce((obj: Dictionary<RomcalCalendar>, item) => {
           const month = new Date(item.date).getUTCMonth();
           const week = item.calendar.weekOfGregorianYear;
@@ -68,30 +68,30 @@ export class RomcalCalendar extends Array implements BaseRomcalCalendar {
           return obj;
         }, {});
 
-      case 'sundayCycles':
+      case 'sundayCycle':
         return _groupBy((item: LiturgicalDay) => item.cycles.sundayCycle);
 
-      case 'weekdayCycles':
+      case 'weekdayCycle':
         return _groupBy((item: LiturgicalDay) => item.cycles.weekdayCycle);
 
-      case 'ranks':
+      case 'rank':
         return _groupBy((item: LiturgicalDay) => item.rank);
 
       // Groups by the first liturgical season in the array
-      case 'liturgicalSeasons':
+      case 'liturgicalSeason':
         return _groupBy((item: LiturgicalDay) => item.seasons[0]);
 
       // Groups by the first liturgical color in the array
-      case 'liturgicalColors':
+      case 'liturgicalColor':
         return _groupBy((item: LiturgicalDay) => item.liturgicalColors[0]);
 
-      case 'psalterWeeks':
+      case 'psalterWeek':
         return _groupBy((item: LiturgicalDay) => item.cycles.psalterWeek);
 
-      case 'days':
+      case 'day':
         return _groupBy((item: LiturgicalDay) => new Date(item.date).getUTCDay());
 
-      case 'dates':
+      case 'date':
         return _groupBy((item: LiturgicalDay) => new Date(item.date).toISOString().substr(0, 10));
 
       default:


### PR DESCRIPTION
Fix https://github.com/romcal/romcal/issues/270.

Romcal will always output data as an array.
This `.groupBy('dates')` method is a syntactic sugar, that allows to quickly group outputted results by dates.

```js
const data = await Romcal.calendarFor({ year: 2021 });
const groupedByDates = data.groupBy('dates');
```

This also can be addressed natively by JavaScript (using a `reduce` method). But I think it will be a convenient method for any romcal users that are not too comfortable with JavaScript.

---

One thing I'm wondering, should the `groupBy` criteria should be singular or plural?
Here is the actual list of `groupBy` options: https://github.com/romcal/romcal/blob/_F-TypeScript/docs/general-usage.md#group-results-by-criteria
