### PR TITLE
Fix a flaky color test

### DIFF
--- a/tests/calendar-builder.test.ts
+++ b/tests/calendar-builder.test.ts
@@ -153,7 +153,7 @@ describe('Testing calendar generation functions', () => {
     });
 
     test('The proper color for the Chair of Peter and the Conversion of St. Paul is white, although both St. Peter and St. Paul were martyrs.', async () => {
-      const dates = Object.values(await new Romcal().generateCalendar())
+      const dates = Object.values(await new Romcal().generateCalendar(2022))
         .flat()
         .filter((d) => ['chair_of_saint_peter_the_apostle', 'conversion_of_saint_paul_the_apostle'].includes(d.key));
       expect(dates.length).toBe(2);


### PR DESCRIPTION
Fix a flaky test by adding explicitly the year in the test.

It was working in 2022, but not in 2023 (since "Chair of Saint Peter the Apostle" do not occur in 2023, because of Ash Wednesday falling the same day).