### PR TITLE
New GitHub Action to automatically publish dev versions to NPM

### DIFF
--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -27,12 +27,6 @@ jobs:
       - name: Install node.js and npm
         uses: volta-cli/action@v1
 
-      - name: Install npm dependencies
-        run: npm ci --no-audit
-
-      - name: Update browsers list (caniuse)
-        run: npx browserslist@latest --update-db
-
       - name: Automated version bump
         uses: phips28/gh-action-bump-version@master
         with:
@@ -44,6 +38,12 @@ jobs:
           preid: dev
           tag-prefix:  'v'
           commit-message: 'ci: bump version to {{version}}'
+
+      - name: Install npm dependencies
+        run: npm ci --no-audit
+
+      - name: Update browsers list (caniuse)
+        run: npx browserslist@latest --update-db
 
       - name: Build romcal project (romcal + all calendar bundles)
         run: npm run build

--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -36,8 +36,8 @@ jobs:
           rc-wording:
           default: prerelease
           preid: dev
-          tag-prefix:  'v'
-          commit-message: 'ci: bump version to {{version}}'
+          skip-commit: 'true'
+          skip-tag:  'true'
 
       - name: Install npm dependencies
         run: npm ci --no-audit
@@ -50,6 +50,18 @@ jobs:
 
       - name: Run tests
         run: npm run test:without-coverage
+
+      - name: Read package.json
+        uses: culshaw/read-package-node-version-actions@v1
+        id: package
+
+      - name: Commit and tag the updated version
+        uses: EndBug/add-and-commit@v7
+        with:
+          message: 'ci: bump version to ${{ steps.package.outputs.version }}'
+          tag: 'v${{ steps.package.outputs.version }}'
+          author_name: ${{ env.GITHUB_USER }}
+          author_email: ${{ env.GITHUB_EMAIL }}
 
       - name: Npm publish a new 'dev' version (romcal + all calendar bundles)
         env:

--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -1,0 +1,57 @@
+name: Dev branch publishing
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  dev_branch_publishing:
+    runs-on: ubuntu-latest
+
+    environment: npm-publish
+
+    if: github.repository == 'romcal/romcal'
+
+    env:
+      CI: true
+      GITHUB_USER: romcalproject
+      GITHUB_EMAIL: romcalproject@gmail.com
+
+    steps:
+      - name: Git checkout dev branch
+        uses: actions/checkout@v2
+        with:
+          ref: dev
+
+      - name: Install node.js and npm
+        uses: volta-cli/action@v1
+
+      - name: Install npm depencancies
+        run: npm ci --no-audit
+
+      - name: Update browsers list (caniuse)
+        run: npx browserslist@latest --update-db
+
+      - name: Automated version bump
+        uses: phips28/gh-action-bump-version@master
+        with:
+          major-wording: 'MajorBump'
+          minor-wording: 'MinorBump'
+          patch-wording: 'PatchBump'
+          rc-wording:
+          default: prerelease
+          preid: dev
+          tag-prefix:  'v'
+          commit-message: 'ci: bumps version to {{version}}'
+
+      - name: Build romcal project (romcal + all calendar bundles)
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test:without-coverage
+
+      - name: Npm publish a new 'dev' version (romcal + all calendar bundles)
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: node -r ts-node/register scripts/publish.ts

--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install node.js and npm
         uses: volta-cli/action@v1
 
-      - name: Install npm depencancies
+      - name: Install npm dependencies
         run: npm ci --no-audit
 
       - name: Update browsers list (caniuse)

--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -43,7 +43,7 @@ jobs:
           default: prerelease
           preid: dev
           tag-prefix:  'v'
-          commit-message: 'ci: bumps version to {{version}}'
+          commit-message: 'ci: bump version to {{version}}'
 
       - name: Build romcal project (romcal + all calendar bundles)
         run: npm run build

--- a/.github/workflows/romcal-ci.yml
+++ b/.github/workflows/romcal-ci.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    env:
+      CI: true
+
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
       - run: npm ci --no-audit
       - run: npm run build
-      - run: npm test
-
-    env:
-      CI: true
+      - run: npm run test:without-coverage

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ coverage/
 dist/
 tmp/
 
+# Act (run GitHub Actions locally)
+*.event
+
 # VS Code
 .vscode
 !.vscode/tasks.js

--- a/.npmignore
+++ b/.npmignore
@@ -26,6 +26,9 @@ tsconfig.*
 dist/bundles/
 tmp/
 
+# Act (run GitHub Actions locally)
+*.event
+
 # VS Code
 .vscode
 !.vscode/tasks.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "romcal",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-dev.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "romcal",
-      "version": "3.0.0-alpha.0",
+      "version": "3.0.0-dev.7",
       "license": "MIT",
       "dependencies": {
         "i18next": "^20.4.0"
       },
       "devDependencies": {
+        "@jsdevtools/npm-publish": "^1.4.3",
         "@types/cli-progress": "^3.9.2",
         "@types/glob": "^7.1.4",
         "@types/humanize-duration": "^3.25.1",
@@ -1061,6 +1062,45 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jsdevtools/ez-spawn": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
+      "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
+      "dev": true,
+      "dependencies": {
+        "call-me-maybe": "^1.0.1",
+        "cross-spawn": "^7.0.3",
+        "string-argv": "^0.3.1",
+        "type-detect": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jsdevtools/npm-publish": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/npm-publish/-/npm-publish-1.4.3.tgz",
+      "integrity": "sha512-EdmrDPCtVZIDeTmLhQFmuwiEXtRZfQh6KwM7uZ//Zpi4FAXPCKLgOxBggbYDpsmobpGOVlWDhhUE5HMhoYJgmQ==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ez-spawn": "^3.0.4",
+        "@jsdevtools/ono": "^7.1.3",
+        "command-line-args": "^5.1.1",
+        "semver": "^7.3.4"
+      },
+      "bin": {
+        "npm-publish": "bin/npm-publish.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1589,8 +1629,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -1659,6 +1700,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/array-union": {
@@ -1941,6 +1991,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
@@ -1959,9 +2015,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -2198,6 +2254,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/component-emitter": {
@@ -3442,6 +3513,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/find-up": {
@@ -5447,6 +5530,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
@@ -7115,6 +7204,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.19"
+      }
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -7299,9 +7397,9 @@
       "dev": true
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -7529,6 +7627,15 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/union-value": {
@@ -8653,6 +8760,36 @@
         "chalk": "^4.0.0"
       }
     },
+    "@jsdevtools/ez-spawn": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
+      "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "cross-spawn": "^7.0.3",
+        "string-argv": "^0.3.1",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@jsdevtools/npm-publish": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/npm-publish/-/npm-publish-1.4.3.tgz",
+      "integrity": "sha512-EdmrDPCtVZIDeTmLhQFmuwiEXtRZfQh6KwM7uZ//Zpi4FAXPCKLgOxBggbYDpsmobpGOVlWDhhUE5HMhoYJgmQ==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ez-spawn": "^3.0.4",
+        "@jsdevtools/ono": "^7.1.3",
+        "command-line-args": "^5.1.1",
+        "semver": "^7.3.4"
+      }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -9057,8 +9194,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -9106,6 +9244,12 @@
     "arr-union": {
       "version": "3.1.0",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "dev": true
     },
     "array-union": {
@@ -9326,6 +9470,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
@@ -9338,9 +9488,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "dev": true
     },
     "capture-exit": {
@@ -9524,6 +9674,18 @@
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "dev": true,
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
       }
     },
     "component-emitter": {
@@ -10488,6 +10650,15 @@
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dev": true,
+      "requires": {
+        "array-back": "^3.0.1"
       }
     },
     "find-up": {
@@ -12036,6 +12207,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
@@ -12669,6 +12846,7 @@
     "romcal": {
       "version": "file:",
       "requires": {
+        "@jsdevtools/npm-publish": "^1.4.3",
         "@types/cli-progress": "^3.9.2",
         "@types/glob": "^7.1.4",
         "@types/humanize-duration": "^3.25.1",
@@ -13482,6 +13660,36 @@
             "chalk": "^4.0.0"
           }
         },
+        "@jsdevtools/ez-spawn": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ez-spawn/-/ez-spawn-3.0.4.tgz",
+          "integrity": "sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==",
+          "dev": true,
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "cross-spawn": "^7.0.3",
+            "string-argv": "^0.3.1",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "@jsdevtools/npm-publish": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/npm-publish/-/npm-publish-1.4.3.tgz",
+          "integrity": "sha512-EdmrDPCtVZIDeTmLhQFmuwiEXtRZfQh6KwM7uZ//Zpi4FAXPCKLgOxBggbYDpsmobpGOVlWDhhUE5HMhoYJgmQ==",
+          "dev": true,
+          "requires": {
+            "@jsdevtools/ez-spawn": "^3.0.4",
+            "@jsdevtools/ono": "^7.1.3",
+            "command-line-args": "^5.1.1",
+            "semver": "^7.3.4"
+          }
+        },
+        "@jsdevtools/ono": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+          "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+          "dev": true
+        },
         "@nodelib/fs.scandir": {
           "version": "2.1.5",
           "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -13886,8 +14094,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -13935,6 +14144,12 @@
         "arr-union": {
           "version": "3.1.0",
           "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+          "dev": true
+        },
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
           "dev": true
         },
         "array-union": {
@@ -14155,6 +14370,12 @@
             "get-intrinsic": "^1.0.2"
           }
         },
+        "call-me-maybe": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+          "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+          "dev": true
+        },
         "callsites": {
           "version": "3.1.0",
           "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
@@ -14167,9 +14388,9 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001251",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-          "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+          "version": "1.0.30001283",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+          "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
           "dev": true
         },
         "capture-exit": {
@@ -14353,6 +14574,18 @@
           "dev": true,
           "requires": {
             "delayed-stream": "~1.0.0"
+          }
+        },
+        "command-line-args": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
+          "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+          "dev": true,
+          "requires": {
+            "array-back": "^3.1.0",
+            "find-replace": "^3.0.0",
+            "lodash.camelcase": "^4.3.0",
+            "typical": "^4.0.0"
           }
         },
         "component-emitter": {
@@ -15317,6 +15550,15 @@
           "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-replace": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+          "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+          "dev": true,
+          "requires": {
+            "array-back": "^3.0.1"
           }
         },
         "find-up": {
@@ -16865,6 +17107,12 @@
           "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
+        "lodash.camelcase": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+          "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+          "dev": true
+        },
         "lodash.clonedeep": {
           "version": "4.5.0",
           "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
@@ -18131,6 +18379,12 @@
             }
           }
         },
+        "string-argv": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+          "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+          "dev": true
+        },
         "string-length": {
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -18271,9 +18525,9 @@
           "dev": true
         },
         "tmpl": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-          "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+          "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
           "dev": true
         },
         "to-fast-properties": {
@@ -18428,6 +18682,12 @@
           "version": "4.3.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
           "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+          "dev": true
+        },
+        "typical": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
           "dev": true
         },
         "union-value": {
@@ -19332,6 +19592,12 @@
         }
       }
     },
+    "string-argv": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+      "dev": true
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -19472,9 +19738,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -19629,6 +19895,12 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "dev": true
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "romcal",
-  "version": "3.0.0-dev.7",
+  "version": "3.0.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "romcal",
-      "version": "3.0.0-dev.7",
+      "version": "3.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "i18next": "^20.4.0"
@@ -2015,9 +2015,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001283",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
-      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
+      "version": "1.0.30001285",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
+      "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -9488,9 +9488,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001283",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
-      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
+      "version": "1.0.30001285",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
+      "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
       "dev": true
     },
     "capture-exit": {
@@ -14388,9 +14388,9 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001283",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
-          "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
+          "version": "1.0.30001285",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz",
+          "integrity": "sha512-KAOkuUtcQ901MtmvxfKD+ODHH9YVDYnBt+TGYSz2KIfnq22CiArbUxXPN9067gNbgMlnNYRSwho8OPXZPALB9Q==",
           "dev": true
         },
         "capture-exit": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "romcal",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.1",
   "description": "JavaScript library that generates liturgical calendars of the Roman Rite of the Roman Catholic Church.",
   "main": "dist/cjs/romcal.js",
   "module": "dist/esm/romcal.js",
@@ -15,6 +15,7 @@
     "build": "node -r ts-node/register scripts/build.ts",
     "doc": "node -r ts-node/register scripts/bundle-doc.ts",
     "test": "jest --coverage",
+    "test:without-coverage": "jest",
     "test:watch": "jest --watch"
   },
   "repository": {
@@ -57,6 +58,7 @@
     "i18next": "^20.4.0"
   },
   "devDependencies": {
+    "@jsdevtools/npm-publish": "^1.4.3",
     "@types/cli-progress": "^3.9.2",
     "@types/glob": "^7.1.4",
     "@types/humanize-duration": "^3.25.1",

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -96,6 +96,7 @@ class RomcalBuilder {
 
 export const RomcalBundler = (): void => {
   rimraf.sync(path.resolve('tmp/bundles'));
+  const isCI = process.env['CI'] === 'true';
 
   const gauge = new cliProgress.SingleBar(
     {
@@ -109,7 +110,7 @@ export const RomcalBundler = (): void => {
   const allLocaleKeys = Object.keys(locales);
 
   log(chalk.bold(`\n✓ Generate calendar bundle files into ${chalk.cyan('./tmp/bundles/')}`));
-  gauge.start(allCalendars.length * allLocaleKeys.length - 1, 0);
+  if (!isCI) gauge.start(allCalendars.length * allLocaleKeys.length - 1, 0);
   let gaugeCount = 0;
 
   for (let i = 0; i < allCalendars.length; i++) {
@@ -130,8 +131,11 @@ export const RomcalBundler = (): void => {
       const calendarName = builder.getCalendarName();
 
       // Provide CLI feedback
-      gauge.update(gaugeCount++, { filename: `${enclosingDir}/${filename}` });
-      if (process.env['CI'] && j === 0) log(chalk.dim('  - ' + calendarName));
+      if (!isCI) {
+        gauge.update(gaugeCount++, { filename: `${enclosingDir}/${filename}` });
+      } else {
+        if (j === 0) log(chalk.dim('  - ' + calendarName));
+      }
 
       // Build and get definitions & martyrology items
       const inputs = builder.getAllInputs();
@@ -250,6 +254,6 @@ export const RomcalBundler = (): void => {
     fs.writeFileSync(path.resolve(dir, `index.d.ts`), dtsOutput, 'utf-8');
   }
 
-  gauge.stop();
+  if (!isCI) gauge.stop();
   log(chalk.dim(`  generated ${allCalendars.length} calendars in ${allLocaleKeys.length} locales in ./tmp/bundles/`));
 };

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,55 @@
+import npmPublish from '@jsdevtools/npm-publish';
+import { Results } from '@jsdevtools/npm-publish/lib/results';
+import fs from 'fs';
+import path from 'path';
+
+const tag = 'dev';
+const dryRun = false;
+const token = process.env.NPM_TOKEN;
+
+/**
+ * Provide a feedback message after a package is published to NPM
+ * @param data
+ */
+const afterPublish = (data: Results) => {
+  if (data.oldVersion !== data.version) {
+    console.log(` ✓ Package "${data.package}" published: ${data.oldVersion} → ${data.version} (${data.tag})\n`);
+  } else if (data.oldVersion === data.version) {
+    console.log(` ✓ Package "${data.package}" is already published: ${data.version} (${data.tag})\n`);
+  } else {
+    console.log(data, '\n');
+  }
+};
+
+(async () => {
+  // Start by publishing the main romcal library
+  console.log(` - Publishing romcal`);
+  const data = await npmPublish({
+    package: path.join(__dirname, '..', 'package.json'),
+    access: 'public',
+    token,
+    tag,
+    dryRun,
+  });
+  afterPublish(data);
+
+  // Retrieve the list of all calendar bundles
+  const bundlesBasePath = path.join(__dirname, '..', 'dist', 'bundles');
+  const bundleNames = fs
+    .readdirSync(bundlesBasePath, { withFileTypes: true })
+    .filter((dirent) => dirent.isDirectory())
+    .map((dirent) => dirent.name);
+
+  // Then, publish every calendar bundles as standalone NPM packages
+  for (let i = 0; i < bundleNames.length; i++) {
+    console.log(` - Publishing bundle: ${bundleNames[i]}`);
+    const data = await npmPublish({
+      package: path.join(bundlesBasePath, bundleNames[i], 'package.json'),
+      access: 'public',
+      token,
+      tag,
+      dryRun,
+    });
+    afterPublish(data);
+  }
+})();

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -34,7 +34,7 @@ const afterPublish = (data: Results) => {
   afterPublish(data);
 
   // Retrieve the list of all calendar bundles
-  const bundlesBasePath = path.join(__dirname, '..', 'dist', 'bundles');
+  const bundlesBasePath = path.join(__dirname, '../dist/bundles');
   const bundleNames = fs
     .readdirSync(bundlesBasePath, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -25,7 +25,7 @@ const afterPublish = (data: Results) => {
   // Start by publishing the main romcal library
   console.log(` - Publishing romcal`);
   const data = await npmPublish({
-    package: path.join(__dirname, '..', 'package.json'),
+    package: path.join(__dirname, '../package.json'),
     access: 'public',
     token,
     tag,


### PR DESCRIPTION
This PR introduces a new GitHub action that automatically publish a new romcal version to NPM, every time a PR is merged into the `dev` branch. This will help to test any latest versions of the `dev` branch, from NPM or even CDN packages.

What does this GitHub Action do:
- It only fires when new commits are added to the `dev` branch, on the `romcal/romcal` repository.
- On an Ubuntu VM (the latest version available):
  - Checkouts the `dev` branch
  - Installs the right Node.js and NPM versions (defined in `package.json`)
  - Updates browsers list used by caniuse and babel (and the romcal build script)
  - Automatically bumps the romcal version, and saves it on the `package.json` (as `x.x.x-dev.x`)
  - Builds romcal and all calendar bundles
  - Runs tests
  - Npm publish romcal and every calendar bundles

I'm taking this opportunity to review the branch and tag names. Until here, we used the traditional `dev`/`test`/`master` branch names, and `alpha`/`beta`/`latest` NPM tag names. @tukusejssirs you suggested a few months ago to align the wordings of these branches/tags. To simplify, I propose to use:
- `dev` branch / `dev` tag (instead of the `alpha` tag)
- `beta` branch / `beta` tag (instead of the `test` branch)
- `latest` branch / `latest` tag (instead of the `master` branch)

Note 1: this PR only contain CI workflow related to the `dev` branch. GitHub Actions for the `beta` and `latest` branches will come later in another PR, and will have a slightly different behavior.

Note 2: the `package.json` version has been updated since I already made a test of this script, and published a new alpha/dev version or romcal to NPM.

Related to #296.