### PR TITLE
chore: update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+/.log*
 *.log
 npm-debug.log*
 


### PR DESCRIPTION
JetBrains IDEs create `/.log*` files in the repository root, therefore we should ignore them.