### PR TITLE
data: update the canonization level of charles_de_foucauld

### DIFF
--- a/lib/catalog/martyrology.ts
+++ b/lib/catalog/martyrology.ts
@@ -972,7 +972,7 @@ export class Martyrology {
     },
 
     charles_de_foucauld: {
-      canonizationLevel: CanonizationLevels.Blessed,
+      canonizationLevel: CanonizationLevels.Saint,
       name: 'Charles de Foucauld',
       titles: [Titles.Priest],
       dateOfDeath: '1916-12-1',

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -318,7 +318,7 @@ export const locale: Locale = {
     chad_of_mercia_and_cedd_of_lastingham_bishops: 'Saints Chad and Cedd, Bishops',
     chair_of_saint_peter_the_apostle: 'Chair of Saint Peter the Apostle',
     charles_borromeo_bishop: 'Saint Charles Borromeo, Bishop',
-    charles_de_foucauld: 'Blessed Charles de Foucauld, Priest',
+    charles_de_foucauld: 'Saint Charles de Foucauld, Priest',
     charles_i_of_austria: 'Blessed Charles of Austria',
     charles_lwanga_and_companions_martyrs: 'Saints Charles Lwanga and Companions, Martyrs',
     charles_spinola_and_jerome_de_angelis_priests:

--- a/lib/locales/fr.ts
+++ b/lib/locales/fr.ts
@@ -272,7 +272,7 @@ export const locale: Locale = {
     ceran_of_paris_bishop: 'Saint Céran, évêque de Paris au 7e siècle',
     chair_of_saint_peter_the_apostle: 'Chaire de Saint Pierre, apôtre',
     charles_borromeo_bishop: 'Saint Charles Borromée, Archevêque de Milan (✝ 1584)',
-    charles_de_foucauld: 'Bienheureux Charles de Foucauld, prêtre, ermite et missionnaire au Sahara († 1916)',
+    charles_de_foucauld: 'Saint Charles de Foucauld, prêtre, ermite et missionnaire au Sahara († 1916)',
     charles_lwanga_and_companions_martyrs: 'Saints Charles Lwanga et ses douze compagnons, martyrs (✝ 618)',
     christopher_magallanes_priest_and_companions_martyrs:
       'Saints Cristóbal Magallanes, prêtre, et ses 24 compagnons, martyrs Mexicains (✝ 1927)',


### PR DESCRIPTION
_Charles de Foucauld_ is now a saint, since May 15, 2022.