### PR TITLE
Localize the cycle metadata

### DIFF
--- a/lib/constants/cycles.ts
+++ b/lib/constants/cycles.ts
@@ -29,8 +29,8 @@ export const PROPER_CYCLES = Object.values(ProperCycles);
 export type ProperCycle = typeof PROPER_CYCLES[number];
 
 /**
- * A three-year cycle for Sunday Mass readings (and some solemnities), designated by A, B, or C. 
- * Each cycle begins on the First Sunday of Advent of the previous civil year and ends on Saturday 
+ * A three-year cycle for Sunday Mass readings (and some solemnities), designated by A, B, or C.
+ * Each cycle begins on the First Sunday of Advent of the previous civil year and ends on Saturday
  * after the Christ the King Solemnity. The cycles follow each other in alphabetical order.
  * C year is always divisible by 3, A has remainder of 1, and B remainder of 2.
  */
@@ -72,9 +72,9 @@ export const WEEKDAY_CYCLES = Object.values(WeekdayCycles);
 export type WeekdayCycle = typeof WEEKDAY_CYCLES[number];
 
 /**
-[GILH §133] The four-week cycle of the psalter is coordinated with the liturgical year in such a way that
- on the First Sunday of Advent, the First Sunday in Ordinary Time, the First Sunday of Lent,
- and Easter Sunday the cycle is always begun again with Week 1 (others being omitted when necessary).
+ * [GILH §133] The four-week cycle of the psalter is coordinated with the liturgical year in such a way that
+ * on the First Sunday of Advent, the First Sunday in Ordinary Time, the First Sunday of Lent,
+ * and Easter Sunday the cycle is always begun again with Week 1 (others being omitted when necessary).
  */
 export const PsalterWeekCycles = {
   Week1: 'WEEK_1',

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -42,6 +42,7 @@ import { RomcalBundle } from './models/bundle';
 import { Calendar } from './models/calendar';
 import { CalendarDef } from './models/calendar-def';
 import { RomcalConfig } from './models/config';
+import { CyclesMetadata } from './models/cycles-metadata';
 import LiturgicalDay from './models/liturgical-day';
 import { LiturgicalDayConfig } from './models/liturgical-day-config';
 import LiturgicalDayDef from './models/liturgical-day-def';
@@ -56,6 +57,7 @@ import {
 } from './types/calendar-def';
 import { Key } from './types/common';
 import { CalendarScope, RomcalConfigInput, RomcalConfigOutput } from './types/config';
+import { BaseCyclesMetadata, PartialCyclesDef, PlainCyclesMetadata } from './types/cycles-metadata';
 import {
   BaseLiturgicalDay,
   BaseLiturgicalDayDef,
@@ -77,9 +79,7 @@ import {
   LiturgyDayDiff,
   MartyrologyItemPointer,
   MartyrologyItemRedefined,
-  PartialCyclesDef,
   RomcalCalendarMetadata,
-  RomcalCyclesMetadata,
   RomcalTitles,
   TitlesDef,
 } from './types/liturgical-day';
@@ -302,6 +302,7 @@ class Romcal {
   static Calendar = Calendar;
   static CalendarDef = CalendarDef;
   static RomcalConfig = RomcalConfig;
+  static CyclesMetadata = CyclesMetadata;
   static LiturgicalDay = LiturgicalDay;
   static LiturgicalDayConfig = LiturgicalDayConfig;
   static LiturgicalDayDef = LiturgicalDayDef;
@@ -330,7 +331,16 @@ class Romcal {
 
 export default Romcal;
 
-export { RomcalBundle, Calendar, CalendarDef, RomcalConfig, LiturgicalDay, LiturgicalDayConfig, LiturgicalDayDef };
+export {
+  RomcalBundle,
+  Calendar,
+  CalendarDef,
+  RomcalConfig,
+  CyclesMetadata,
+  LiturgicalDay,
+  LiturgicalDayConfig,
+  LiturgicalDayDef,
+};
 
 export {
   // constants/colors.ts
@@ -375,6 +385,10 @@ export {
   RomcalConfigInput,
   RomcalConfigOutput,
   CalendarScope,
+  // types/cycles-metadata.ts
+  BaseCyclesMetadata,
+  PartialCyclesDef,
+  PlainCyclesMetadata,
   // types/liturgical-day.ts
   BaseLiturgicalDay,
   BaseLiturgicalDayDef,
@@ -390,8 +404,6 @@ export {
   DateDefSubtractDay,
   DateDefException,
   CalendarMetadata,
-  RomcalCyclesMetadata,
-  PartialCyclesDef,
   RomcalCalendarMetadata,
   i18nDef,
   TitlesDef,

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -59,6 +59,20 @@ export const locale: Locale = {
     weekday: 'weekday',
   },
 
+  cycles: {
+    proper_of_time: 'Proper of Time',
+    proper_of_saints: 'Proper of Saints',
+    sunday_year_a: 'Year A',
+    sunday_year_b: 'Year B',
+    sunday_year_c: 'Year C',
+    weekday_year_1: 'Cycle I',
+    weekday_year_2: 'Cycle II',
+    psalter_week_1: 'Week I',
+    psalter_week_2: 'Week II',
+    psalter_week_3: 'Week III',
+    psalter_week_4: 'Week IV',
+  },
+
   weekdays: {
     0: 'Sunday',
     1: 'Monday',

--- a/lib/locales/fr.ts
+++ b/lib/locales/fr.ts
@@ -63,6 +63,20 @@ export const locale: Locale = {
     weekday: 'Férie',
   },
 
+  cycles: {
+    proper_of_time: 'Propre du Temps',
+    proper_of_saints: 'Propre des Saints',
+    sunday_year_a: 'Année A',
+    sunday_year_b: 'Année B',
+    sunday_year_c: 'Année C',
+    weekday_year_1: 'Année impaire',
+    weekday_year_2: 'Année paire',
+    psalter_week_1: 'Semaine I des Psaumes',
+    psalter_week_2: 'Semaine II des Psaumes',
+    psalter_week_3: 'Semaine III des Psaumes',
+    psalter_week_4: 'Semaine IV des Psaumes',
+  },
+
   weekdays: {
     0: 'dimanche',
     1: 'lundi',

--- a/lib/locales/it.ts
+++ b/lib/locales/it.ts
@@ -59,6 +59,20 @@ export const locale: Locale = {
     weekday: 'Feria',
   },
 
+  cycles: {
+    proper_of_time: 'Proprio del Tempo',
+    proper_of_saints: 'Proprio dei Santi',
+    sunday_year_a: 'Anno A',
+    sunday_year_b: 'Anno B',
+    sunday_year_c: 'Anno C',
+    weekday_year_1: 'Anno dispari',
+    weekday_year_2: 'Anno pari',
+    psalter_week_1: 'I Settimana del Salterio',
+    psalter_week_2: 'II Settimana del Salterio',
+    psalter_week_3: 'III Settimana del Salterio',
+    psalter_week_4: 'IV Settimana del Salterio',
+  },
+
   weekdays: {
     0: 'domenica',
     1: 'lunedì',

--- a/lib/models/config.ts
+++ b/lib/models/config.ts
@@ -11,6 +11,7 @@ import { MartyrologyCatalog } from '../types/martyrology';
 import { Dates } from '../utils/dates';
 import { toRomanNumber } from '../utils/numbers';
 import { CalendarDef } from './calendar-def';
+import { BaseCyclesMetadata } from '../types/cycles-metadata';
 
 /**
  * The [[Config]] class encapsulates all options that can be sent to this library to adjust date output.
@@ -27,7 +28,7 @@ export class RomcalConfig implements IRoncalConfig {
   readonly i18next: i18n;
   readonly dates: typeof Dates;
   readonly martyrologyCatalog: MartyrologyCatalog;
-
+  readonly cyclesCache: Record<number, Pick<BaseCyclesMetadata, 'sundayCycle' | 'weekdayCycle'>> = {};
   readonly calendarsDef: InstanceType<CalendarDefInstance>[];
   liturgicalDayDef: LiturgicalDayDefinitions = {};
 
@@ -136,6 +137,7 @@ export class RomcalConfig implements IRoncalConfig {
     this.i18next.addResourceBundle(locale.key, 'seasons', locale.seasons);
     this.i18next.addResourceBundle(locale.key, 'periods', locale.periods);
     this.i18next.addResourceBundle(locale.key, 'ranks', locale.ranks);
+    this.i18next.addResourceBundle(locale.key, 'cycles', locale.cycles);
     this.i18next.addResourceBundle(locale.key, 'weekdays', locale.weekdays);
     this.i18next.addResourceBundle(locale.key, 'months', locale.months);
     this.i18next.addResourceBundle(locale.key, 'colors', locale.colors);

--- a/lib/models/cycles-metadata.ts
+++ b/lib/models/cycles-metadata.ts
@@ -40,8 +40,8 @@ export class CyclesMetadata implements BaseCyclesMetadata {
       let weekdayCycle: WeekdayCycle;
 
       // Formula to calculate Sunday cycle (Year A, B, C)
-      const thisSundayCycleIndex: number = (year - 1963) % 3;
-      const nextSundayCycleIndex: number = thisSundayCycleIndex === 2 ? 0 : thisSundayCycleIndex + 1;
+      const thisSundayCycleIndex: number = (year + 2) % 3;
+      const nextSundayCycleIndex: number = (year + 3) % 3;
 
       // If the date is on or after the First Sunday of Advent,
       // it is the next liturgical cycle

--- a/lib/models/cycles-metadata.ts
+++ b/lib/models/cycles-metadata.ts
@@ -1,0 +1,111 @@
+import { BaseCyclesMetadata, PlainCyclesMetadata } from '../types/cycles-metadata';
+import {
+  ProperCycle,
+  PSALTER_WEEKS,
+  PsalterWeekCycle,
+  SUNDAY_CYCLES,
+  SundayCycle,
+  WEEKDAY_CYCLES,
+  WeekdayCycle,
+} from '../constants/cycles';
+import { RomcalConfig } from './config';
+import { getUtcDateFromString } from '../utils/dates';
+import { RomcalCalendarMetadata } from '../types/liturgical-day';
+
+/**
+ * A cycle metadata object, based on the contextual liturgical day & year
+ */
+export class CyclesMetadata implements BaseCyclesMetadata {
+  properCycle: ProperCycle;
+  #properCycleName?: string;
+  sundayCycle: SundayCycle;
+  #sundayCycleName?: string;
+  weekdayCycle: WeekdayCycle;
+  #weekdayCycleName?: string;
+  psalterWeek: PsalterWeekCycle;
+  #psalterWeekName?: string;
+  #config: RomcalConfig;
+
+  constructor(date: Date, calendar: RomcalCalendarMetadata, properCycle: ProperCycle, config: RomcalConfig) {
+    this.#config = config;
+
+    const year = parseInt(calendar.startOfLiturgicalYear, 10);
+
+    // Compute cycle of the liturgical year,
+    // and cache the data since they are the same for every day of the year
+    if (!this.#config.cyclesCache[year]) {
+      const firstSundayOfAdvent = getUtcDateFromString(calendar.startOfLiturgicalYear);
+
+      let sundayCycle: SundayCycle;
+      let weekdayCycle: WeekdayCycle;
+
+      // Formula to calculate Sunday cycle (Year A, B, C)
+      const thisSundayCycleIndex: number = (year - 1963) % 3;
+      const nextSundayCycleIndex: number = thisSundayCycleIndex === 2 ? 0 : thisSundayCycleIndex + 1;
+
+      // If the date is on or after the First Sunday of Advent,
+      // it is the next liturgical cycle
+      if (date.getTime() >= firstSundayOfAdvent.getTime()) {
+        sundayCycle = SUNDAY_CYCLES[nextSundayCycleIndex];
+        weekdayCycle = WEEKDAY_CYCLES[year % 2];
+      } else {
+        sundayCycle = SUNDAY_CYCLES[thisSundayCycleIndex];
+        weekdayCycle = WEEKDAY_CYCLES[(year + 1) % 2];
+      }
+
+      this.#config.cyclesCache[year] = {
+        sundayCycle,
+        weekdayCycle,
+      };
+    }
+
+    // Psalter week cycle restart to 1 at the beginning of each season.
+    // Except during the four first days of lent (ash wednesday to the next saturday),
+    // which are in week 4, to start on week 1 after the first sunday of lent.
+    const weekIndex = (calendar.weekOfSeason % 4) - 1;
+    const psalterWeek = PSALTER_WEEKS[weekIndex > -1 ? weekIndex : 3];
+
+    this.properCycle = properCycle;
+    this.sundayCycle = this.#config.cyclesCache[year].sundayCycle;
+    this.weekdayCycle = this.#config.cyclesCache[year].weekdayCycle;
+    this.psalterWeek = psalterWeek;
+  }
+
+  get properCycleName(): string {
+    if (this.#properCycleName !== undefined) return this.#properCycleName;
+    this.#properCycleName = this.#config.i18next.t(`cycles:${this.properCycle.toLowerCase()}`);
+    return this.#properCycleName;
+  }
+
+  get sundayCycleName(): string {
+    if (this.#sundayCycleName !== undefined) return this.#sundayCycleName;
+    this.#sundayCycleName = this.#config.i18next.t(`cycles:sunday_${this.sundayCycle.toLowerCase()}`);
+    console.log(this.#config.i18next.t(`cycles:sunday_${this.sundayCycle.toLowerCase()}`));
+    return this.#sundayCycleName;
+  }
+
+  get weekdayCycleName(): string {
+    if (this.#weekdayCycleName !== undefined) return this.#weekdayCycleName;
+    this.#weekdayCycleName = this.#config.i18next.t(`cycles:weekday_${this.weekdayCycle.toLowerCase()}`);
+    return this.#weekdayCycleName;
+  }
+
+  get psalterWeekName(): string {
+    if (this.#psalterWeekName !== undefined) return this.#psalterWeekName;
+    this.#psalterWeekName = this.#config.i18next.t(`cycles:psalter_${this.psalterWeek.toLowerCase()}`);
+    return this.#psalterWeekName;
+  }
+
+  toObject(): PlainCyclesMetadata {
+    return {
+      properCycle: this.properCycle,
+      properCycleName: this.properCycleName,
+      sundayCycle: this.sundayCycle,
+      sundayCycleName: this.sundayCycleName,
+      weekdayCycle: this.weekdayCycle,
+      weekdayCycleName: this.weekdayCycleName,
+      psalterWeek: this.psalterWeek,
+      psalterWeekName: this.psalterWeekName,
+    };
+  }
+}

--- a/lib/models/liturgical-day-def.ts
+++ b/lib/models/liturgical-day-def.ts
@@ -1,3 +1,4 @@
+import { PartialCyclesDef } from '../types/cycles-metadata';
 import { Color, Colors } from '../constants/colors';
 import { ProperCycles } from '../constants/cycles';
 import { GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
@@ -20,7 +21,6 @@ import {
   LiturgicalDayProperOfTimeInput,
   LiturgyDayDiff,
   MartyrologyItemRedefined,
-  PartialCyclesDef,
   RomcalTitles,
   TitlesDef,
 } from '../types/liturgical-day';

--- a/lib/models/liturgical-day.ts
+++ b/lib/models/liturgical-day.ts
@@ -12,13 +12,13 @@ import {
   i18nDef,
   LiturgyDayDiff,
   RomcalCalendarMetadata,
-  RomcalCyclesMetadata,
   RomcalTitles,
 } from '../types/liturgical-day';
 import { LiturgicalDayConfigOutput } from '../types/liturgical-day-config';
 import { MartyrologyItem } from '../types/martyrology';
 import { LiturgicalDayConfig } from './liturgical-day-config';
 import LiturgicalDayDef from './liturgical-day-def';
+import { CyclesMetadata } from './cycles-metadata';
 
 class LiturgicalDay implements BaseLiturgicalDay {
   readonly #liturgicalDayDef: LiturgicalDayDef;
@@ -38,7 +38,7 @@ class LiturgicalDay implements BaseLiturgicalDay {
   readonly martyrology: MartyrologyItem[];
   readonly titles: RomcalTitles;
   readonly calendar: RomcalCalendarMetadata;
-  readonly cycles: RomcalCyclesMetadata;
+  readonly cycles: CyclesMetadata;
   readonly fromCalendar: FromCalendar;
   readonly fromExtendedCalendars: LiturgyDayDiff[];
   weekday?: LiturgicalDay;
@@ -82,7 +82,6 @@ class LiturgicalDay implements BaseLiturgicalDay {
     date: Date,
     liturgicalDayConfig: LiturgicalDayConfig,
     calendar: RomcalCalendarMetadata,
-    cycles: RomcalCyclesMetadata,
     baseData: LiturgicalDay | null,
     weekday: LiturgicalDay | null,
   ) {
@@ -141,7 +140,7 @@ class LiturgicalDay implements BaseLiturgicalDay {
     this.martyrology = def.martyrology;
     this.titles = def.titles;
     this.calendar = baseData?.calendar ?? calendar;
-    this.cycles = cycles;
+    this.cycles = new CyclesMetadata(date, calendar, def.cycles.properCycle, liturgicalDayConfig.config);
     this.fromCalendar = def.fromCalendar;
     this.fromExtendedCalendars = def.fromExtendedCalendars;
 

--- a/lib/types/cycles-metadata.ts
+++ b/lib/types/cycles-metadata.ts
@@ -1,0 +1,56 @@
+import { ProperCycle, PsalterWeekCycle, SundayCycle, WeekdayCycle } from '../constants/cycles';
+
+/**
+ * Cycles Metadata
+ */
+export type BaseCyclesMetadata = {
+  /**
+   * The proper cycle in which the liturgical day is part
+   */
+  properCycle: ProperCycle;
+
+  /**
+   * The proper cycle name in which the liturgical day is part
+   */
+  properCycleName: string;
+
+  /**
+   * The Sunday yearly cycle in which the liturgical day is part
+   */
+  sundayCycle: SundayCycle;
+
+  /**
+   * The Sunday yearly cycle name in which the liturgical day is part
+   */
+  sundayCycleName: string;
+
+  /**
+   * The weekday yearly cycle in which the liturgical day is part
+   */
+  weekdayCycle: WeekdayCycle;
+
+  /**
+   * The weekday yearly cycle name in which the liturgical day is part
+   */
+  weekdayCycleName: string;
+
+  /**
+   * The psalter week cycle in which the liturgical day is part
+   */
+  psalterWeek: PsalterWeekCycle;
+
+  /**
+   * The psalter week cycle name in which the liturgical day is part
+   */
+  psalterWeekName: string;
+};
+
+/**
+ * Partial Cycle Metadata definition
+ */
+export type PartialCyclesDef = Pick<BaseCyclesMetadata, 'properCycle'>;
+
+/**
+ * Plain object of the {@Link CycleMetadata} object
+ */
+export type PlainCyclesMetadata = BaseCyclesMetadata;

--- a/lib/types/liturgical-day.ts
+++ b/lib/types/liturgical-day.ts
@@ -1,6 +1,6 @@
 import { StringMap } from 'i18next';
 import { Color } from '../constants/colors';
-import { ProperCycle, PsalterWeekCycle, SundayCycle, WeekdayCycle } from '../constants/cycles';
+import { ProperCycle } from '../constants/cycles';
 import { PatronTitle, Title } from '../constants/martyrology-metadata';
 import { Period } from '../constants/periods';
 import { Precedence } from '../constants/precedences';
@@ -13,6 +13,7 @@ import { AllXOR, Key, XOR } from './common';
 import { MartyrologyItem, SaintCount } from './martyrology';
 import { MonthIndex } from '../constants/months';
 import { DayOfWeek } from '../constants/weekdays';
+import { PartialCyclesDef, BaseCyclesMetadata } from './cycles-metadata';
 
 /**
  * The liturgical day date definition
@@ -173,36 +174,6 @@ export type CalendarMetadata = {
   weekOfSeason?: number;
   dayOfWeek?: number;
 };
-
-/**
- * Cycles Metadata
- */
-export type RomcalCyclesMetadata = {
-  /**
-   * The proper cycle in which the liturgical day is part.
-   */
-  properCycle: ProperCycle;
-
-  /**
-   * The Sunday yearly cycle in which the liturgical day is part.
-   */
-  sundayCycle: SundayCycle;
-
-  /**
-   * The weekday yearly cycle in which the liturgical day is part.
-   */
-  weekdayCycle: WeekdayCycle;
-
-  /**
-   * The psalter week cycle in which the liturgical day is part.
-   */
-  psalterWeek: PsalterWeekCycle;
-};
-
-/**
- * Partial Cycle Metadata definition
- */
-export type PartialCyclesDef = Pick<RomcalCyclesMetadata, 'properCycle'>;
 
 /**
  * Calendar Metadata
@@ -424,7 +395,7 @@ type LiturgicalDayRoot = {
   /**
    * Cycle metadata of a liturgical day.
    */
-  cycles: RomcalCyclesMetadata;
+  cycles: BaseCyclesMetadata;
 
   /**
    * The proper cycle in which the liturgical day is part.
@@ -600,7 +571,7 @@ export type LiturgyDayDiff = Pick<LiturgicalDayDef, 'fromCalendar'> &
       | 'i18nDef'
       | 'titles'
       | 'colors'
-    > & { cycles: Partial<Pick<RomcalCyclesMetadata, 'properCycle'>>; martyrology: Key[] }
+    > & { cycles: Partial<Pick<BaseCyclesMetadata, 'properCycle'>>; martyrology: Key[] }
   >;
 
 /**

--- a/lib/types/locale.ts
+++ b/lib/types/locale.ts
@@ -52,6 +52,19 @@ export interface Locale {
     memorial?: string;
     weekday?: string;
   };
+  cycles?: {
+    proper_of_time?: string;
+    proper_of_saints?: string;
+    sunday_year_a?: string;
+    sunday_year_b?: string;
+    sunday_year_c?: string;
+    weekday_year_1?: string;
+    weekday_year_2?: string;
+    psalter_week_1?: string;
+    psalter_week_2?: string;
+    psalter_week_3?: string;
+    psalter_week_4?: string;
+  };
   names?: LocaleLiturgicalDayNames;
 }
 

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -192,6 +192,7 @@ export const RomcalBundler = (): void => {
           ordinals: mergedLocale.ordinals,
           periods: mergedLocale.periods,
           ranks: mergedLocale.ranks,
+          cycles: mergedLocale.cycles,
           seasons: mergedLocale.seasons,
           weekdays: mergedLocale.weekdays,
           names,


### PR DESCRIPTION
**Closes #233.**  Related to #346.

- New cycles properties:
  - `properCycleName`
  - `sundayCycleName`
  - `weekdayCycleName`
  - `psalterWeekName`
- New i18n entries (in `en`, `fr`, `it`) to translate these new properties. Then, PRs are welcome to translate all the other existing locales.
- Refactor of the `CycleMetadata` object.