### PR TITLE
Fixes and refactoring of the calendar metadata computing

### DIFF
--- a/lib/general-calendar/proper-of-saints.ts
+++ b/lib/general-calendar/proper-of-saints.ts
@@ -434,7 +434,7 @@ export class GeneralRoman extends CalendarDef {
     mary_mother_of_the_church: {
       precedence: Precedences.GeneralMemorial_10,
       // The Monday, after Pentecost Sunday
-      dateDef: { dateFn: 'pentecostSunday', addDay: 1 },
+      dateDef: { dateFn: 'maryMotherOfTheChurch' },
       properCycle: ProperCycles.ProperOfTime,
     },
 

--- a/lib/general-calendar/proper-of-time.ts
+++ b/lib/general-calendar/proper-of-time.ts
@@ -308,7 +308,7 @@ export class ProperOfTime extends CalendarDef {
         isHolyDayOfObligation: dow === 0,
         seasons: [Seasons.Lent],
         periods: [Periods.PresentationOfTheLordToHolyThursday],
-        calendarMetadata: { weekOfSeason: week, dayOfSeason: i + 4, dayOfWeek: dow },
+        calendarMetadata: { weekOfSeason: week, dayOfSeason: i + 5, dayOfWeek: dow },
         colors: [
           ...(week === 4 && dow === 0 ? [Colors.Rose] : []), // Laetare
           Colors.Purple,
@@ -324,7 +324,7 @@ export class ProperOfTime extends CalendarDef {
       isHolyDayOfObligation: true,
       seasons: [Seasons.Lent],
       periods: [Periods.HolyWeek, Periods.PresentationOfTheLordToHolyThursday],
-      calendarMetadata: { weekOfSeason: 6, dayOfSeason: 35, dayOfWeek: 0 },
+      calendarMetadata: { weekOfSeason: 6, dayOfSeason: 40, dayOfWeek: 0 },
       colors: [Colors.Red],
       i18nDef: [`names:palm_sunday`],
     });
@@ -336,7 +336,7 @@ export class ProperOfTime extends CalendarDef {
         dateDef: { dateFn: 'palmSunday', addDay: dow, yearOffset: yearOffset },
         seasons: [Seasons.Lent],
         periods: [Periods.HolyWeek, Periods.PresentationOfTheLordToHolyThursday],
-        calendarMetadata: { weekOfSeason: 6, dayOfSeason: 35 + dow, dayOfWeek: dow },
+        calendarMetadata: { weekOfSeason: 6, dayOfSeason: 40 + dow, dayOfWeek: dow },
         colors: [Colors.Purple],
         i18nDef: ['seasons:lent.holy_week_day', { dow }],
       });
@@ -388,7 +388,7 @@ export class ProperOfTime extends CalendarDef {
       isHolyDayOfObligation: true,
       seasons: [Seasons.PaschalTriduum, Seasons.EasterTime],
       periods: [Periods.EasterOctave],
-      calendarMetadata: { weekOfSeason: 1, dayOfSeason: 1, dayOfWeek: 1 },
+      calendarMetadata: { weekOfSeason: 1, dayOfSeason: 1, dayOfWeek: 0 },
       colors: [Colors.White],
       i18nDef: [`names:easter_sunday`],
     });
@@ -522,8 +522,8 @@ export class ProperOfTime extends CalendarDef {
         dateDef: { dateFn: 'dateOfOrdinaryTime', dateArgs: [dow, week], yearOffset: yearOffset },
         isHolyDayOfObligation: dow === 0,
         seasons: [Seasons.OrdinaryTime],
-        periods: [], // todo: add early / late ordinary time
-        calendarMetadata: { weekOfSeason: week, dayOfSeason: i, dayOfWeek: dow },
+        periods: [],
+        calendarMetadata: { weekOfSeason: week, dayOfWeek: dow },
         colors: [Colors.Green],
         i18nDef:
           dow === 0 ? ['seasons:ordinary_time.sunday', { week }] : ['seasons:ordinary_time.weekday', { week, dow }],

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -214,7 +214,7 @@ export class Calendar implements BaseCalendar {
             : builtData.byKeys[builtData.datesIndex[dateStr][0]]
                 // Look up for the right LiturgicalDay item, according to its date.
                 // Note: Two LiturgicalDay objects with the same key can occur within the same liturgical year,
-                // for example, Saint Andrew Apostle (30 November), in 2012.
+                // for example, Saint Andrew Apostle (30 November 2011 and 30 November 2012), in liturgical year 2012, which starts on 27 November 2011 and ends 1 December 2012.
                 .find((d) => d.date === date.toISOString().substr(0, 10)) || null;
 
           // Retrieve calendar metadata from the proper of time
@@ -309,7 +309,7 @@ export class Calendar implements BaseCalendar {
         .reduce((acc, key) => {
           // Look up for the right LiturgicalDay item, according to its date.
           // Note: Two LiturgicalDay objects with the same key can occur within the same liturgical year,
-          // for example, Saint Andrew Apostle (30 November), in 2012.
+          // for example, Saint Andrew Apostle (30 November 2011 and 30 November 2012), in liturgical year 2012, which starts on 27 November 2011 and ends 1 December 2012.
           const item = builtData.byKeys[key].find((d) => d.date === dateStr);
           if (item) acc.push(item);
           return acc;

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -308,7 +308,7 @@ export class Calendar implements BaseCalendar {
       const dates: LiturgicalDay[] = builtData.datesIndex[dateStr]
         .reduce((acc, key) => {
           // Look up for the right LiturgicalDay item, according to its date.
-          // Note: Two LiturgicalDay objects with the same date can occur within the same liturgical year,
+          // Note: Two LiturgicalDay objects with the same key can occur within the same liturgical year,
           // for example, Saint Andrew Apostle (30 November), in 2012.
           const item = builtData.byKeys[key].find((d) => d.date === dateStr);
           if (item) acc.push(item);

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -72,7 +72,7 @@ export class Calendar implements BaseCalendar {
       def.calendarMetadata.dayOfSeason ??
       (startOfSeason ? dateDifference(date, startOfSeason) + 1 : NaN);
 
-    // In later Ordinary Time, we need to subtract the days of Lent, Paschal Triduum and Easter Time,
+    // In late Ordinary Time, we need to subtract the days of Lent, Paschal Triduum and Easter Time,
     // from the first day of Ordinary Time (the day after the Baptism of the Lord).
     if (isLaterOrdinaryTime) {
       dayOfSeason = dayOfSeason - 96;
@@ -83,7 +83,7 @@ export class Calendar implements BaseCalendar {
       def.calendarMetadata.weekOfSeason ??
       (startOfSeason ? Math.ceil((dayOfSeason + startOfSeason.getDay()) / 7) : NaN);
 
-    // In later Ordinary Time, we need compute the week number from the remaining days of the liturgical year
+    // In late Ordinary Time, we need to compute the week number from the remaining days of the liturgical year
     if (isLaterOrdinaryTime) {
       weekOfSeason = endOfSeason ? Math.ceil(34 - dateDifference(date, endOfSeason) / 7) : NaN;
     }
@@ -213,7 +213,7 @@ export class Calendar implements BaseCalendar {
             ? null
             : builtData.byKeys[builtData.datesIndex[dateStr][0]]
                 // Look up for the right LiturgicalDay item, according to its date.
-                // Note: 2 LiturgicalDay objects with the same date can occur within the same liturgical year,
+                // Note: Two LiturgicalDay objects with the same key can occur within the same liturgical year,
                 // for example, Saint Andrew Apostle (30 November), in 2012.
                 .find((d) => d.date === date.toISOString().substr(0, 10)) || null;
 
@@ -308,7 +308,7 @@ export class Calendar implements BaseCalendar {
       const dates: LiturgicalDay[] = builtData.datesIndex[dateStr]
         .reduce((acc, key) => {
           // Look up for the right LiturgicalDay item, according to its date.
-          // Note: 2 LiturgicalDay objects with the same date can occur within the same liturgical year,
+          // Note: Two LiturgicalDay objects with the same date can occur within the same liturgical year,
           // for example, Saint Andrew Apostle (30 November), in 2012.
           const item = builtData.byKeys[key].find((d) => d.date === dateStr);
           if (item) acc.push(item);

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -26,12 +26,14 @@ export class Calendar implements BaseCalendar {
   readonly dates: Dates;
   readonly #startOfSeasonsDic: Record<number, Record<Seasons, Date>> = {};
   readonly #endOfSeasonsDic: Record<number, Record<Seasons, Date>> = {};
+  readonly #startOfLaterOrdinaryTime: Date;
   readonly #cyclesCache: Record<number, Pick<RomcalCyclesMetadata, 'sundayCycle' | 'weekdayCycle'>> = {};
 
   constructor(config: RomcalConfig, liturgicalDayConfig: LiturgicalDayConfig) {
     this.#config = config;
     this.#liturgicalDayConfig = liturgicalDayConfig;
     this.dates = new Dates(config, liturgicalDayConfig.year);
+    this.#startOfLaterOrdinaryTime = this.dates.maryMotherOfTheChurch();
   }
 
   /**
@@ -60,16 +62,34 @@ export class Calendar implements BaseCalendar {
 
     const startOfSeason = def.seasons.length ? startOfSeasonsDic[def.seasons[0]] : undefined;
     const endOfSeason = def.seasons.length ? endOfSeasonsDic[def.seasons[0]] : undefined;
-    const dayOfSeason =
+
+    const isLaterOrdinaryTime =
+      (baseData?.seasons ?? def.seasons).includes(Seasons.OrdinaryTime) &&
+      date.getTime() >= this.#startOfLaterOrdinaryTime.getTime();
+
+    let dayOfSeason =
       baseData?.calendar.dayOfSeason ??
       def.calendarMetadata.dayOfSeason ??
-      (startOfSeason ? dateDifference(date, startOfSeason) + 2 : NaN);
+      (startOfSeason ? dateDifference(date, startOfSeason) + 1 : NaN);
+
+    // In later Ordinary Time, we need to subtract the days of Lent, Paschal Triduum and Easter Time,
+    // from the first day of Ordinary Time (the day after the Baptism of the Lord).
+    if (isLaterOrdinaryTime) {
+      dayOfSeason = dayOfSeason - 96;
+    }
+
+    let weekOfSeason =
+      baseData?.calendar.weekOfSeason ??
+      def.calendarMetadata.weekOfSeason ??
+      (startOfSeason ? Math.ceil((dayOfSeason + startOfSeason.getDay()) / 7) : NaN);
+
+    // In later Ordinary Time, we need compute the week number from the remaining days of the liturgical year
+    if (isLaterOrdinaryTime) {
+      weekOfSeason = endOfSeason ? Math.ceil(34 - dateDifference(date, endOfSeason) / 7) : NaN;
+    }
 
     return {
-      weekOfSeason:
-        baseData?.calendar.weekOfSeason ??
-        def.calendarMetadata.weekOfSeason ??
-        (Number.isNaN(dayOfSeason) ? NaN : Math.ceil(dayOfSeason / 7)),
+      weekOfSeason,
       dayOfSeason,
       dayOfWeek: baseData?.calendar.dayOfWeek ?? def.calendarMetadata.dayOfWeek ?? date.getDay(),
       nthDayOfWeekInMonth: Math.ceil(date.getDate() / 7),
@@ -168,12 +188,11 @@ export class Calendar implements BaseCalendar {
         // because of any general/particular calendar settings.
         // E.g. The 6th Thursday within the Easter Time can be not celebrated
         // because in some calendars, the Solemnity of the Ascension is taking precedence.
-        .filter((d) => d && isValidDate(d))
+        .reduce((acc, d) => {
+          if (d && isValidDate(d)) acc.push(d as Date);
+          return acc;
+        }, [] as Date[])
         .forEach((date) => {
-          // Typing: the nullable dates have been removed in the filter above,
-          // so we redefine the date object as a non-nullable Date object
-          date = date as Date;
-
           const dateStr = date.toISOString().substr(0, 10);
 
           // All the dates of the whole year (gregorian or liturgical) are already generated
@@ -192,7 +211,11 @@ export class Calendar implements BaseCalendar {
           // the baseData must be null.
           const baseData: LiturgicalDay | null = isFromProperOfTime
             ? null
-            : builtData.byKeys[builtData.datesIndex[dateStr][0]];
+            : builtData.byKeys[builtData.datesIndex[dateStr][0]]
+                // Look up for the right LiturgicalDay item, according to its date.
+                // Note: 2 LiturgicalDay objects with the same date can occur within the same liturgical year,
+                // for example, Saint Andrew Apostle (30 November), in 2012.
+                .find((d) => d.date === date.toISOString().substr(0, 10)) || null;
 
           // Retrieve calendar metadata from the proper of time
           const calendar: RomcalCalendarMetadata = isFromProperOfTime
@@ -221,15 +244,10 @@ export class Calendar implements BaseCalendar {
             baseData && [Ranks.Feast, Ranks.Memorial].some((r) => r === def.rank) ? baseData : null;
 
           // Create a new LiturgicalDay object, and add it to the builtData object.
-          builtData.byKeys[def.key] = new LiturgicalDay(
-            def,
-            date,
-            this.#liturgicalDayConfig,
-            calendar,
-            cycles,
-            baseData,
-            weekday,
-          );
+          builtData.byKeys[def.key] = [
+            ...(builtData.byKeys[def.key] ?? []),
+            new LiturgicalDay(def, date, this.#liturgicalDayConfig, calendar, cycles, baseData, weekday),
+          ];
 
           // Also add the corresponding date-key object.
           builtData.datesIndex[dateStr] = [...(builtData.datesIndex[dateStr] ?? []), def.key];
@@ -288,7 +306,14 @@ export class Calendar implements BaseCalendar {
     Object.keys(builtData.datesIndex).forEach((dateStr) => {
       // Order the LiturgicalDays objects, following the precedence rules defined in the UNLY #49.
       const dates: LiturgicalDay[] = builtData.datesIndex[dateStr]
-        .map((key) => builtData.byKeys[key])
+        .reduce((acc, key) => {
+          // Look up for the right LiturgicalDay item, according to its date.
+          // Note: 2 LiturgicalDay objects with the same date can occur within the same liturgical year,
+          // for example, Saint Andrew Apostle (30 November), in 2012.
+          const item = builtData.byKeys[key].find((d) => d.date === dateStr);
+          if (item) acc.push(item);
+          return acc;
+        }, [] as LiturgicalDay[])
         .sort(
           (
             {

--- a/lib/types/calendar.ts
+++ b/lib/types/calendar.ts
@@ -11,7 +11,7 @@ export type LiturgicalCalendar = Record<string, LiturgicalDay[]>;
  * General date definition collection
  */
 
-export type ByKeys = Record<Key, LiturgicalDay>;
+export type ByKeys = Record<Key, LiturgicalDay[]>;
 export type DatesIndex = Record<string, Key[]>;
 
 export type LiturgicalBuiltData = {

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -861,7 +861,7 @@ export class Dates {
             ? lateOrdinaryStartWeekCount + Math.floor(idx / 7) + 1
             : lateOrdinaryStartWeekCount + Math.floor(idx / 7);
 
-          // When the Baptism of the Lord is a Monday, it means that the Ordinary Time start a Tuesday.
+          // When the Baptism of the Lord is observed on Monday, Ordinary Time starts on Tuesday.
           // So in this case, the Monday (from the group of 7 days computed above) takes place in the next week.
           if (isEarlyOrdinaryTime && baptismOfTheLordIsMonday && item.getDay() === 1) week++;
 

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -843,6 +843,7 @@ export class Dates {
       const early = this.allDatesOfEarlyOrdinaryTime(year, epiphanyOnSunday);
       const late = this.allDatesOfLateOrdinaryTime(year);
       const lateOrdinaryStartWeekCount = Math.floor(35 - (late.length + 1) / 7);
+      const baptismOfTheLordIsMonday = this.baptismOfTheLord(year).getDay() === 1;
 
       const trinitySunday = this.trinitySunday(year).getTime();
       const corpusChristi = this.corpusChristi(year).getTime();
@@ -850,7 +851,7 @@ export class Dates {
 
       const groupBy = (dates: Date[], isEarlyOrdinaryTime: boolean) =>
         dates.reduce((result: Record<string, Record<string, Date | null>>, item, idx) => {
-          const week = isEarlyOrdinaryTime
+          let week = isEarlyOrdinaryTime
             ? // Early Ordinary Time
               item.getDay() === 0
               ? Math.floor(idx / 7) + 2
@@ -859,6 +860,10 @@ export class Dates {
             item.getDay() === 0
             ? lateOrdinaryStartWeekCount + Math.floor(idx / 7) + 1
             : lateOrdinaryStartWeekCount + Math.floor(idx / 7);
+
+          // When the Baptism of the Lord is a Monday, it means that the Ordinary Time start a Tuesday.
+          // So in this case, the Monday (from the group of 7 days computed above) takes place in the next week.
+          if (isEarlyOrdinaryTime && baptismOfTheLordIsMonday && item.getDay() === 1) week++;
 
           const dateTime = item.getTime();
           const date =
@@ -1040,6 +1045,17 @@ export class Dates {
         addDays(this.easterSunday(year), 39));
   };
   #ascension: Record<string, Date> = {};
+
+  /**
+   * Get the date of the Memorial of Mary, Mother of the Church
+   * (occurs the day after Pentecost Sunday)
+   * @param year Gregorian year
+   */
+  maryMotherOfTheChurch = (year = this.#year): Date => {
+    if (this.#maryMotherOfTheChurch[year]) return this.#maryMotherOfTheChurch[year];
+    return (this.#maryMotherOfTheChurch[year] = addDays(this.easterSunday(year), 50));
+  };
+  #maryMotherOfTheChurch: Record<string, Date> = {};
 
   /**
    * Get the date of the Solemnity of Trinity Sunday

--- a/tests/calendar-builder.test.ts
+++ b/tests/calendar-builder.test.ts
@@ -209,7 +209,7 @@ describe('Testing calendar generation functions', () => {
   });
 
   describe('Testing calendar metadata', () => {
-    const testCalendarMetada = async (scope: CalendarScope) => {
+    const testCalendarMetadata = async (scope: CalendarScope) => {
       for (let year = 2010; year <= 2050; year++) {
         const romcal = new Romcal({ scope });
         const data: LiturgicalDay[] = Object.values(await romcal.generateCalendar(year)).flatMap((d) => d[0]);
@@ -290,11 +290,11 @@ describe('Testing calendar generation functions', () => {
     };
 
     test('Testing calendar metadata in a gregorian scope, from 2010 to 2050', async () => {
-      await testCalendarMetada('gregorian');
+      await testCalendarMetadata('gregorian');
     });
 
     test('Testing calendar metadata in a liturgical scope, from 2010 to 2050', async () => {
-      await testCalendarMetada('liturgical');
+      await testCalendarMetadata('liturgical');
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/romcal/romcal/issues/288.

I knew while rewriting the romcal core codebase, that the calendar metadata is a tricky part, and not enough tested until now. And indeed I discovered a few bugs while testing more that part.

This PR contains a test of the calendar metadata, and a few bug fixes:
- Calendar metadata were not correctly computed on several liturgical days
- When a same liturgical day can occur twice in the same liturgical year (e.g. Andrew Apostle), the calendar metadata wasn't correct on the first occurrence of this liturgical day
- If the Baptism of the Lord is a Monday, the proper of time of the early ordinary time wasn't correctly computed: Mondays were shifted by a week.