### PR TITLE
Import the calendar of the diocese of Strasbourg & update the associated documentation

### DIFF
--- a/docs/calendar-plugins.md
+++ b/docs/calendar-plugins.md
@@ -2,7 +2,7 @@
 
 The complete **General Roman Calendar**, and any other **particular calendar** (for a country, a region or a diocese) are available as **separated plugins**, that contain a bundle of the calendar data, localizations, and a martyrology catalog (containing extra metadata).
 
-For example, to install the *General Roman Calendar* and the calendar of *France*:
+For example, to install the _General Roman Calendar_ and the calendar of _France_:
 
 ```bash
 # npm
@@ -16,64 +16,65 @@ yarn add @romcal/calendar.france@dev
 
 Below the list of all available calendar plugins:
 
-| Name | NPM Package name |
-| -----|------------------|
-| General Roman|`@romcal/calendar.general-roman@dev`|
-| Americas|`@romcal/calendar.americas@dev`|
-| Argentina|`@romcal/calendar.argentina@dev`|
-| Australia|`@romcal/calendar.australia@dev`|
-| Austria|`@romcal/calendar.austria@dev`|
-| Belgium|`@romcal/calendar.belgium@dev`|
-| Bolivia|`@romcal/calendar.bolivia@dev`|
-| Bosnia Herzegovina|`@romcal/calendar.bosnia-herzegovina@dev`|
-| Brazil|`@romcal/calendar.brazil@dev`|
-| Canada|`@romcal/calendar.canada@dev`|
-| Chile|`@romcal/calendar.chile@dev`|
-| China|`@romcal/calendar.china@dev`|
-| Costa Rica|`@romcal/calendar.costa-rica@dev`|
-| Croatia|`@romcal/calendar.croatia@dev`|
-| Czech Republic|`@romcal/calendar.czech-republic@dev`|
-| Denmark|`@romcal/calendar.denmark@dev`|
-| England|`@romcal/calendar.england@dev`|
-| Europe|`@romcal/calendar.europe@dev`|
-| Finland|`@romcal/calendar.finland@dev`|
-| France|`@romcal/calendar.france@dev`|
-| France /  Paris|`@romcal/calendar.france.paris@dev`|
-| France /  Saint Denis|`@romcal/calendar.france.saint-denis@dev`|
-| Germany|`@romcal/calendar.germany@dev`|
-| Greece|`@romcal/calendar.greece@dev`|
-| Guatemala|`@romcal/calendar.guatemala@dev`|
-| Hungary|`@romcal/calendar.hungary@dev`|
-| India|`@romcal/calendar.india@dev`|
-| Ireland|`@romcal/calendar.ireland@dev`|
-| Italy|`@romcal/calendar.italy@dev`|
-| Japan|`@romcal/calendar.japan@dev`|
-| Lebanon|`@romcal/calendar.lebanon@dev`|
-| Lithuania|`@romcal/calendar.lithuania@dev`|
-| Malta|`@romcal/calendar.malta@dev`|
-| Mexico|`@romcal/calendar.mexico@dev`|
-| Netherlands|`@romcal/calendar.netherlands@dev`|
-| New Zealand|`@romcal/calendar.new-zealand@dev`|
-| Norway|`@romcal/calendar.norway@dev`|
-| Panama|`@romcal/calendar.panama@dev`|
-| Paraguay|`@romcal/calendar.paraguay@dev`|
-| Peru|`@romcal/calendar.peru@dev`|
-| Philippines|`@romcal/calendar.philippines@dev`|
-| Poland|`@romcal/calendar.poland@dev`|
-| Portugal|`@romcal/calendar.portugal@dev`|
-| Puerto Rico|`@romcal/calendar.puerto-rico@dev`|
-| Romania|`@romcal/calendar.romania@dev`|
-| Russia|`@romcal/calendar.russia@dev`|
-| Scotland|`@romcal/calendar.scotland@dev`|
-| Slovakia|`@romcal/calendar.slovakia@dev`|
-| Slovenia|`@romcal/calendar.slovenia@dev`|
-| Spain|`@romcal/calendar.spain@dev`|
-| Sri Lanka|`@romcal/calendar.sri-lanka@dev`|
-| Sweden|`@romcal/calendar.sweden@dev`|
-| Switzerland|`@romcal/calendar.switzerland@dev`|
-| Ukraine|`@romcal/calendar.ukraine@dev`|
-| United States|`@romcal/calendar.united-states@dev`|
-| Uruguay|`@romcal/calendar.uruguay@dev`|
-| Venezuela|`@romcal/calendar.venezuela@dev`|
-| Vietnam|`@romcal/calendar.vietnam@dev`|
-| Wales|`@romcal/calendar.wales@dev`|
+| Name                 | NPM Package name                          |
+| -------------------- | ----------------------------------------- |
+| General Roman        | `@romcal/calendar.general-roman@dev`      |
+| Americas             | `@romcal/calendar.americas@dev`           |
+| Argentina            | `@romcal/calendar.argentina@dev`          |
+| Australia            | `@romcal/calendar.australia@dev`          |
+| Austria              | `@romcal/calendar.austria@dev`            |
+| Belgium              | `@romcal/calendar.belgium@dev`            |
+| Bolivia              | `@romcal/calendar.bolivia@dev`            |
+| Bosnia Herzegovina   | `@romcal/calendar.bosnia-herzegovina@dev` |
+| Brazil               | `@romcal/calendar.brazil@dev`             |
+| Canada               | `@romcal/calendar.canada@dev`             |
+| Chile                | `@romcal/calendar.chile@dev`              |
+| China                | `@romcal/calendar.china@dev`              |
+| Costa Rica           | `@romcal/calendar.costa-rica@dev`         |
+| Croatia              | `@romcal/calendar.croatia@dev`            |
+| Czech Republic       | `@romcal/calendar.czech-republic@dev`     |
+| Denmark              | `@romcal/calendar.denmark@dev`            |
+| England              | `@romcal/calendar.england@dev`            |
+| Europe               | `@romcal/calendar.europe@dev`             |
+| Finland              | `@romcal/calendar.finland@dev`            |
+| France               | `@romcal/calendar.france@dev`             |
+| France / Paris       | `@romcal/calendar.france.paris@dev`       |
+| France / Saint Denis | `@romcal/calendar.france.saint-denis@dev` |
+| France / Strasbourg  | `@romcal/calendar.france.strasbourg@dev`  |
+| Germany              | `@romcal/calendar.germany@dev`            |
+| Greece               | `@romcal/calendar.greece@dev`             |
+| Guatemala            | `@romcal/calendar.guatemala@dev`          |
+| Hungary              | `@romcal/calendar.hungary@dev`            |
+| India                | `@romcal/calendar.india@dev`              |
+| Ireland              | `@romcal/calendar.ireland@dev`            |
+| Italy                | `@romcal/calendar.italy@dev`              |
+| Japan                | `@romcal/calendar.japan@dev`              |
+| Lebanon              | `@romcal/calendar.lebanon@dev`            |
+| Lithuania            | `@romcal/calendar.lithuania@dev`          |
+| Malta                | `@romcal/calendar.malta@dev`              |
+| Mexico               | `@romcal/calendar.mexico@dev`             |
+| Netherlands          | `@romcal/calendar.netherlands@dev`        |
+| New Zealand          | `@romcal/calendar.new-zealand@dev`        |
+| Norway               | `@romcal/calendar.norway@dev`             |
+| Panama               | `@romcal/calendar.panama@dev`             |
+| Paraguay             | `@romcal/calendar.paraguay@dev`           |
+| Peru                 | `@romcal/calendar.peru@dev`               |
+| Philippines          | `@romcal/calendar.philippines@dev`        |
+| Poland               | `@romcal/calendar.poland@dev`             |
+| Portugal             | `@romcal/calendar.portugal@dev`           |
+| Puerto Rico          | `@romcal/calendar.puerto-rico@dev`        |
+| Romania              | `@romcal/calendar.romania@dev`            |
+| Russia               | `@romcal/calendar.russia@dev`             |
+| Scotland             | `@romcal/calendar.scotland@dev`           |
+| Slovakia             | `@romcal/calendar.slovakia@dev`           |
+| Slovenia             | `@romcal/calendar.slovenia@dev`           |
+| Spain                | `@romcal/calendar.spain@dev`              |
+| Sri Lanka            | `@romcal/calendar.sri-lanka@dev`          |
+| Sweden               | `@romcal/calendar.sweden@dev`             |
+| Switzerland          | `@romcal/calendar.switzerland@dev`        |
+| Ukraine              | `@romcal/calendar.ukraine@dev`            |
+| United States        | `@romcal/calendar.united-states@dev`      |
+| Uruguay              | `@romcal/calendar.uruguay@dev`            |
+| Venezuela            | `@romcal/calendar.venezuela@dev`          |
+| Vietnam              | `@romcal/calendar.vietnam@dev`            |
+| Wales                | `@romcal/calendar.wales@dev`              |

--- a/lib/particular-calendars/index.ts
+++ b/lib/particular-calendars/index.ts
@@ -20,6 +20,7 @@ import { Finland } from './finland';
 import { France } from './france';
 import { France_Paris } from './france.paris';
 import { France_SaintDenis } from './france.saint-denis';
+import { France_Strasbourg } from './france.strasbourg';
 import { Germany } from './germany';
 import { Greece } from './greece';
 import { Guatemala } from './guatemala';
@@ -80,6 +81,7 @@ export const particularCalendars: Record<string, typeof CalendarDef> = {
   France: France,
   France_Paris: France_Paris,
   France_SaintDenis: France_SaintDenis,
+  France_Strasbourg: France_Strasbourg,
   Germany: Germany,
   Greece: Greece,
   Guatemala: Guatemala,

--- a/scripts/bundle-doc.ts
+++ b/scripts/bundle-doc.ts
@@ -6,6 +6,7 @@ import { CalendarDef } from '../lib/models/calendar-def';
 import { particularCalendars } from '../lib/particular-calendars';
 import { toPackageName } from '../lib/utils/string';
 import { getDuration } from './time';
+import prettier from 'prettier';
 
 const log = console.log;
 const time = new Date();
@@ -18,7 +19,7 @@ let mdTemplate = `# Calendar plugins
 
 The complete **General Roman Calendar**, and any other **particular calendar** (for a country, a region or a diocese) are available as **separated plugins**, that contain a bundle of the calendar data, localizations, and a martyrology catalog (containing extra metadata).
 
-For example, to install the *General Roman Calendar* and the calendar of *France*:
+For example, to install the _General Roman Calendar_ and the calendar of _France_:
 
 \`\`\`bash
 # npm
@@ -37,9 +38,12 @@ Below the list of all available calendar plugins:
 
 for (let i = 0; i < allCalendars.length; i++) {
   const calendar = allCalendars[i];
-  const humanName = calendar.name.replace(/([A-Z])/g, ' $1').replace('_', ' / ');
+  const humanName = calendar.name.replace(/([A-Z])/g, ' $1').replace('_', ' /');
   mdTemplate += `|${humanName}|\`@romcal/calendar.${toPackageName(calendar.name)}@dev\`|\n`;
 }
+
+// Prettify the generated documentation
+mdTemplate = prettier.format(mdTemplate, { parser: 'markdown' });
 
 fs.writeFileSync(path.resolve('./docs/', 'calendar-plugins.md'), mdTemplate, 'utf-8');
 


### PR DESCRIPTION
- The particular calendar of the diocese of Strasbourg was created, but not imported (an oversight). By importing it, this calendar is automatically added to the documentation listing all available calendars, and will be published as a new standalone npm module.

- I'm taking this opportunity to run `prettier` on this generated documentation.