### PR TITLE
Update GA workflow to be able to push commits on dev

### DIFF
--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -15,14 +15,15 @@ jobs:
 
     env:
       CI: true
-      GITHUB_USER: romcalproject
-      GITHUB_EMAIL: romcalproject@gmail.com
+      GITHUB_USER: github-actions
+      GITHUB_EMAIL: github-actions@github.com
 
     steps:
       - name: Git checkout dev branch
         uses: actions/checkout@v2
         with:
           ref: dev
+          token: ${{ secrets.REPO_TOKEN }}
 
       - name: Install node.js and npm
         uses: volta-cli/action@v1
@@ -39,6 +40,13 @@ jobs:
           skip-commit: 'true'
           skip-tag:  'true'
 
+      - name: Read package.json
+        uses: culshaw/read-package-node-version-actions@v1
+        id: package
+
+      - name: Display bumped version
+        run: 'echo "New romcal version: ${{ steps.package.outputs.version }}"'
+
       - name: Install npm dependencies
         run: npm ci --no-audit
 
@@ -51,17 +59,15 @@ jobs:
       - name: Run tests
         run: npm run test:without-coverage
 
-      - name: Read package.json
-        uses: culshaw/read-package-node-version-actions@v1
-        id: package
-
       - name: Commit and tag the updated version
-        uses: EndBug/add-and-commit@v7
-        with:
-          message: 'ci: bump version to ${{ steps.package.outputs.version }}'
-          tag: 'v${{ steps.package.outputs.version }}'
-          author_name: ${{ env.GITHUB_USER }}
-          author_email: ${{ env.GITHUB_EMAIL }}
+        run: |
+          git config user.name ${{ env.GITHUB_USER }}
+          git config user.email ${{ env.GITHUB_EMAIL }}
+          git add .
+          git commit -m "ci: bump version to ${{ steps.package.outputs.version }}"
+          git push
+          git tag v${{ steps.package.outputs.version }}
+          git push --tags
 
       - name: Npm publish a new 'dev' version (romcal + all calendar bundles)
         env:

--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -11,7 +11,7 @@ jobs:
 
     environment: npm-publish
 
-    if: github.repository == 'romcal/romcal'
+    if: github.repository == 'romcal/romcal' && !startsWith(github.event.head_commit.message, 'ci:')
 
     env:
       CI: true


### PR DESCRIPTION
Related to: https://github.com/romcal/romcal/pull/332.

Because `dev` is a protected branch.... this PR:
- updates the GitHub credentials (to be able to push commits on `dev`), additional settings has been made in this repo settings.
- displays the new updated version in the console (after the version is bumped), just to provide more feedback when looking at the console.
- Git commit/tag do not use a third-party module anymore. `git` commands are run directly.
- Prevent this CI workflow to run in a loop (since this workflow is automatically running on a new commit(s) event, do not run again this workflow if the latest commit message starts with "ci:").