### PR TITLE
fix: dateExceptions not correctly merged from previous item definition

### DIFF
--- a/lib/models/liturgical-day-def.ts
+++ b/lib/models/liturgical-day-def.ts
@@ -110,6 +110,8 @@ export default class LiturgicalDayDef implements BaseLiturgicalDayDef {
       ? input.dateExceptions
       : input.dateExceptions
       ? [input.dateExceptions]
+      : previousDef
+      ? previousDef.dateExceptions
       : [];
 
     if (!input.precedence && !previousDef) {

--- a/lib/models/liturgical-day.ts
+++ b/lib/models/liturgical-day.ts
@@ -8,6 +8,7 @@ import { Id } from '../types/common';
 import {
   BaseLiturgicalDay,
   DateDef,
+  DateDefException,
   FromCalendarId,
   i18nDef,
   LiturgyDayDiff,
@@ -26,6 +27,7 @@ class LiturgicalDay implements BaseLiturgicalDay {
   readonly id: Id;
   readonly date: string;
   readonly dateDef: DateDef;
+  readonly dateExceptions: DateDefException[];
   readonly precedence: Precedence;
   readonly rank: Rank;
   readonly allowSimilarRankItems: boolean;
@@ -90,6 +92,7 @@ class LiturgicalDay implements BaseLiturgicalDay {
     this.id = def.id;
     this.date = date.toISOString().substring(0, 10);
     this.dateDef = def.dateDef;
+    this.dateExceptions = def.dateExceptions;
     this.precedence = def.precedence;
     this.rank = def.rank;
     this.allowSimilarRankItems = def.allowSimilarRankItems;

--- a/tests/calendar-builder.test.ts
+++ b/tests/calendar-builder.test.ts
@@ -37,6 +37,7 @@ describe('Testing calendar generation functions', () => {
         'id',
         'date',
         'dateDef',
+        'dateExceptions',
         'precedence',
         'rank',
         'isHolyDayOfObligation',

--- a/tests/calendar-date-overrides.test.ts
+++ b/tests/calendar-date-overrides.test.ts
@@ -71,6 +71,22 @@ describe('Testing national calendar overrides', () => {
     });
   });
 
+  describe('Extend already defined liturgical day definitions on calendars', () => {
+    test('Extend an existing liturgical day definition, does not affect date exceptions rules on the base liturgical day definition', async () => {
+      const generalDates = Object.values(await new Romcal().generateCalendar(2023)).flat();
+      const generalDate = generalDates.find((d) => d.id === 'joseph_spouse_of_mary');
+
+      const skDates = Object.values(await new Romcal({ localizedCalendar: Slovakia_Sk }).generateCalendar(2023)).flat();
+      const skDate = skDates.find((d) => d.id === 'joseph_spouse_of_mary');
+
+      expect(generalDate?.date).toEqual(skDate?.date);
+      expect(generalDate?.date).toEqual('2023-03-20'); // Date is moved to the day after in 2023, because of a date rule exception.
+      expect(generalDate?.isHolyDayOfObligation).toBeTruthy();
+      expect(skDate?.isHolyDayOfObligation).toBeFalsy();
+      expect(skDate?.dateExceptions.length).toBeGreaterThan(0);
+    });
+  });
+
   describe('The Solemnity of Epiphany of the Lord', () => {
     test('Should always be celebrated on January 6 in Slovakia unless explicitly configured otherwise', async () => {
       const slovakiaDates = Object.values(


### PR DESCRIPTION
- `dateExceptions` property not correctly merged from previous liturgical day definition.
- `dateExceptions` property not output on the final `LiturgicalDay` object.

Fixes #432 & #433.

