### PR TITLE
NPM publish & install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,48 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependencies
+node_modules/
+
+# Coverage
+coverage/
+
+# Main codebase
+.github/
+examples/
+lib/
+scripts/
+tests/
+.editorconfig
+.eslintignore
+.eslintrc.json
+.prettierrc
+jest.config.js
+tsconfig.*
+
+# Transpiled files
+dist/bundles/
+tmp/
+
+# VS Code
+.vscode
+!.vscode/tasks.js
+
+# JetBrains IDEs
+.idea/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Misc
+.DS_Store
+local-*
+*.bak
+*.orig
+*code-workspace
+*~

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ Romcal can be added to your project using npm or yarn:
 
 ```bash
 # npm
-npm install romcal@3.x
+npm install romcal
 
 # yarn
-yarn add romcal@3.x
+yarn add romcal
 ```
 
 The default export is CommonJS compatible (`cjs`).
@@ -115,7 +115,7 @@ esm or cjs:
 - https://unpkg.com/romcal/dist/esm/romcal.js
 - https://unpkg.com/romcal/dist/cjs/romcal.js
 
-Make sure to use a fixed version in production like https://unpkg.com/romcal@3.0.0/dist/cjs/romcal.js as passing no version will redirect to the latest version which might contain breaking changes in the future.
+Make sure to use a fixed version in production like https://unpkg.com/romcal@3.0.0-alpha.0/dist/cjs/romcal.js as passing no version will redirect to the latest version which might contain breaking changes in the future.
 
 #### cdnjs.com
 


### PR DESCRIPTION
- This PR adds a `.npmignore` file, to package and publish clean romcal core library.
- Updates the `npm install` instructions & CDN example.