### PR TITLE
Add `DoctorOfTheChurch` title to `irenaeus_of_lyon_bishop`

### DIFF
--- a/lib/catalog/martyrology.ts
+++ b/lib/catalog/martyrology.ts
@@ -2098,7 +2098,7 @@ export class Martyrology {
     irenaeus_of_lyon_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Irenaeus',
-      titles: [Titles.Bishop, Titles.Martyr],
+      titles: [Titles.Bishop, Titles.Martyr, Titles.DoctorOfTheChurch],
       dateOfDeath: 201,
       dateOfDeathIsApproximative: true,
     },


### PR DESCRIPTION
According the [Catholic News Agency](http://www.catholicnewsagency.com/news/249215/pope-francis-to-declare-st-irenaeus-a-doctor-of-the-church-with-title-doctor-of-unity), Pope Francis _will_ name St Irenaeus of Lyon a doctor of the Church.

I don’t know if we should already update romcal, but the PR should be ready, unless there is something else needed to be done.