### PR TITLE
fix: sanctorale spelling

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -30,12 +30,12 @@ The structure of the locale file is typically like so:
   liturgical_colors: {},
   ranks: {},
   celebrations: {},
-  sanctoral: {},
+  sanctorale: {},
 }
 ```
 
 The first 7 objects define locale keys used by `src/lib/Seasons.ts` when generating liturgical dates.
 
-The `celebrations` and `sanctoral` objects will hold localization for `src/lib/Celebrations.ts`, `src/calendars/general.ts` and `src/calendars/<country>.ts` respectively where the celebration `key` is used as an identifier for localization purposes.
+The `celebrations` and `sanctorale` objects will hold localization for `src/lib/Celebrations.ts`, `src/calendars/general.ts` and `src/calendars/<country>.ts` respectively where the celebration `key` is used as an identifier for localization purposes.
 
 See the end of these files to see the function that localizes the dates according to their keys.

--- a/src/lib/locales.test.ts
+++ b/src/lib/locales.test.ts
@@ -34,7 +34,7 @@ describe('Testing localization functionality', () => {
   test('If the locale is set to "en-gb", romcal should output text in British English', async () => {
     await Locales.setLocale('en-gb');
     const localizedName = await Locales.localize({
-      key: 'sanctoral.paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin',
+      key: 'sanctorale.paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin',
     });
     expect(localizedName).toBe('Saint Paulina of the Agonising Heart of Jesus Visintainer, Virgin');
   });

--- a/src/lib/locales.ts
+++ b/src/lib/locales.ts
@@ -269,22 +269,22 @@ const localize = async ({ key, count, week, day, useDefaultOrdinalFn }: RomcalLo
  * Allows the specification of a source where when defined, points the localization logic
  * to a specific sub-tree within the locale file to obtain localized values from.
  *
- * If the source is `temporal`, the logic will only use the key for the lookup.
+ * If the source is `temporale`, the logic will only use the key for the lookup.
  *
  * @param dates A list of [[RomcalDateItem]]s to process
  * @param source The source of the date to localize. This value is used to lookup a specific sub tree in the locale file for the localized value.
  */
 const localizeDates = async (
   dates: Array<LiturgicalDayInput>,
-  source: RomcalLiturgicalDaySources = 'sanctoral',
+  source: RomcalLiturgicalDaySources = 'sanctorale',
 ): Promise<LiturgicalDayInput[]> => {
   const promiseDates: Promise<LiturgicalDayInput>[] = dates.map(async (date: LiturgicalDayInput) => {
     if (date.name !== undefined) return Promise.resolve(date);
     return {
       ...date,
       name: await localize({
-        // If the source is `temporal`, do not append anything before the date key
-        key: `${source === 'temporal' ? date.key : !isNil(date.source) ? date.source : source}.${date.key}`,
+        // If the source is `temporale`, do not append anything before the date key
+        key: `${source === 'temporale' ? date.key : !isNil(date.source) ? date.source : source}.${date.key}`,
       }),
     } as LiturgicalDayInput;
   });

--- a/src/lib/seasons.ts
+++ b/src/lib/seasons.ts
@@ -87,7 +87,7 @@ const setMetadata = async (items: Array<LiturgicalDayInput>): Promise<Array<Litu
     return {
       ...rest,
       date,
-      source: 'temporal', // IMPORTANT! Refer to RomcalDateItem.source for more information
+      source: 'temporale', // IMPORTANT! Refer to RomcalDateItem.source for more information
     } as LiturgicalDayInput;
   });
   return await Promise.all(metadataPromises);
@@ -506,9 +506,10 @@ export class Seasons {
    * @param epiphanyOnSunday
    */
   static ordinaryTime = async (year: number, epiphanyOnSunday: boolean): Promise<LiturgicalDayInput[]> =>
-    Promise.all([Seasons.earlyOrdinaryTime(year, epiphanyOnSunday), Seasons.lateOrdinaryTime(year)]).then(
-      ([early, later]) => early.concat(later),
-    );
+    Promise.all([
+      Seasons.earlyOrdinaryTime(year, epiphanyOnSunday),
+      Seasons.lateOrdinaryTime(year),
+    ]).then(([early, later]) => early.concat(later));
 
   /**
    * Calculates the days in the season of Lent

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Proměnění Páně',
     trinity_sunday: 'Nejsvětější Trojice',
   },
-  sanctoral: {
+  sanctorale: {
     '205_blessed_martyrs_of_japan': 'Bl. 205 japonských mučedníků',
     adalbert_of_prague_bishop: 'Sv. Vojtěcha, biskupa a mučedníka',
     adalbert_of_prague_bishop_patron_of_poland: 'Sv. Vojtěcha, biskupa, mučedníka a patrona Polska',

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -28,7 +28,7 @@ export default {
     corpus_christi: 'Most Holy Body and Blood of the Lord',
     holy_thursday: 'Maundy Thursday',
   },
-  sanctoral: {
+  sanctorale: {
     bernardine_of_siena_priest: 'Saint Bernardine of Siena, Priest, Religious and Missionary', // TODO: This key should be removed after one can add titles within celebration definions
     louis_grignion_de_montfort_priest: 'Saint Louis Marie Grignion de Montfort, Priest',
     paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin:

--- a/src/locales/en-ie.ts
+++ b/src/locales/en-ie.ts
@@ -1,7 +1,7 @@
 import { RomcalLocale } from '@romcal/models/locale/romcal-locale.type';
 
 export default {
-  sanctoral: {
+  sanctorale: {
     columban_of_luxeuil_abbot: 'Saint Columban, Abbot and Missionary', // TODO: This key should be removed after one can add titles within celebration definions
     willibrord_of_utrecht_bishop: 'Saint Willibrord, Bishop and Missionary', // TODO: This key should be removed after one can add titles within celebration definions
   },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Transfiguration of the Lord',
     trinity_sunday: 'Most Holy Trinity',
   },
-  sanctoral: {
+  sanctorale: {
     '205_blessed_martyrs_of_japan': '205 Blessed Martyrs of Japan',
     adalbert_of_prague_bishop: 'Saint Adalbert, Bishop and Martyr',
     adalbert_of_prague_bishop_patron_of_poland: 'Saint Adalbert, Bishop, Martyr and Patron of Poland',

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Transfiguración',
     trinity_sunday: 'Domingo de la Santísima Trinidad',
   },
-  sanctoral: {
+  sanctorale: {
     '205_blessed_martyrs_of_japan': '205 Beatos y Mártires de Japón',
     adalbert_of_prague_bishop: 'San Adalberto, Obispo y Mártir',
     agatha_of_sicily_virgin: 'Santa Ágatha, Vírgen y Mártir',

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Transfiguration du Seigneur',
     trinity_sunday: 'Très Sainte Trinité',
   },
-  sanctoral: {
+  sanctorale: {
     adalbert_of_prague_bishop: 'Saint Adalbert, Évêque de Prague et Martyr (✝ 997)',
     adalbert_of_prague_bishop_patron_of_poland:
       'Saint Adalbert, Évêque de Prague, Martyr et Patron de la Pologne (✝ 997)',

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Trasfigurazione del Signore',
     trinity_sunday: 'Santissima Trinitá',
   },
-  sanctoral: {
+  sanctorale: {
     adalbert_of_prague_bishop: 'Sant’Adalberto, vescovo e martire',
     adalbert_of_prague_bishop_patron_of_poland: 'Sant’Adalberto, vescovo, martire e patrono della Polonia',
     agatha_of_sicily_virgin: 'Sant’Agata, vergine e martire',

--- a/src/locales/la.ts
+++ b/src/locales/la.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'In Transfiguratione Domini',
     trinity_sunday: 'Ss.mæ Trinitatis',
   },
-  sanctoral: {
+  sanctorale: {
     '205_blessed_martyrs_of_japan': 'B. Martyres Iaponici CCV',
     adalbert_of_prague_bishop: 'S. Adalberti, episcopi et martyris',
     adalbert_of_prague_bishop_patron_of_poland: 'S. Adalberti, episcopi, martyris et patroni Poloniæ',

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Przemienienie Pańskie',
     trinity_sunday: 'Najświętszej Trójcy',
   },
-  sanctoral: {
+  sanctorale: {
     adalbert_of_prague_bishop: 'Św. Wojciecha, biskupa i męczennika',
     adalbert_of_prague_bishop_patron_of_poland: 'Św. Wojciecha, biskupa i męczennika, głównego patrona Polski',
     agatha_of_sicily_virgin: 'Św. Agaty, dziewicy i męczennicy',
@@ -129,7 +129,8 @@ export default {
     augustine_of_canterbury_bishop: 'Św. Augustyna z Canterbury, biskupa',
     augustine_of_hippo_bishop: 'Św. Augustyna, biskupa i doktora Kościoła',
     augustine_zhao_rong_priest: 'Św. Augustyna Zhao Rong, prezbitera i męczennika',
-    augustine_zhao_rong_priest_and_companions_martyrs: 'Świętych męczenników Augustyna Zhao Rong, prezbitera, i Towarzyszy',
+    augustine_zhao_rong_priest_and_companions_martyrs:
+      'Świętych męczenników Augustyna Zhao Rong, prezbitera, i Towarzyszy',
     barbara_of_heliopolis_virgin: 'Św. Barbary, dziewicy i męczennicy',
     barnabas_apostle: 'Św. Barnaby, Apostoła',
     bartholomew_apostle: 'Św. Bartłomieja, Apostoła',
@@ -179,7 +180,7 @@ export default {
     cyril_of_alexandria_bishop: 'Św. Cyryla Aleksandryjskiego, biskupa i doktora Kościoła',
     cyril_of_jerusalem_bishop: 'Św. Cyryla Jerozolimskiego, biskupa i doktora Kościoła',
     cyril_the_philosopher_monk_and_methodius_of_thessaloniki_bishop: 'Świętych Cyryla, mnicha i Metodego, biskupa',
-    cyril_the_philosopher_monk_and_methodius_of_thessaloniki_bishop_copatrons_of_europe:    
+    cyril_the_philosopher_monk_and_methodius_of_thessaloniki_bishop_copatrons_of_europe:
       'Świętych Cyryla, mnicha i Metodego, biskupa, patronów Europy',
     damasus_i_pope: 'Św. Damazego I, papieża',
     dedication_of_consecrated_churches: 'Rocznica poświęcenia kościoła własnego',

--- a/src/locales/pt-br.ts
+++ b/src/locales/pt-br.ts
@@ -92,7 +92,7 @@ export default {
     transfiguration: 'Transfiguração do Senhor',
     trinity_sunday: 'Santíssima Trindade',
   },
-  sanctoral: {
+  sanctorale: {
     gregory_of_narek_abbot: 'São Gregório de Narek, abade e doutor da Igreja',
     hildegard_of_bingen_abbess: 'Santa Hildegarda de Bingen, virgem e doutora da Igreja',
     john_of_avila_priest: 'São João De Ávila, presbítero e doutor da Igreja',

--- a/src/locales/sk.ts
+++ b/src/locales/sk.ts
@@ -93,7 +93,7 @@ export default {
     transfiguration: 'Premenenie Pána',
     trinity_sunday: 'Najsvätejšej Trojice',
   },
-  sanctoral: {
+  sanctorale: {
     '205_blessed_martyrs_of_japan': 'Blahoslavených 205 japonských mučeníkov',
     adalbert_of_prague_bishop: 'Svätého Vojtecha, biskupa a mučeníka',
     adalbert_of_prague_bishop_patron_of_poland: 'Svätého Vojtecha, biskupa, mučeníka a patróna Poľska',

--- a/src/models/liturgical-day/liturgical-day.types.ts
+++ b/src/models/liturgical-day/liturgical-day.types.ts
@@ -127,7 +127,7 @@ export type BaseLiturgicalDayInput = Pick<BaseLiturgicalDay, 'key'> &
      * This value is used when localizing dates so that the [[Locales.localizeDates]] function knows
      * which subtree in the locale file to look for.
      *
-     * A special key, "temporal", may be used when you do not wish to specify any subtree but rather
+     * A special key, "temporale", may be used when you do not wish to specify any subtree but rather
      * provide the entire path (as a period delimited string) to the [[Locales.localizeDates]] function
      * to lookup.
      */
@@ -191,12 +191,12 @@ export type LiturgicalDayMetadata = {
  * This value is used when localizing dates so that the [[Locales.localizeDates]] function knows
  * which subtree in the locale file to look for.
  *
- * A special key, "temporal", may be used when you do not wish to specify any subtree but rather
+ * A special key, "temporale", may be used when you do not wish to specify any subtree but rather
  * provide the entire path (as a period delimited string) to the [[Locales.localizeDates]] function
  * to lookup.
  */
 export type RomcalLiturgicalDaySources =
-  | 'temporal'
+  | 'temporale'
   | 'advent'
   | 'christmastide'
   | 'epiphany'
@@ -205,4 +205,4 @@ export type RomcalLiturgicalDaySources =
   | 'holy_week'
   | 'eastertide'
   | 'celebrations'
-  | 'sanctoral';
+  | 'sanctorale';

--- a/src/models/locale/romcal-locale.type.ts
+++ b/src/models/locale/romcal-locale.type.ts
@@ -25,7 +25,7 @@ export interface RomcalLocale {
   readonly celebrations?: {
     readonly [key: string]: string;
   };
-  readonly sanctoral?: {
+  readonly sanctorale?: {
     readonly [key: string]: string;
   };
   readonly liturgical_colors?: {


### PR DESCRIPTION
Closes https://github.com/romcal/romcal/issues/242.

Fix the spelling of the "sanctorale" and "temporale" words.