### PR TITLE
fix: no-console in src codebase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
     'prettier',
   ],
   rules: {
+    'no-console': 'error',
     'simple-import-sort/imports': 'error',
     'simple-import-sort/exports': 'error',
     'import/first': 'error',

--- a/lib/models/cycles-metadata.ts
+++ b/lib/models/cycles-metadata.ts
@@ -80,7 +80,6 @@ export class CyclesMetadata implements BaseCyclesMetadata {
   get sundayCycleName(): string {
     if (this.#sundayCycleName !== undefined) return this.#sundayCycleName;
     this.#sundayCycleName = this.#config.i18next.t(`cycles:sunday_${this.sundayCycle.toLowerCase()}`);
-    console.log(this.#config.i18next.t(`cycles:sunday_${this.sundayCycle.toLowerCase()}`));
     return this.#sundayCycleName;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6507,8 +6507,17 @@
       }
     },
     "node_modules/romcal": {
-      "resolved": "",
-      "link": true
+      "version": "3.0.0-dev.36",
+      "resolved": "file:",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "i18next": "^21.6.0",
+        "ts-deepmerge": "^6.0.2"
+      },
+      "engines": {
+        "node": "^14.16 || >=16.0.0"
+      }
     },
     "node_modules/rsvp": {
       "version": "4.8.5",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,6 +19,7 @@ import { RomcalBundler } from './bundle';
 import { getDuration } from './time';
 
 const tsConfigPath = './tsconfig.release.json';
+// eslint-disable-next-line no-console
 const log = console.log;
 const formatCode = (code: string): string => prettier.format(code, { parser: 'typescript', singleQuote: true });
 

--- a/scripts/bundle-doc.ts
+++ b/scripts/bundle-doc.ts
@@ -9,6 +9,7 @@ import { particularCalendars } from '../lib/particular-calendars';
 import { toPackageName } from '../lib/utils/string';
 import { getDuration } from './time';
 
+// eslint-disable-next-line no-console
 const log = console.log;
 const time = new Date();
 

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -27,6 +27,7 @@ import LiturgicalDayDef from '../lib/models/liturgical-day-def';
 import { particularCalendars } from '../lib/particular-calendars';
 import { sanitizeLocaleId, toPascalCase } from '../lib/utils/string';
 
+// eslint-disable-next-line no-console
 const log = console.log;
 
 /**

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -7,23 +7,26 @@ const tag = 'dev';
 const dryRun = false;
 const token = process.env.NPM_TOKEN;
 
+// eslint-disable-next-line no-console
+const log = console.log;
+
 /**
  * Provide a feedback message after a package is published to NPM
  * @param data
  */
 const afterPublish = (data: Results): void => {
   if (data.oldVersion !== data.version) {
-    console.log(` ✓ Package "${data.package}" published: ${data.oldVersion} → ${data.version} (${data.tag})\n`);
+    log(` ✓ Package "${data.package}" published: ${data.oldVersion} → ${data.version} (${data.tag})\n`);
   } else if (data.oldVersion === data.version) {
-    console.log(` ✓ Package "${data.package}" is already published: ${data.version} (${data.tag})\n`);
+    log(` ✓ Package "${data.package}" is already published: ${data.version} (${data.tag})\n`);
   } else {
-    console.log(data, '\n');
+    log(data, '\n');
   }
 };
 
 (async (): Promise<void> => {
   // Start by publishing the main romcal library
-  console.log(` - Publishing romcal`);
+  log(` - Publishing romcal`);
   const mainData = await npmPublish({
     package: path.join(__dirname, '../package.json'),
     access: 'public',
@@ -42,7 +45,7 @@ const afterPublish = (data: Results): void => {
 
   // Then, publish every calendar bundles as standalone NPM packages
   for (let i = 0; i < bundleNames.length; i++) {
-    console.log(` - Publishing bundle: ${bundleNames[i]}`);
+    log(` - Publishing bundle: ${bundleNames[i]}`);
     const calendarData = await npmPublish({
       package: path.join(bundlesBasePath, bundleNames[i], 'package.json'),
       access: 'public',


### PR DESCRIPTION
- Added an ESLint rule to disallow `console.log` statements in the code.
- Removed a `console.log` statements from the code.
- Allowed `console.log` statements on a case-by-case basis in the `/scripts/` files.