### PR TITLE
Add allowSimilarRankItems option on liturgical day definitions

### DIFF
--- a/docs/data-output.md
+++ b/docs/data-output.md
@@ -28,6 +28,7 @@ romcal returns an array of liturgical date objects in the following structure
     rank: 'SOLEMNITY',
     rankName: 'Solemnity',
     isHolyDayOfObligation: true,
+    allowSimilarRankItems: false,
     prioritized: false,
     liturgicalColors: ['WHITE'],
     seasons: ['CHRISTMASTIDE'],
@@ -67,6 +68,7 @@ romcal returns an array of liturgical date objects in the following structure
 - `name`: The [localizable name](localization.md) of the liturgical day
 - `date`: Date of the liturgical day as a ISO8601 string
 - `rank`: A key representing the [liturgical day rank](#liturgical-day-ranks)
+- `allowSimilarRankItems`: In addition to this liturgical day, allow similar items that have the same rank, and the same or lower precedence, so the current liturgical day will not overwrite another defined item.
 - `isHolyDayOfObligation`: If the current liturgical day is a [Holy Day of Obligation](https://en.wikipedia.org/wiki/Holy_day_of_obligation). Holy days of obligation are days on which the faithful are expected to attend Mass, and engage in rest from work and recreation.
 - `prioritized`: A optional boolean that when true, gives the liturgical day higher priority over another coinciding liturgical day even though that liturgical day has a higher-ranking type. This flag should be used with caution.
 - `liturgicalColors`: The [liturgical color(s)](#liturgical-colors) assigned for this liturgical day (usually follows the liturgical season but may defer if this liturgical day is a solemnity, feast or memorial)

--- a/lib/general-calendar/proper-of-saints.ts
+++ b/lib/general-calendar/proper-of-saints.ts
@@ -442,8 +442,8 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralMemorial_10,
       // The Saturday, after the Solemnity of the Most Sacred Heart of Jesus
       dateDef: { dateFn: 'immaculateHeartOfMary' },
-      // If this liturgical day fall the same day of another memorial, do not
-      // replace this another memorial, but keep them both.
+      // If this liturgical day and a memorial occur on the same day,
+      // do not replace the latter, but output them both.
       allowSimilarRankItems: true,
       colors: Colors.White,
       properCycle: ProperCycles.ProperOfTime,

--- a/lib/general-calendar/proper-of-saints.ts
+++ b/lib/general-calendar/proper-of-saints.ts
@@ -442,6 +442,9 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralMemorial_10,
       // The Saturday, after the Solemnity of the Most Sacred Heart of Jesus
       dateDef: { dateFn: 'immaculateHeartOfMary' },
+      // If this liturgical day fall the same day of another memorial, do not
+      // replace this another memorial, but keep them both.
+      allowSimilarRankItems: true,
       colors: Colors.White,
       properCycle: ProperCycles.ProperOfTime,
     },

--- a/lib/models/calendar-def.ts
+++ b/lib/models/calendar-def.ts
@@ -118,6 +118,7 @@ export class CalendarDef implements BaseCalendarDef {
         dateDef: input.dateDef,
         dateExceptions: input.dateExceptions,
         precedence: input.precedence,
+        allowSimilarRankItems: input.allowSimilarRankItems,
         customLocaleKey: input.customLocaleKey,
         isHolyDayOfObligation: input.isHolyDayOfObligation,
         isOptional: input.isOptional,

--- a/lib/models/liturgical-day-def.ts
+++ b/lib/models/liturgical-day-def.ts
@@ -33,6 +33,7 @@ export default class LiturgicalDayDef implements BaseLiturgicalDayDef {
   readonly precedence: Precedence;
   readonly rank: Rank;
   readonly isHolyDayOfObligation: boolean;
+  readonly allowSimilarRankItems: boolean;
   readonly isOptional: boolean;
   readonly i18nDef: [string] | [string, StringMap | string];
   readonly seasons: Season[];
@@ -114,6 +115,8 @@ export default class LiturgicalDayDef implements BaseLiturgicalDayDef {
     this.precedence = input.precedence ?? previousDef!.precedence;
 
     this.rank = LiturgicalDayDef.precedenceToRank(this.precedence, key);
+
+    this.allowSimilarRankItems = input.allowSimilarRankItems ?? previousDef?.allowSimilarRankItems ?? false;
 
     this.isHolyDayOfObligation = input.isHolyDayOfObligation ?? previousDef?.isHolyDayOfObligation ?? false;
 

--- a/lib/models/liturgical-day.ts
+++ b/lib/models/liturgical-day.ts
@@ -27,6 +27,7 @@ class LiturgicalDay implements BaseLiturgicalDay {
   readonly dateDef: DateDef;
   readonly precedence: Precedence;
   readonly rank: Rank;
+  readonly allowSimilarRankItems: boolean;
   readonly isHolyDayOfObligation: boolean;
   isOptional: boolean;
   readonly i18nDef: [string] | [string, StringMap | string];
@@ -91,6 +92,7 @@ class LiturgicalDay implements BaseLiturgicalDay {
     this.dateDef = def.dateDef;
     this.precedence = def.precedence;
     this.rank = def.rank;
+    this.allowSimilarRankItems = def.allowSimilarRankItems;
     this.isHolyDayOfObligation = calendar.dayOfWeek === 0 ? true : def.isHolyDayOfObligation;
     this.isOptional = def.isOptional;
     this.i18nDef = def.i18nDef;

--- a/lib/types/liturgical-day.ts
+++ b/lib/types/liturgical-day.ts
@@ -333,6 +333,13 @@ type LiturgicalDayRoot = {
   rankName: string;
 
   /**
+   * In addition to this liturgical day, allow similar items that have the same rank,
+   * and the same or lower precedence,
+   * so the current liturgical day will not overwrite another defined item.
+   */
+  allowSimilarRankItems: boolean;
+
+  /**
    * The liturgical colors of the liturgical day.
    */
   colors: Color[];
@@ -499,7 +506,14 @@ export type BaseLiturgicalDayDef = Pick<
 export type LiturgicalDayInput = Partial<
   Pick<
     LiturgicalDayRoot,
-    'dateDef' | 'precedence' | 'isHolyDayOfObligation' | 'isOptional' | 'properCycle' | 'customLocaleKey' | 'drop'
+    | 'dateDef'
+    | 'precedence'
+    | 'allowSimilarRankItems'
+    | 'isHolyDayOfObligation'
+    | 'isOptional'
+    | 'properCycle'
+    | 'customLocaleKey'
+    | 'drop'
   >
 > & {
   /**
@@ -544,7 +558,7 @@ export type LiturgicalDayProperOfTimeInput = Pick<
   | 'dateDef'
   | 'dateExceptions'
 > &
-  Partial<Pick<LiturgicalDayRoot, 'isHolyDayOfObligation' | 'isOptional'>>;
+  Partial<Pick<LiturgicalDayRoot, 'allowSimilarRankItems' | 'isHolyDayOfObligation' | 'isOptional'>>;
 
 /**
  * Generated object with computed date within a specific year

--- a/tests/dates.test.ts
+++ b/tests/dates.test.ts
@@ -468,6 +468,18 @@ describe('Testing specific liturgical date functions', () => {
         expect(rangeContainsDate(range, immaculateHeartOfMary)).toBeTrue();
       }
     });
+
+    test('When it falls the same day as another memorial, both memorials are kept', async () => {
+      const romcal = new Romcal();
+      const keys = (await romcal.generateCalendar(2015))['2015-06-13'].map((d) => d.key);
+      expect(JSON.stringify(keys)).toEqual(JSON.stringify(['immaculate_heart_of_mary', 'anthony_of_padua_priest']));
+    });
+
+    test('When it falls on a weekday, only one item is output for this day', async () => {
+      const romcal = new Romcal();
+      const keys = (await romcal.generateCalendar(2022))['2022-06-25'].map((d) => d.key);
+      expect(JSON.stringify(keys)).toEqual(JSON.stringify(['immaculate_heart_of_mary']));
+    });
   });
 
   describe('Christ the King is always the 34th (and last) Sunday of Ordinary Time and is the week before the First Sunday of Advent', () => {

--- a/tests/dates.test.ts
+++ b/tests/dates.test.ts
@@ -469,7 +469,7 @@ describe('Testing specific liturgical date functions', () => {
       }
     });
 
-    test('When it falls the same day as another memorial, both memorials are kept', async () => {
+    test('When it occurs on the same day as another memorial, both memorials are output', async () => {
       const romcal = new Romcal();
       const keys = (await romcal.generateCalendar(2015))['2015-06-13'].map((d) => d.key);
       expect(JSON.stringify(keys)).toEqual(JSON.stringify(['immaculate_heart_of_mary', 'anthony_of_padua_priest']));

--- a/tests/dates.test.ts
+++ b/tests/dates.test.ts
@@ -475,7 +475,7 @@ describe('Testing specific liturgical date functions', () => {
       expect(JSON.stringify(keys)).toEqual(JSON.stringify(['immaculate_heart_of_mary', 'anthony_of_padua_priest']));
     });
 
-    test('When it falls on a weekday, only one item is output for this day', async () => {
+    test('When it occurs on a weekday, only one item is output for this day', async () => {
       const romcal = new Romcal();
       const keys = (await romcal.generateCalendar(2022))['2022-06-25'].map((d) => d.key);
       expect(JSON.stringify(keys)).toEqual(JSON.stringify(['immaculate_heart_of_mary']));


### PR DESCRIPTION
Fixes #172.

This also introduce a new `LiturgicalDay` definition parameter: `allowSimilarRankItems: boolean`.

When this option is enabled, in addition to the current liturgical day, similar items can also be output.
The similar items must have the same rank, and a precedence equal or lower to the current item.

This makes possible to output **Immaculate heart of Mary** while keeping existing memorials on this day.
- 2014 June 28: **Immaculate heart of Mary** + **Saint Irenaeus**
- 2015 June 13: **Immaculate heart of Mary** + **Saint Anthony of Padua**
- 2022 June 25: **Immaculate heart of Mary only**, because there are no other memorials.
