### PR TITLE
Refactor the type name of the cycle metadata, to the correct form singular/plural

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 Romcal generates liturgical calendars of the Roman Rite of the Roman Catholic Church.
 Output conforms to the revised liturgical calendar as approved by Paul VI in [Mysterii Paschalis](http://w2.vatican.va/content/paul-vi/en/motu_proprio/documents/hf_p-vi_motu-proprio_19690214_mysterii-paschalis.html) dated 14 February 1969.
-The rules are defined in the [_General Instruction on the Roman Missal_](https://www.catholicculture.org/culture/library/view.cfm?recnum=337) (GIRM) and the [_General Norms for the Liturgical Year and the Calendar_](https://www.catholicculture.org/culture/library/view.cfm?id=10842) (GNLY).
+The rules are defined in the [_General Instruction on the Roman Missal_](https://www.catholicculture.org/culture/library/view.cfm?recnum=337) (GIRM), the [_General Norms for the Liturgical Year and the Calendar_](https://www.catholicculture.org/culture/library/view.cfm?id=10842) (GNLY), and the [General Instructions of the Liturgy of the Hours](https://divineoffice.org/general-instructions/) (GILH).
 
 - :date: **Perpetual calendar:**<br> romcal allows querying liturgical dates for any year in the standard calendar.
   Note that dates for years before 1969 will still be returned in a format conforming to the calendar reforms of 1969, even though those years came before this calendar reform.

--- a/lib/constants/cycles.ts
+++ b/lib/constants/cycles.ts
@@ -3,7 +3,7 @@
  */
 export const ProperCycles = {
   /**
-   * The "Proper of Time" (or "Temporal") consists of the movable feasts,
+   * The "Proper of Time" (or "Temporale") consists of the movable feasts,
    * most of them keyed to Easter (which falls on a different Sunday every year),
    * including Ascension, Pentecost, and so on.
    */
@@ -17,7 +17,7 @@ export const ProperCycles = {
 } as const;
 
 /**
- * A dynamically generated array from {@link ProperCycles} that contains all the possible proper cycles,
+ * A dynamically generated array from {@link ProperCycles} that contains all possible proper cycles,
  * that compose the liturgical year in the Roman rite.
  */
 export const PROPER_CYCLES = Object.values(ProperCycles);
@@ -40,19 +40,19 @@ export const SundayCycles = {
 } as const;
 
 /**
- * A dynamically generated array from {@link SundayCycles} that contains all the possible
+ * A dynamically generated array from {@link SundayCycles} that contains all possible
  * three-year Sunday cycles.
  */
 export const SUNDAY_CYCLES = Object.values(SundayCycles);
 
 /**
- * Represent one of the three-year Sunday cycles (available from {@link SundayCycles}).
+ * Represent one of the three-year Sunday cycle (available from {@link SundayCycles}).
  */
 export type SundayCycle = typeof SUNDAY_CYCLES[number];
 
 /**
- * A two-year cycle for the weekday mass readings (also called Cycle I and Cycle II).
- * Odd-numbered years are the year 1 (or Cycle I); even-numbered ones are the year 2 (or Cycle II).
+ * A two-year cycle for the weekday Mass readings (also called Cycle I and Cycle II).
+ * Odd-numbered years are the Cycle I (year 1); even-numbered ones are the Cycle II (year 2).
  */
 export const WeekdayCycles = {
   Year1: 'YEAR_1',
@@ -60,18 +60,18 @@ export const WeekdayCycles = {
 } as const;
 
 /**
- * A dynamically generated array from {@link WeekdayCycles} that contains all the possible
+ * A dynamically generated array from {@link WeekdayCycles} that contains all possible
  * two-year weekday cycles.
  */
 export const WEEKDAY_CYCLES = Object.values(WeekdayCycles);
 
 /**
- * Represent one of the two-year weekday cycles (available from {@link WeekdayCycles}).
+ * Represent one of the two-year weekday cycle (available from {@link WeekdayCycles}).
  */
 export type WeekdayCycle = typeof WEEKDAY_CYCLES[number];
 
 /**
- The four-week cycle of the psalter is coordinated with the liturgical year in such a way that
+[GILH §133] The four-week cycle of the psalter is coordinated with the liturgical year in such a way that
  on the First Sunday of Advent, the First Sunday in Ordinary Time, the First Sunday of Lent,
  and Easter Sunday the cycle is always begun again with Week 1 (others being omitted when necessary).
  */
@@ -83,12 +83,12 @@ export const PsalterWeekCycles = {
 } as const;
 
 /**
- * A dynamically generated array from {@link PsalterWeekCycles} that contains all the possible
+ * A dynamically generated array from {@link PsalterWeekCycles} that contains all possible
  * psalter week cycles.
  */
 export const PSALTER_WEEKS = Object.values(PsalterWeekCycles);
 
 /**
- * Represent one of the four-week psalter cycles (available from {@link PsalterWeekCycles}).
+ * Represent one of the four-week psalter cycle (available from {@link PsalterWeekCycles}).
  */
 export type PsalterWeekCycle = typeof PSALTER_WEEKS[number];

--- a/lib/constants/cycles.ts
+++ b/lib/constants/cycles.ts
@@ -1,5 +1,5 @@
 /**
- * Liturgical Day cycle that can be used as metadata for liturgical days.
+ * Liturgical Day cycles that can be used as metadata for liturgical days.
  */
 export const ProperCycles = {
   ProperOfTime: 'PROPER_OF_TIME',
@@ -9,7 +9,7 @@ export const ProperCycles = {
 /**
  * Sundays cycle that can be used as metadata for liturgical days.
  */
-export const SundaysCycles = {
+export const SundayCycles = {
   YearA: 'YEAR_A',
   YearB: 'YEAR_B',
   YearC: 'YEAR_C',
@@ -18,7 +18,7 @@ export const SundaysCycles = {
 /**
  * Weekdays cycle that can be used as metadata for liturgical days.
  */
-export const WeekdaysCycles = {
+export const WeekdayCycles = {
   Year1: 'YEAR_1',
   Year2: 'YEAR_2',
 } as const;
@@ -26,7 +26,7 @@ export const WeekdaysCycles = {
 /**
  * Psalter weeks that can be used as metadata for liturgical days.
  */
-export const PsalterWeeksCycles = {
+export const PsalterWeekCycles = {
   Week1: 'WEEK_1',
   Week2: 'WEEK_2',
   Week3: 'WEEK_3',
@@ -42,17 +42,17 @@ export type ProperCycle = typeof PROPER_CYCLE[number];
 /**
  * A dynamically generated constant consisting of all the enum keys in [[SUNDAY_CYCLES]]
  */
-export const SUNDAYS_CYCLE = Object.values(SundaysCycles);
-export type SundaysCycle = typeof SUNDAYS_CYCLE[number];
+export const SUNDAYS_CYCLE = Object.values(SundayCycles);
+export type SundayCycle = typeof SUNDAYS_CYCLE[number];
 
 /**
  * A dynamically generated constant consisting of all the enum keys in [[WEEKDAY_CYCLES]]
  */
-export const WEEKDAYS_CYCLE = Object.values(WeekdaysCycles);
-export type WeekdaysCycle = typeof WEEKDAYS_CYCLE[number];
+export const WEEKDAYS_CYCLE = Object.values(WeekdayCycles);
+export type WeekdayCycle = typeof WEEKDAYS_CYCLE[number];
 
 /**
  * A dynamically generated constant consisting of all the enum keys in [[PSALTER_WEEKS]]
  */
-export const PSALTER_WEEKS = Object.values(PsalterWeeksCycles);
-export type PsalterWeeksCycle = typeof PSALTER_WEEKS[number];
+export const PSALTER_WEEKS = Object.values(PsalterWeekCycles);
+export type PsalterWeekCycle = typeof PSALTER_WEEKS[number];

--- a/lib/constants/cycles.ts
+++ b/lib/constants/cycles.ts
@@ -1,13 +1,37 @@
 /**
- * Liturgical Day cycles that can be used as metadata for liturgical days.
+ * Represent the two main cycle, that compose the liturgical year in the Roman rite.
  */
 export const ProperCycles = {
+  /**
+   * The "Proper of Time" (or "Temporal") consists of the movable feasts,
+   * most of them keyed to Easter (which falls on a different Sunday every year),
+   * including Ascension, Pentecost, and so on.
+   */
   ProperOfTime: 'PROPER_OF_TIME',
+  /**
+   * The "Proper of Saints" (or "Sanctorale") consists of the fixed feasts,
+   * celebrated on the very same date each year (no matter what the day of the week),
+   * including Christmas and all the saints' days.
+   */
   ProperOfSaints: 'PROPER_OF_SAINTS',
 } as const;
 
 /**
- * Sundays cycle that can be used as metadata for liturgical days.
+ * A dynamically generated array from {@link ProperCycles} that contains all the possible proper cycles,
+ * that compose the liturgical year in the Roman rite.
+ */
+export const PROPER_CYCLES = Object.values(ProperCycles);
+
+/**
+ * Represent one of the two main cycles (available from {@link ProperCycles}),
+ * that compose the liturgical year in the Roman rite.
+ */
+export type ProperCycle = typeof PROPER_CYCLES[number];
+
+/**
+ * A three-year cycles for the Sunday mass readings (and some solemnities).
+ * The years are designated A, B, or C. Each yearly cycle begins on the first Sunday of Advent.
+ * Year B follows year A, year C follows year B, then back again to A.
  */
 export const SundayCycles = {
   YearA: 'YEAR_A',
@@ -16,7 +40,19 @@ export const SundayCycles = {
 } as const;
 
 /**
- * Weekdays cycle that can be used as metadata for liturgical days.
+ * A dynamically generated array from {@link SundayCycles} that contains all the possible
+ * three-year Sunday cycles.
+ */
+export const SUNDAY_CYCLES = Object.values(SundayCycles);
+
+/**
+ * Represent one of the three-year Sunday cycles (available from {@link SundayCycles}).
+ */
+export type SundayCycle = typeof SUNDAY_CYCLES[number];
+
+/**
+ * A two-year cycle for the weekday mass readings (also called Cycle I and Cycle II).
+ * Odd-numbered years are the year 1 (or Cycle I); even-numbered ones are the year 2 (or Cycle II).
  */
 export const WeekdayCycles = {
   Year1: 'YEAR_1',
@@ -24,7 +60,20 @@ export const WeekdayCycles = {
 } as const;
 
 /**
- * Psalter weeks that can be used as metadata for liturgical days.
+ * A dynamically generated array from {@link WeekdayCycles} that contains all the possible
+ * two-year weekday cycles.
+ */
+export const WEEKDAY_CYCLES = Object.values(WeekdayCycles);
+
+/**
+ * Represent one of the two-year weekday cycles (available from {@link WeekdayCycles}).
+ */
+export type WeekdayCycle = typeof WEEKDAY_CYCLES[number];
+
+/**
+ The four-week cycle of the psalter is coordinated with the liturgical year in such a way that
+ on the First Sunday of Advent, the First Sunday in Ordinary Time, the First Sunday of Lent,
+ and Easter Sunday the cycle is always begun again with Week 1 (others being omitted when necessary).
  */
 export const PsalterWeekCycles = {
   Week1: 'WEEK_1',
@@ -34,25 +83,12 @@ export const PsalterWeekCycles = {
 } as const;
 
 /**
- * A dynamically generated constant consisting of all the enum keys in [[LITURGICAL_DAY_CYCLES]]
- */
-export const PROPER_CYCLE = Object.values(ProperCycles);
-export type ProperCycle = typeof PROPER_CYCLE[number];
-
-/**
- * A dynamically generated constant consisting of all the enum keys in [[SUNDAY_CYCLES]]
- */
-export const SUNDAYS_CYCLE = Object.values(SundayCycles);
-export type SundayCycle = typeof SUNDAYS_CYCLE[number];
-
-/**
- * A dynamically generated constant consisting of all the enum keys in [[WEEKDAY_CYCLES]]
- */
-export const WEEKDAYS_CYCLE = Object.values(WeekdayCycles);
-export type WeekdayCycle = typeof WEEKDAYS_CYCLE[number];
-
-/**
- * A dynamically generated constant consisting of all the enum keys in [[PSALTER_WEEKS]]
+ * A dynamically generated array from {@link PsalterWeekCycles} that contains all the possible
+ * psalter week cycles.
  */
 export const PSALTER_WEEKS = Object.values(PsalterWeekCycles);
+
+/**
+ * Represent one of the four-week psalter cycles (available from {@link PsalterWeekCycles}).
+ */
 export type PsalterWeekCycle = typeof PSALTER_WEEKS[number];

--- a/lib/constants/cycles.ts
+++ b/lib/constants/cycles.ts
@@ -29,9 +29,10 @@ export const PROPER_CYCLES = Object.values(ProperCycles);
 export type ProperCycle = typeof PROPER_CYCLES[number];
 
 /**
- * A three-year cycles for the Sunday mass readings (and some solemnities).
- * The years are designated A, B, or C. Each yearly cycle begins on the first Sunday of Advent.
- * Year B follows year A, year C follows year B, then back again to A.
+ * A three-year cycle for Sunday Mass readings (and some solemnities), designated by A, B, or C. 
+ * Each cycle begins on the First Sunday of Advent of the previous civil year and ends on Saturday 
+ * after the Christ the King Solemnity. The cycles follow each other in alphabetical order.
+ * C year is always divisible by 3, A has remainder of 1, and B remainder of 2.
  */
 export const SundayCycles = {
   YearA: 'YEAR_A',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import { CALENDAR_PKG_NAMES, CALENDAR_VAR_NAMES } from '../tmp/constants/calenda
 import { LOCALE_KEYS, LOCALE_VAR_NAMES } from '../tmp/constants/locales';
 import { Color, COLORS, Colors, isColor } from './constants/colors';
 import {
-  PROPER_CYCLE,
+  PROPER_CYCLES,
   ProperCycle,
   ProperCycles,
   PSALTER_WEEKS,
@@ -11,10 +11,10 @@ import {
   PsalterWeekCycles,
   SundayCycle,
   SundayCycles,
-  SUNDAYS_CYCLE,
+  SUNDAY_CYCLES,
   WeekdayCycle,
   WeekdayCycles,
-  WEEKDAYS_CYCLE,
+  WEEKDAY_CYCLES,
 } from './constants/cycles';
 import { GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from './constants/general-calendar-names';
 import {
@@ -261,11 +261,11 @@ class Romcal {
   static isColor = isColor;
   // constants/cycles.ts
   static ProperCycles = ProperCycles;
-  static PROPER_CYCLE = PROPER_CYCLE;
+  static PROPER_CYCLE = PROPER_CYCLES;
   static SundayCycles = SundayCycles;
-  static SUNDAYS_CYCLE = SUNDAYS_CYCLE;
+  static SUNDAYS_CYCLE = SUNDAY_CYCLES;
   static WeekdayCycles = WeekdayCycles;
-  static WEEKDAYS_CYCLE = WEEKDAYS_CYCLE;
+  static WEEKDAYS_CYCLE = WEEKDAY_CYCLES;
   static PsalterWeekCycles = PsalterWeekCycles;
   static PSALTER_WEEKS = PSALTER_WEEKS;
   // constants/general-calendar-names.ts

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,14 +7,14 @@ import {
   ProperCycle,
   ProperCycles,
   PSALTER_WEEKS,
-  PsalterWeeksCycle,
-  PsalterWeeksCycles,
+  PsalterWeekCycle,
+  PsalterWeekCycles,
+  SundayCycle,
+  SundayCycles,
   SUNDAYS_CYCLE,
-  SundaysCycle,
-  SundaysCycles,
+  WeekdayCycle,
+  WeekdayCycles,
   WEEKDAYS_CYCLE,
-  WeekdaysCycle,
-  WeekdaysCycles,
 } from './constants/cycles';
 import { GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from './constants/general-calendar-names';
 import {
@@ -262,11 +262,11 @@ class Romcal {
   // constants/cycles.ts
   static ProperCycles = ProperCycles;
   static PROPER_CYCLE = PROPER_CYCLE;
-  static SundaysCycles = SundaysCycles;
+  static SundayCycles = SundayCycles;
   static SUNDAYS_CYCLE = SUNDAYS_CYCLE;
-  static WeekdaysCycles = WeekdaysCycles;
+  static WeekdayCycles = WeekdayCycles;
   static WEEKDAYS_CYCLE = WEEKDAYS_CYCLE;
-  static PsalterWeeksCycles = PsalterWeeksCycles;
+  static PsalterWeekCycles = PsalterWeekCycles;
   static PSALTER_WEEKS = PSALTER_WEEKS;
   // constants/general-calendar-names.ts
   static PROPER_OF_TIME_NAME = PROPER_OF_TIME_NAME;
@@ -337,9 +337,9 @@ export {
   Color,
   // constants/cycles.ts
   ProperCycle,
-  SundaysCycle,
-  WeekdaysCycle,
-  PsalterWeeksCycle,
+  SundayCycle,
+  WeekdayCycle,
+  PsalterWeekCycle,
   // constants/martyrology-metadata.ts
   CanonizationLevel,
   Title,

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -2,9 +2,9 @@ import {
   ProperCycle,
   PSALTER_WEEKS,
   SundayCycle,
-  SUNDAYS_CYCLE,
+  SUNDAY_CYCLES,
   WeekdayCycle,
-  WEEKDAYS_CYCLE,
+  WEEKDAY_CYCLES,
 } from '../constants/cycles';
 import { PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
 import { Periods } from '../constants/periods';
@@ -135,11 +135,11 @@ export class Calendar implements BaseCalendar {
       // If the date is on or after the First Sunday of Advent,
       // it is the next liturgical cycle
       if (date.getTime() >= firstSundayOfAdvent.getTime()) {
-        sundayCycle = SUNDAYS_CYCLE[nextSundayCycleIndex];
-        weekdayCycle = WEEKDAYS_CYCLE[year % 2];
+        sundayCycle = SUNDAY_CYCLES[nextSundayCycleIndex];
+        weekdayCycle = WEEKDAY_CYCLES[year % 2];
       } else {
-        sundayCycle = SUNDAYS_CYCLE[thisSundayCycleIndex];
-        weekdayCycle = WEEKDAYS_CYCLE[(year + 1) % 2];
+        sundayCycle = SUNDAY_CYCLES[thisSundayCycleIndex];
+        weekdayCycle = WEEKDAY_CYCLES[(year + 1) % 2];
       }
 
       this.#cyclesCache[year] = {

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -1,10 +1,10 @@
 import {
   ProperCycle,
   PSALTER_WEEKS,
+  SundayCycle,
   SUNDAYS_CYCLE,
-  SundaysCycle,
+  WeekdayCycle,
   WEEKDAYS_CYCLE,
-  WeekdaysCycle,
 } from '../constants/cycles';
 import { PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
 import { Periods } from '../constants/periods';
@@ -125,8 +125,8 @@ export class Calendar implements BaseCalendar {
     if (!this.#cyclesCache[year]) {
       const firstSundayOfAdvent = getUtcDateFromString(calendar.startOfLiturgicalYear);
 
-      let sundayCycle: SundaysCycle;
-      let weekdayCycle: WeekdaysCycle;
+      let sundayCycle: SundayCycle;
+      let weekdayCycle: WeekdayCycle;
 
       // Formula to calculate Sunday cycle (Year A, B, C)
       const thisSundayCycleIndex: number = (year - 1963) % 3;

--- a/lib/types/liturgical-day.ts
+++ b/lib/types/liturgical-day.ts
@@ -1,6 +1,6 @@
 import { StringMap } from 'i18next';
 import { Color } from '../constants/colors';
-import { ProperCycle, PsalterWeeksCycle, SundaysCycle, WeekdaysCycle } from '../constants/cycles';
+import { ProperCycle, PsalterWeekCycle, SundayCycle, WeekdayCycle } from '../constants/cycles';
 import { PatronTitle, Title } from '../constants/martyrology-metadata';
 import { Period } from '../constants/periods';
 import { Precedence } from '../constants/precedences';
@@ -186,17 +186,17 @@ export type RomcalCyclesMetadata = {
   /**
    * The Sunday yearly cycle in which the liturgical day is part.
    */
-  sundayCycle: SundaysCycle;
+  sundayCycle: SundayCycle;
 
   /**
    * The weekday yearly cycle in which the liturgical day is part.
    */
-  weekdayCycle: WeekdaysCycle;
+  weekdayCycle: WeekdayCycle;
 
   /**
    * The psalter week cycle in which the liturgical day is part.
    */
-  psalterWeek: PsalterWeeksCycle;
+  psalterWeek: PsalterWeekCycle;
 };
 
 /**
@@ -222,7 +222,7 @@ export type RomcalCalendarMetadata = {
 
   /**
    * The day of the week.
-   * Returns numbers from 0 (Sunday) to 6 (Saturday).
+   * Returns a number from 0 (Sunday) to 6 (Saturday).
    */
   dayOfWeek: number; // 0 | 1 | 2 | 3 | 4 | 5 | 6;
 


### PR DESCRIPTION
These types weren't named correctly, named in the plural form when they represented an element in the singular form.