### PR TITLE
fix(slovakia): remove celebrations not inscribed into national proper

### DIFF
--- a/lib/general-calendar/proper-of-time.ts
+++ b/lib/general-calendar/proper-of-time.ts
@@ -173,7 +173,6 @@ export class ProperOfTime extends CalendarDef {
     this.#newLiturgicalDayDef(`holy_family_of_jesus_mary_and_joseph`, {
       precedence: Precedences.GeneralLordFeast_5,
       dateDef: { dateFn: 'holyFamily', yearOffset: -1 + yearOffset },
-      isHolyDayOfObligation: false,
       seasons: [Seasons.ChristmasTime],
       periods: [Periods.ChristmasOctave, Periods.ChristmasToPresentationOfTheLord],
       calendarMetadata: {},
@@ -260,7 +259,6 @@ export class ProperOfTime extends CalendarDef {
     this.#newLiturgicalDayDef(`baptism_of_the_lord`, {
       precedence: Precedences.ProperOfTimeSolemnity_2,
       dateDef: { dateFn: 'baptismOfTheLord', yearOffset: yearOffset },
-      isHolyDayOfObligation: true,
       seasons: [Seasons.ChristmasTime],
       periods: [Periods.DaysFromEpiphany, Periods.ChristmasToPresentationOfTheLord],
       calendarMetadata: {},
@@ -504,7 +502,7 @@ export class ProperOfTime extends CalendarDef {
     this.#newLiturgicalDayDef(`most_sacred_heart_of_jesus`, {
       precedence: Precedences.GeneralSolemnity_3,
       dateDef: { dateFn: 'mostSacredHeartOfJesus', yearOffset: yearOffset },
-      isHolyDayOfObligation: true,
+      isHolyDayOfObligation: false,
       seasons: [Seasons.OrdinaryTime],
       periods: [],
       calendarMetadata: { dayOfWeek: 5 },

--- a/lib/particular-calendars/slovakia.ts
+++ b/lib/particular-calendars/slovakia.ts
@@ -47,11 +47,6 @@ export class Slovakia extends CalendarDef {
       dateDef: { month: 5, date: 16 },
     },
 
-    ladislaus_i_of_hungary: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 6, date: 27 },
-    },
-
     visitation_of_mary: {
       precedence: Precedences.ProperFeast_8f,
       dateDef: { month: 7, date: 2 },
@@ -92,11 +87,6 @@ export class Slovakia extends CalendarDef {
       dateDef: { month: 8, date: 18 },
     },
 
-    teresa_of_calcutta_religious: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 9, date: 5 },
-    },
-
     marko_krizin_melchior_grodziecki_and_stephen_pongracz_priests: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 9, date: 7 },
@@ -131,16 +121,6 @@ export class Slovakia extends CalendarDef {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 11, date: 2 },
       colors: [Colors.Purple, Colors.Black],
-    },
-
-    emeric_of_hungary: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 11, date: 5 },
-    },
-
-    john_damascene_priest: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 12, date: 4 },
     },
 
     barbara_of_heliopolis_virgin: {

--- a/tests/calendar-date-overrides.test.ts
+++ b/tests/calendar-date-overrides.test.ts
@@ -2,6 +2,7 @@ import { CzechRepublic_Cs } from 'romcal/dist/bundles/czech-republic';
 import { England_En } from 'romcal/dist/bundles/england';
 import { Germany_En } from 'romcal/dist/bundles/germany';
 import { Hungary_En } from 'romcal/dist/bundles/hungary';
+import { Ireland_En } from 'romcal/dist/bundles/ireland'
 import { Malta_En } from 'romcal/dist/bundles/malta';
 import { Mexico_Es } from 'romcal/dist/bundles/mexico';
 import { Slovakia_Sk } from 'romcal/dist/bundles/slovakia';
@@ -266,20 +267,21 @@ describe('Testing national calendar overrides', () => {
     });
   });
 
-  describe('Saint Ladislaus', () => {
-    test('A feast in Hungary but an optional memorial in Slovakia', async () => {
-      const hungaryDates = Object.values(
-        await new Romcal({ localizedCalendar: Hungary_En }).generateCalendar(2018),
+  describe('Saint Oliver Plunket', () => {
+    test('A memorial in Ireland but an optional memorial in England', async () => {
+      const irelandDates = Object.values(
+        await new Romcal({ localizedCalendar: Ireland_En }).generateCalendar(2019),
       ).flat();
-      const slovakiaDates = Object.values(
-        await new Romcal({ localizedCalendar: Slovakia_Sk }).generateCalendar(2018),
+      const englandDates = Object.values(
+        await new Romcal({ localizedCalendar: England_En }).generateCalendar(2019),
       ).flat();
-      const ladislausIOfHungaryHungary = hungaryDates.find((d) => d.key === 'ladislaus_i_of_hungary');
-      const ladislausIOfHungarySlovakia = slovakiaDates.find((d) => d.key === 'ladislaus_i_of_hungary');
-      expect(ladislausIOfHungaryHungary?.precedence).toEqual(Precedences.ProperFeast_8f);
-      expect(ladislausIOfHungarySlovakia?.precedence).toEqual(Precedences.OptionalMemorial_12);
-    });
-  });
+      const oliverPlunketBishopIreland = irelandDates.find((d) => d.key === 'oliver_plunket_bishop');
+      const oliverPlunketBishopEngland = englandDates.find((d) => d.key === 'oliver_plunket_bishop');
+
+      expect(oliverPlunketBishopIreland?.precedence).toEqual(Precedences.ProperMemorial_11b);
+      expect(oliverPlunketBishopEngland?.precedence).toEqual(Precedences.OptionalMemorial_12);
+    })
+  })
 
   describe('Our Lady of Sorrows', () => {
     test('Should be celebrated on the September 15, 2018 as a memorial in the General Calendar', async () => {


### PR DESCRIPTION
Celebrations `ladislaus_i_of_hungary` and `teresa_of_calcutta_religious` are not inscribed in the national Proper of Slovakia. `john_damascene_priest` is already defined in the GRC. `emeric_of_hungary` is celebrated in the Diocese of Roznava only.