### PR TITLE
Bump romcal version to 2.0.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "1.3.1-alpha.8",
+  "version": "2.0.0-alpha.0",
   "description": "Generates the liturgical calendar of the Catholic Church used by the Roman Rite (post-Vatican II).",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
When merging the `_F-TypeScript` branch, I forgot to update the package version. Here it is.