### PR TITLE
Allow calendars to be computed from a Julian Easter date

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -94,7 +94,6 @@ import {
 import { MartyrologyCatalog, MartyrologyItem, SaintCount, SaintDate, SaintDateDef } from './types/martyrology';
 import {
   addDays,
-  computeGregorianEasterDate,
   dateDifference,
   Dates,
   daysInMonth,
@@ -108,6 +107,7 @@ import {
   startOfWeek,
   subtractsDays,
 } from './utils/dates';
+import { calculateGregorianEasterDate, calculateJulianEasterDateToGregorianDate } from './utils/easter.dates';
 import { isInteger, toRomanNumber } from './utils/numbers';
 
 class Romcal {
@@ -316,7 +316,8 @@ class Romcal {
   static isValidDate = isValidDate;
   static daysInMonth = daysInMonth;
   static getWeekNumber = getWeekNumber;
-  static computeGregorianEasterDate = computeGregorianEasterDate;
+  static computeGregorianEasterDate = calculateGregorianEasterDate;
+  static computeJulianEasterDate = calculateJulianEasterDateToGregorianDate;
   static rangeContainsDate = rangeContainsDate;
   static rangeOfDays = rangeOfDays;
   // utils/numbers.ts

--- a/lib/models/config.ts
+++ b/lib/models/config.ts
@@ -6,7 +6,13 @@ import { GeneralRoman } from '../general-calendar/proper-of-saints';
 import { ProperOfTime } from '../general-calendar/proper-of-time';
 import { RomcalBundleObject } from '../types/bundle';
 import { CalendarDefInstance, LiturgicalDayDefinitions } from '../types/calendar-def';
-import { CalendarScope, IRomcalConfig, RomcalConfigInput, RomcalConfigOutput } from '../types/config';
+import {
+  CalendarScope,
+  EasterCalculationType,
+  IRomcalConfig,
+  RomcalConfigInput,
+  RomcalConfigOutput,
+} from '../types/config';
 import { BaseCyclesMetadata } from '../types/cycles-metadata';
 import { Locale } from '../types/locale';
 import { MartyrologyCatalog } from '../types/martyrology';
@@ -26,6 +32,7 @@ export class RomcalConfig implements IRomcalConfig {
   epiphanyOnSunday: boolean;
   corpusChristiOnSunday: boolean;
   ascensionOnSunday: boolean;
+  easterCalculationType: EasterCalculationType;
   readonly scope: CalendarScope;
   readonly i18next: i18n;
   readonly dates: typeof Dates;
@@ -60,6 +67,7 @@ export class RomcalConfig implements IRomcalConfig {
       this.localizedCalendar = config.localizedCalendar;
     }
 
+    this.easterCalculationType = config?.easterCalculationType ?? 'gregorian';
     this.scope = config?.scope ?? 'gregorian';
 
     this.epiphanyOnSunday =
@@ -179,6 +187,7 @@ export class RomcalConfig implements IRomcalConfig {
       ascensionOnSunday: this.ascensionOnSunday,
       localeId: this.localeId,
       calendarName: this.calendarName,
+      easterCalculationType: this.easterCalculationType,
       scope: this.scope,
     };
   }

--- a/lib/particular-calendars/greece.ts
+++ b/lib/particular-calendars/greece.ts
@@ -1,10 +1,14 @@
 import { Precedences } from '../constants/precedences';
 import { CalendarDef } from '../models/calendar-def';
-import { Inputs } from '../types/calendar-def';
+import { Inputs, ParticularConfig } from '../types/calendar-def';
 import { Europe } from './europe';
 
 export class Greece extends CalendarDef {
   parentCalendar = Europe;
+
+  particularConfig: ParticularConfig = {
+    easterCalculationType: 'julian',
+  };
 
   inputs: Inputs = {
     cyril_of_jerusalem_bishop: {

--- a/lib/types/calendar-def.ts
+++ b/lib/types/calendar-def.ts
@@ -9,7 +9,7 @@ import { LiturgicalDayBundleInput, LiturgicalDayInput } from './liturgical-day';
  * Specific and proper configuration of a particular calendar
  */
 export type ParticularConfig = Partial<
-  Pick<RomcalConfig, 'ascensionOnSunday' | 'epiphanyOnSunday' | 'corpusChristiOnSunday'>
+  Pick<RomcalConfig, 'ascensionOnSunday' | 'epiphanyOnSunday' | 'corpusChristiOnSunday' | 'easterCalculationType'>
 >;
 
 /**

--- a/lib/types/config.ts
+++ b/lib/types/config.ts
@@ -39,6 +39,11 @@ export interface BaseRomcalConfig {
   readonly ascensionOnSunday?: boolean;
 
   /**
+   * Determines if the date of Easter is calculated using the Gregorian calendar or the Julian calendar.
+   */
+  readonly easterCalculationType: EasterCalculationType;
+
+  /**
    * The calendar scope to query for.
    *
    * The scope can be specified either as:
@@ -79,3 +84,5 @@ export type RomcalConfigInput = Omit<Partial<BaseRomcalConfig>, 'localeId' | 'ca
 export type RomcalConfigOutput = Required<Omit<BaseRomcalConfig, 'localizedCalendar' | 'calendarsDef'>>;
 
 export type CalendarScope = 'gregorian' | 'liturgical';
+
+export type EasterCalculationType = 'gregorian' | 'julian';

--- a/lib/utils/easter.dates.spec.ts
+++ b/lib/utils/easter.dates.spec.ts
@@ -1,0 +1,139 @@
+import {
+  calculateGregorianEasterDate,
+  calculateJulianEasterDateToGregorianDate,
+  EasterDate,
+  gregorianToJulianDay,
+  isLeapGregorianYear,
+  julianToGregorian,
+  julianToJulianDay,
+} from './easter.dates';
+
+describe('Easter calculation', () => {
+  describe('calculateGregorianEasterDate', () => {
+    const expectedDates: Record<string, EasterDate> = {
+      '2001': { year: 2001, month: 4, day: 15 },
+      '2002': { year: 2002, month: 3, day: 31 },
+      '2003': { year: 2003, month: 4, day: 20 },
+      '2004': { year: 2004, month: 4, day: 11 },
+      '2005': { year: 2005, month: 3, day: 27 },
+      '2006': { year: 2006, month: 4, day: 16 },
+      '2007': { year: 2007, month: 4, day: 8 },
+      '2008': { year: 2008, month: 3, day: 23 },
+      '2009': { year: 2009, month: 4, day: 12 },
+      '2010': { year: 2010, month: 4, day: 4 },
+      '2011': { year: 2011, month: 4, day: 24 },
+      '2012': { year: 2012, month: 4, day: 8 },
+      '2013': { year: 2013, month: 3, day: 31 },
+      '2014': { year: 2014, month: 4, day: 20 },
+      '2015': { year: 2015, month: 4, day: 5 },
+      '2016': { year: 2016, month: 3, day: 27 },
+      '2017': { year: 2017, month: 4, day: 16 },
+      '2018': { year: 2018, month: 4, day: 1 },
+      '2019': { year: 2019, month: 4, day: 21 },
+      '2020': { year: 2020, month: 4, day: 12 },
+      '2021': { year: 2021, month: 4, day: 4 },
+      '2022': { year: 2022, month: 4, day: 17 },
+      '2023': { year: 2023, month: 4, day: 9 },
+      '2024': { year: 2024, month: 3, day: 31 },
+      '2025': { year: 2025, month: 4, day: 20 },
+    };
+
+    for (const year in expectedDates) {
+      it(`should calculate Gregorian Easter date for year ${year} correctly`, () => {
+        const expected: EasterDate = expectedDates[year];
+        expect(calculateGregorianEasterDate(parseInt(year))).toEqual(expected);
+      });
+    }
+  });
+
+  describe('calculateJulianEasterDateToGregorianDate', () => {
+    const expectedDates: Record<string, EasterDate> = {
+      '2001': { year: 2001, month: 4, day: 15 },
+      '2002': { year: 2002, month: 5, day: 5 },
+      '2003': { year: 2003, month: 4, day: 27 },
+      '2004': { year: 2004, month: 4, day: 11 },
+      '2005': { year: 2005, month: 5, day: 1 },
+      '2006': { year: 2006, month: 4, day: 23 },
+      '2007': { year: 2007, month: 4, day: 8 },
+      '2008': { year: 2008, month: 4, day: 27 },
+      '2009': { year: 2009, month: 4, day: 19 },
+      '2010': { year: 2010, month: 4, day: 4 },
+      '2011': { year: 2011, month: 4, day: 24 },
+      '2012': { year: 2012, month: 4, day: 15 },
+      '2013': { year: 2013, month: 5, day: 5 },
+      '2014': { year: 2014, month: 4, day: 20 },
+      '2015': { year: 2015, month: 4, day: 12 },
+      '2016': { year: 2016, month: 5, day: 1 },
+      '2017': { year: 2017, month: 4, day: 16 },
+      '2018': { year: 2018, month: 4, day: 8 },
+      '2019': { year: 2019, month: 4, day: 28 },
+      '2020': { year: 2020, month: 4, day: 19 },
+      '2021': { year: 2021, month: 5, day: 2 },
+      '2022': { year: 2022, month: 4, day: 24 },
+      '2023': { year: 2023, month: 4, day: 16 },
+      '2024': { year: 2024, month: 5, day: 5 },
+      '2025': { year: 2025, month: 4, day: 20 },
+    };
+
+    for (const year in expectedDates) {
+      it(`should calculate Julian Easter date for year ${year}`, () => {
+        const expected: EasterDate = expectedDates[year];
+        expect(calculateJulianEasterDateToGregorianDate(parseInt(year))).toEqual(expected);
+      });
+    }
+
+    it('should throw an error for a year before 326 AD', () => {
+      expect(() => calculateJulianEasterDateToGregorianDate(200)).toThrow(
+        'Easter date calculation within the Julian calendar is not valid for years before 326 AD',
+      );
+    });
+  });
+
+  describe('Calendar utilities', () => {
+    describe('Leap Year Tests', () => {
+      it('should verify a leap Gregorian year', () => {
+        const actual = isLeapGregorianYear(2020);
+        expect(actual).toBe(true);
+      });
+
+      it('should verify a non-leap Gregorian year', () => {
+        const actual = isLeapGregorianYear(2021);
+        expect(actual).toBe(false);
+      });
+    });
+
+    describe('Julian Calendar Conversion Tests', () => {
+      it('should convert a non-leap recent date to Julian Day', () => {
+        const date = new Date(Date.UTC(2023, 1, 1));
+        const actual = julianToJulianDay(date);
+        expect(actual).toBe(2459989.5);
+      });
+
+      it('should convert a leap recent date to Julian Day', () => {
+        const date = new Date(Date.UTC(2020, 6, 1));
+        const actual = julianToJulianDay(date);
+        expect(actual).toBe(2459044.5);
+      });
+
+      it('should convert a recent date from Julian to Gregorian', () => {
+        const date = new Date(Date.UTC(2023, 1, 1));
+        const actual = julianToGregorian(date);
+        expect(actual.toISOString()).toBe('2023-02-14T00:00:00.000Z');
+      });
+    });
+
+    describe('Gregorian Calendar Conversion Tests', () => {
+      it('should convert a non-leap recent date to Julian Day', () => {
+        const date = new Date(Date.UTC(2023, 1, 1));
+        const actual = gregorianToJulianDay(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+        expect(actual).toBe(2459976.5);
+      });
+
+      it('should convert a leap recent date to Julian Day', () => {
+        const date = new Date(Date.UTC(2020, 6, 1));
+        const actual = gregorianToJulianDay(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+        expect(actual).toBe(2459031.5);
+      });
+    });
+  });
+});

--- a/lib/utils/easter.dates.ts
+++ b/lib/utils/easter.dates.ts
@@ -1,0 +1,152 @@
+export type EasterDate = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+const GREGORIAN_EPOCH = 1721425.5;
+
+/**
+ * This algorithm is based on the algorithm of Oudin (1940) and quoted in
+ * "Explanatory Supplement to the Astronomical Almanac", P. Kenneth
+ * Seidelmann, editor.
+ *
+ * @param year The year on which to check when Easter falls (integer)
+ */
+export const calculateGregorianEasterDate = (year: number): EasterDate => {
+  const Y = year;
+  const C = Math.floor(Y / 100);
+  const N = Y - 19 * Math.floor(Y / 19);
+  const K = Math.floor((C - 17) / 25);
+  let I = C - Math.floor(C / 4) - Math.floor((C - K) / 3) + 19 * N + 15;
+
+  I = I - 30 * Math.floor(I / 30);
+  I = I - Math.floor(I / 28) * (1 - Math.floor(I / 28) * Math.floor(29 / (I + 1)) * Math.floor((21 - N) / 11));
+
+  let J = Y + Math.floor(Y / 4) + I + 2 - C + Math.floor(C / 4);
+  J = J - 7 * Math.floor(J / 7);
+
+  const L = I - J;
+  const M = 3 + Math.floor((L + 40) / 44);
+  const D = L + 28 - 31 * Math.floor(M / 4);
+
+  return { year: Y, month: M, day: D };
+};
+
+const mod = (a: number, b: number): number => {
+  return a - b * Math.floor(a / b);
+};
+
+/**
+ * Is a given year in the Gregorian calendar a leap year?
+ *
+ * @param {Number} year Year
+ * @returns true if the given year is a leap year
+ */
+export const isLeapGregorianYear = (year: number): boolean => {
+  return year % 4 === 0 && !(year % 100 === 0 && year % 400 !== 0);
+};
+
+export const gregorianToJulianDay = (year: number, month: number, day: number): number => {
+  return (
+    GREGORIAN_EPOCH -
+    1 +
+    365 * (year - 1) +
+    Math.floor((year - 1) / 4) +
+    -Math.floor((year - 1) / 100) +
+    Math.floor((year - 1) / 400) +
+    Math.floor((367 * month - 362) / 12 + (month <= 2 ? 0 : isLeapGregorianYear(year) ? -1 : -2) + day)
+  );
+};
+
+/**
+ * Calculates Julian day number from Julian calendar date.
+ *
+ * @param {Date} date Julian calendar date
+ * @returns Julian day number
+ */
+export const julianToJulianDay = (date: Date): number => {
+  let year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  // Adjust negative common era years to the zero-based notation we use.
+  if (year < 1) year += 1;
+
+  // Algorithm as given in Meeus, Astronomical Algorithms.
+  if (month <= 2) {
+    year -= 1;
+    month += 12;
+  }
+
+  return Math.floor(365.25 * (year + 4716)) + Math.floor(30.6001 * (month + 1)) + day - 1524.5;
+};
+
+/**
+ * Calculates Gregorian calendar date from Julian day.
+ *
+ * @param {Number} julianDay Julian day
+ * @returns Gregorian calendar date
+ */
+export const julianDayToGregorian = (julianDay: number): Date => {
+  const wjd = Math.floor(julianDay - 0.5) + 0.5;
+  const depoch = wjd - GREGORIAN_EPOCH;
+  const quadricent = Math.floor(depoch / 146097);
+  const dqc = mod(depoch, 146097);
+  const cent = Math.floor(dqc / 36524);
+  const dcent = mod(dqc, 36524);
+  const quad = Math.floor(dcent / 1461);
+  const dquad = mod(dcent, 1461);
+  const yindex = Math.floor(dquad / 365);
+
+  let year = quadricent * 400 + cent * 100 + quad * 4 + yindex;
+  if (!(cent === 4 || yindex === 4)) {
+    year += 1;
+  }
+
+  const yearday = wjd - gregorianToJulianDay(year, 1, 1);
+  const leapadj = wjd < gregorianToJulianDay(year, 3, 1) ? 0 : isLeapGregorianYear(year) ? 1 : 2;
+  const month = Math.floor(((yearday + leapadj) * 12 + 373) / 367);
+  const day = wjd - gregorianToJulianDay(year, month, 1) + 1;
+
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+/**
+ * Converts date in Julian calendar to a date in Gregorian calendar.
+ *
+ * @param {Date} date Julian calendar date.
+ * @returns Gregorian calendar date.
+ */
+export const julianToGregorian = (date: Date): Date => {
+  return julianDayToGregorian(julianToJulianDay(date));
+};
+
+export const calculateJulianEasterDate = (year: number): Date => {
+  const a = year % 4;
+  const b = year % 7;
+  const c = year % 19;
+  const d = (19 * c + 15) % 30;
+  const e = (2 * a + 4 * b - d + 34) % 7;
+  const month = Math.floor((d + e + 114) / 31);
+  const day = ((d + e + 114) % 31) + 1;
+
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+/**
+ * Calculate the Julian Easter date to a date in the Gregorian calendar.
+ *
+ * Calculation is performed according to Meeus's Julian algorithm
+ * and converts it to Gregorian calendar.
+ * @see {@link https://en.wikipedia.org/wiki/Date_of_Easter#Meeus's_Julian_algorithm}
+ * @param year
+ */
+export const calculateJulianEasterDateToGregorianDate = (year: number): EasterDate => {
+  if (year < 326) {
+    throw new Error('Easter date calculation within the Julian calendar is not valid for years before 326 AD');
+  }
+
+  const date = julianToGregorian(calculateJulianEasterDate(year));
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
+};

--- a/tests/calendar-builder.test.ts
+++ b/tests/calendar-builder.test.ts
@@ -114,7 +114,9 @@ describe('Testing calendar generation functions', () => {
   describe('Testing liturgical colors', () => {
     test('The proper color of a Memorial or a Feast is white except for martyrs in which case it is red, and All Souls which is purple', async () => {
       const defs: LiturgicalDayDef[] = Object.values(
-        (await new Romcal({ localizedCalendar: GeneralRoman_En }).getAllDefinitions()) as LiturgicalDayDef[][],
+        (await new Romcal({
+          localizedCalendar: GeneralRoman_En,
+        }).getAllDefinitions()) as unknown as LiturgicalDayDef[][],
       ).flat();
 
       defs
@@ -360,6 +362,22 @@ describe('Testing calendar generation functions', () => {
       expect(date?.id).not.toEqual(
         'cyril_constantine_the_philosopher_monk_and_methodius_michael_of_thessaloniki_bishop',
       );
+    });
+  });
+
+  describe('Testing the Easter Date calculation', () => {
+    it('should calculate the Gregorian Easter date for the year 2019', async () => {
+      const calendar = Object.values(await new Romcal().generateCalendar(2019)).flat();
+      const easter = calendar.find((item) => item.id === 'easter_sunday');
+      expect(easter?.date).toEqual('2019-04-21');
+    });
+
+    it('should calculate the Julian Easter date for the year 2019', async () => {
+      const calendar = Object.values(
+        await new Romcal({ easterCalculationType: 'julian' }).generateCalendar(2019),
+      ).flat();
+      const easter = calendar.find((item) => item.id === 'easter_sunday');
+      expect(easter?.date).toEqual('2019-04-28');
     });
   });
 });


### PR DESCRIPTION
This provides the ability to compute a calendar, based on a _Julian Easter date_ (in addition to the _Gregorian Easter date_, which remain the default calculation type).

Within a calendar definition, you now can specify an `easterCalculationType` property, which accepts a `gregorian` or `julian` value (defaults to `gregorian`).

```ts
// Example for greece.ts
export class Greece extends CalendarDef {
  parentCalendar = Europe;

  particularConfig: ParticularConfig = {
    easterCalculationType: 'julian',
  };

  inputs: Inputs = {}
}
```

It's also possible to specify the Easter calculation type, directly from the Romcal settings : 
```ts
const romcal = new Romcal({ easterCalculationType: 'julian' });
const calendar = await romcal.generateCalendar(2019);
```



