### PR TITLE
fix: make sure all l10n keys are defined in `en.ts`

### DIFF
--- a/lib/locales/la.ts
+++ b/lib/locales/la.ts
@@ -742,7 +742,7 @@ export const locale: Locale = {
     mary_mother_of_god: 'In octava Nativitatis. Sollemnitas Sanctæ Dei Genetricis Mariæ',
     mary_mother_of_the_church: 'B. Mariæ Virginis Ecclesiæ Matris',
     mary_of_jesus_crucified_petkovic_virgin: 'B. Mariæ a Iesu Crucifixo Petković, virginis',
-    mary_of_jesus_in_the_blessed_sacrament_venegas_virgin: 'S. Mariæ a Iesu Sacramentato Venegas de la Torre, virginis',
+    mary_of_jesus_in_the_blessed_sacrament_venegas_de_la_torre_virgin: 'S. Mariæ a Iesu Sacramentato Venegas de la Torre, virginis',
     mary_of_jesus_the_good_shepherd_siedliska_virgin: 'B. Mariæ a Iesu Bono Pastore Siedliska, virginis',
     mary_of_the_cross_mackillop_virgin: 'S. Mariæ a Cruce MacKillop, virginis',
     mary_of_the_incarnation_barbara_acarie_religious: 'B. Mariæ ab Incarnatione Barbaræ Acarie, religiosæ',

--- a/tests/locales.test.ts
+++ b/tests/locales.test.ts
@@ -1,6 +1,8 @@
 import { Brazil_PtBr } from 'romcal/dist/bundles/brazil';
 import { France_Fr } from 'romcal/dist/bundles/france';
 
+import { locales } from './../lib/locales/index'
+
 import Romcal from '../lib';
 
 describe('Testing localization functionality', () => {
@@ -13,4 +15,21 @@ describe('Testing localization functionality', () => {
     const date = await new Romcal({ localizedCalendar: Brazil_PtBr }).getOneLiturgicalDay('all_saints');
     expect(date?.name).toBe('Todos os Santos');
   });
+});
+
+describe('Testing localization data', () => {
+  const localeList = Object.keys(locales)
+  const sourceLocaleName = 'En'
+
+  const keyPerLocaleList: {[k: string]: string[]} = localeList
+    .reduce((a, c) => ({
+      ...a,
+      [c]: Object.keys(locales[c].names).sort((a, b) => a === b ? 0 : a < b ? -1 : 1)
+    }), {})
+
+  for (const l of localeList.filter(i => i !== sourceLocaleName)) {
+    test(`If \`${l}\` contain only keys from \`${sourceLocaleName}\` in \`names\``, async () => {
+      expect(keyPerLocaleList[l].filter(x => !keyPerLocaleList[sourceLocaleName].includes(x))).toBeArrayOfSize(0)
+    })
+  }
 });


### PR DESCRIPTION
Changes:

- fix(`la`): rename `mary_of_jesus_in_the_blessed_sacrament_venegas_virgin` to `mary_of_jesus_in_the_blessed_sacrament_venegas_de_la_torre_virgin`;
- test(l10n): add a unit test to check if all `names` l10n keys defined in non-English locales, are also defined in `en.ts`.