### PR TITLE
Checking and cleaning Canada calendar entries

### DIFF
--- a/lib/locales/en-gb.ts
+++ b/lib/locales/en-gb.ts
@@ -5,6 +5,7 @@ export const locale: Locale = {
 
   names: {
     bernardine_of_siena_priest: 'Saint Bernardine of Siena, Priest, Religious and Missionary', // TODO: This property should be removed after one can add titles within celebration definions.
+    labor_day: 'Labour Day',
     louis_grignion_de_montfort_priest: 'Saint Louis Marie Grignion de Montfort, Priest',
     paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin:
       'Saint Paulina of the Agonising Heart of Jesus Visintainer, Virgin',

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -623,7 +623,7 @@ export const locale: Locale = {
     kilian_of_wurzburg_bishop_and_companions_martyrs: 'Saint Kilian, Bishop, and Companions, Martyrs',
     kinga_of_poland_virgin: 'Saint Kinga, Virgin',
     kuriakose_elias_of_the_holy_family_chavara_priest: 'Saint Kuriakose Elias of the Holy Family Chavara, priest',
-    labour_day: 'Labour Day',
+    labor_day: 'Labor Day',
     ladislas_of_gielniow_priest: 'Blessed Ladislas of Gielniow, Priest',
     ladislaus_batthyany_strattmann: 'Blessed Ladislaus Batthyány-Strattmann',
     ladislaus_i_of_hungary: 'Saint Ladislaus',

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -273,6 +273,7 @@ export const locale: Locale = {
     cajetan_of_thiene_priest: 'Saint Cajetan, Priest',
     callistus_i_pope: 'Saint Callistus I, Pope and Martyr',
     camillus_de_lellis_priest: 'Saint Camillus de Lellis, Priest',
+    canada_day: 'Canada Day',
     canice_of_kilkenny_abbot: 'Saint Canice, Abbot',
     canute_iv_of_denmark_eric_ix_of_sweden_and_olaf_ii_of_norway_martyrs: 'Saints Canute, Eric and Olaf, Martyrs',
     canute_iv_of_denmark_martyr: 'Saint Canute, Martyr',
@@ -622,6 +623,7 @@ export const locale: Locale = {
     kilian_of_wurzburg_bishop_and_companions_martyrs: 'Saint Kilian, Bishop, and Companions, Martyrs',
     kinga_of_poland_virgin: 'Saint Kinga, Virgin',
     kuriakose_elias_of_the_holy_family_chavara_priest: 'Saint Kuriakose Elias of the Holy Family Chavara, priest',
+    labour_day: 'Labour Day',
     ladislas_of_gielniow_priest: 'Blessed Ladislas of Gielniow, Priest',
     ladislaus_batthyany_strattmann: 'Blessed Ladislaus Batthyány-Strattmann',
     ladislaus_i_of_hungary: 'Saint Ladislaus',
@@ -952,6 +954,7 @@ export const locale: Locale = {
     teresa_of_jesus_of_avila_virgin: 'Saint Teresa of Jesus, Virgin and Doctor of the Church',
     teresa_of_jesus_of_los_andes_virgin: 'Saint Teresa of Jesus of Los Andes, Virgin',
     teresa_of_portugal_religious: 'Blessed Teresa of Portugal, Religious',
+    thanksgiving_day: 'Thanksgiving Day', // src: mr_en_2011_ed3_us
     theodore_of_canterbury_bishop: 'Saint Theodore of Canterbury, Bishop',
     theodore_romzha_bishop: 'Blessed Theodore Romzha, Bishop and Martyr',
     theodosius_of_the_caves_abbot: 'Saint Theodosius of the Caves, Abbot',

--- a/lib/locales/fr.ts
+++ b/lib/locales/fr.ts
@@ -237,6 +237,7 @@ export const locale: Locale = {
     cajetan_of_thiene_priest: 'Saint Gaétan de Thienne, prêtre († 1547)',
     callistus_i_pope: 'Saint Calixte Ier, pape et martyr († 222)',
     camillus_de_lellis_priest: 'Saint Camille de Lellis, prêtre († 1614)',
+    canada_day: 'Fête du Canada', // src: mr_fr_2021_ed3
     carmelites_of_compiegne_virgins_and_martyrs:
       'Bienheureuses Carmélites de Compiègne : Mère Thérèse et ses 15 compagnes, martyres († guillotinées en 1794)',
     casimir_of_poland: 'Saint Casimir († 1484)',
@@ -415,6 +416,7 @@ export const locale: Locale = {
     justin_martyr: 'Saint Justin, martyr († 165)',
     justus_of_lyon_bishop: 'Saint Just, évêque († v. 389)', // src: mr_fr_2014_ed2_lyon
     kateri_tekakwitha_virgin: 'Sainte Kateri Tekakwitha, vierge Amérindienne († 1680)',
+    labour_day: 'Fête du travail', // src: mr_fr_2021_ed3
     lambert_of_maastricht_bishop: 'Saint Lambert, évêque et martyr († 705)',
     landry_of_paris_bishop: 'Saint Landry, évêque de Paris († au 7e s.)',
     lawrence_of_brindisi_priest: 'Saint Laurent de Brindisi, prêtre et docteur de l’Église († 1619)',
@@ -574,6 +576,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Sainte Thérèse-Bénédicte de la Croix (Edith Stein), Carmélite, martyr en Pologne, co-patronne de l’Europe († 1942)',
     teresa_of_jesus_of_avila_virgin: 'Sainte Thérèse de Jésus (d’Avila), vierge et docteur de l’Église († 1582)',
+    thanksgiving_day: 'Jour de l’action de grâce', // src: mr_fr_2021_ed3
     therese_marie_victoire_couderc_virgin: 'Sainte Thérèse Couderc, vierge († 1885)', // src: mr_fr_2014_ed2_lyon
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
       'Sainte Thérèse de l’Enfant-Jésus, vierge et docteur de l’Église († 1897)',

--- a/lib/locales/fr.ts
+++ b/lib/locales/fr.ts
@@ -416,7 +416,7 @@ export const locale: Locale = {
     justin_martyr: 'Saint Justin, martyr († 165)',
     justus_of_lyon_bishop: 'Saint Just, évêque († v. 389)', // src: mr_fr_2014_ed2_lyon
     kateri_tekakwitha_virgin: 'Sainte Kateri Tekakwitha, vierge Amérindienne († 1680)',
-    labour_day: 'Fête du travail', // src: mr_fr_2021_ed3
+    labor_day: 'Fête du travail', // src: mr_fr_2021_ed3
     lambert_of_maastricht_bishop: 'Saint Lambert, évêque et martyr († 705)',
     landry_of_paris_bishop: 'Saint Landry, évêque de Paris († au 7e s.)',
     lawrence_of_brindisi_priest: 'Saint Laurent de Brindisi, prêtre et docteur de l’Église († 1619)',

--- a/lib/particular-calendars/canada.ts
+++ b/lib/particular-calendars/canada.ts
@@ -1,11 +1,18 @@
 import { PatronTitles } from '../constants/martyrology-metadata';
 import { Precedences } from '../constants/precedences';
 import { CalendarDef } from '../models/calendar-def';
-import { Inputs } from '../types/calendar-def';
+import { Inputs, ParticularConfig } from '../types/calendar-def';
 import { Americas } from './americas';
 
+// src: mr_fr_2021_ed3
 export class Canada extends CalendarDef {
   parentCalendar = Americas;
+
+  particularConfig: ParticularConfig = {
+    epiphanyOnSunday: true,
+    ascensionOnSunday: true,
+    corpusChristiOnSunday: true,
+  };
 
   inputs: Inputs = {
     andre_bessette_religious: {
@@ -14,7 +21,6 @@ export class Canada extends CalendarDef {
     },
 
     raymond_of_penyafort_priest: {
-      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 8 },
     },
 
@@ -30,7 +36,7 @@ export class Canada extends CalendarDef {
     },
 
     kateri_tekakwitha_virgin: {
-      precedence: Precedences.OptionalMemorial_12,
+      precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 4, date: 17 },
     },
 
@@ -45,8 +51,12 @@ export class Canada extends CalendarDef {
     },
 
     mary_of_the_incarnation_marie_guyart_religious: {
-      precedence: Precedences.OptionalMemorial_12,
+      precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 4, date: 30 },
+    },
+
+    pius_v_pope: {
+      dateDef: { month: 5, date: 1 },
     },
 
     marie_leonie_paradis_virgin: {
@@ -55,7 +65,7 @@ export class Canada extends CalendarDef {
     },
 
     francois_de_montmorency_laval_bishop: {
-      precedence: Precedences.OptionalMemorial_12,
+      precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 5, date: 6 },
     },
 
@@ -80,9 +90,14 @@ export class Canada extends CalendarDef {
       martyrology: ['nykyta_budka_bishop', 'vasyl_velychkovsky_bishop'],
     },
 
-    joachim_and_anne_patroness_of_the_province_of_quebec_parents_of_mary: {
+    canada_day: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 7, date: 1 },
+    },
+
+    joachim_and_anne_parents_of_mary: {
       precedence: Precedences.ProperFeast_PrincipalPatronOfARegion_8c,
-      dateDef: { month: 7, date: 26 },
+      customLocaleId: 'joachim_and_anne_patroness_of_the_province_of_quebec_parents_of_mary',
       martyrology: [
         {
           id: 'anne_mother_of_mary',
@@ -95,6 +110,11 @@ export class Canada extends CalendarDef {
     frederic_janssoone_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 5 },
+    },
+
+    labour_day: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 9, nthWeekInMonth: 1, dayOfWeek: 1 },
     },
 
     andre_grasset_priest: {
@@ -112,26 +132,25 @@ export class Canada extends CalendarDef {
       dateDef: { month: 9, date: 24 },
     },
 
-    john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs_copatrons_of_canada: {
+    cosmas_of_cilicia_and_damian_of_cilicia_martyrs: {
+      dateDef: { month: 9, date: 25 },
+    },
+
+    john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
+      customLocaleId: 'john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs_copatrons_of_canada',
       precedence: Precedences.ProperFeast_PrincipalPatronOfARegion_8c,
       dateDef: { month: 9, date: 26 },
       titles: { append: [PatronTitles.CopatronOfCanada] },
-      martyrology: ['john_de_brebeuf_priest', 'isaac_jogues_priest', 'companions_martyrs'],
-    },
-
-    nereus_of_terracina_and_achilleus_of_terracina_martyrs: {
-      precedence: Precedences.ProperFeast_8f,
-      dateDef: { month: 9, date: 26 },
-    },
-
-    pancras_of_rome_martyr: {
-      precedence: Precedences.ProperFeast_8f,
-      dateDef: { month: 9, date: 26 },
     },
 
     marie_rose_durocher_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 6 },
+    },
+
+    thanksgiving_day: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 10, nthWeekInMonth: 2, dayOfWeek: 1 },
     },
 
     marguerite_dyouville_religious: {
@@ -140,17 +159,15 @@ export class Canada extends CalendarDef {
     },
 
     hedwig_of_silesia_religious: {
-      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 20 },
     },
 
     margaret_mary_alacoque_virgin: {
-      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 20 },
     },
 
     dedication_of_consecrated_churches_on_october_25: {
-      dateDef: { month: 10, date: 22 },
+      dateDef: { month: 10, date: 25 },
     },
 
     dedication_of_consecrated_churches_on_last_sunday_of_october: {

--- a/lib/particular-calendars/canada.ts
+++ b/lib/particular-calendars/canada.ts
@@ -4,7 +4,6 @@ import { CalendarDef } from '../models/calendar-def';
 import { Inputs, ParticularConfig } from '../types/calendar-def';
 import { Americas } from './americas';
 
-// src: mr_fr_2021_ed3
 export class Canada extends CalendarDef {
   parentCalendar = Americas;
 
@@ -15,86 +14,103 @@ export class Canada extends CalendarDef {
   };
 
   inputs: Inputs = {
+    // src: mr_fr_2021_ed3
     andre_bessette_religious: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 1, date: 7 },
     },
 
+    // src: mr_fr_2021_ed3
     raymond_of_penyafort_priest: {
       dateDef: { month: 1, date: 8 },
     },
 
+    // src: mr_fr_2021_ed3
     marguerite_bourgeoys_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 1, date: 12 },
     },
 
+    // src: mr_fr_2021_ed3
     joseph_spouse_of_mary: {
       customLocaleId: 'joseph_spouse_of_mary_patron_of_canada',
       precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
       titles: { append: [PatronTitles.PatronOfCanada] },
     },
 
+    // src: mr_fr_2021_ed3
     kateri_tekakwitha_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 4, date: 17 },
     },
 
+    // src: mr_fr_2021_ed3
     marie_anne_blondin_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 18 },
     },
 
+    // src: mr_fr_2021_ed3
     our_lady_of_good_counsel: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 26 },
     },
 
+    // src: mr_fr_2021_ed3
     mary_of_the_incarnation_marie_guyart_religious: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 4, date: 30 },
     },
 
+    // src: mr_fr_2021_ed3
     pius_v_pope: {
       dateDef: { month: 5, date: 1 },
     },
 
+    // src: mr_fr_2021_ed3
     marie_leonie_paradis_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 4 },
     },
 
+    // src: mr_fr_2021_ed3
     francois_de_montmorency_laval_bishop: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 5, date: 6 },
     },
 
+    // src: mr_fr_2021_ed3
     catherine_of_saint_augustine_de_simon_de_longpre_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 8 },
     },
 
+    // src: mr_fr_2021_ed3
     eugene_de_mazenod_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 21 },
     },
 
+    // src: mr_fr_2021_ed3
     louis_zephirin_moreau_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 24 },
     },
 
+    // src: mr_fr_2021_ed3
     nykyta_budka_and_vasyl_velychkovsky_bishops: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 27 },
       martyrology: ['nykyta_budka_bishop', 'vasyl_velychkovsky_bishop'],
     },
 
+    // src: mr_fr_2021_ed3
     canada_day: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 1 },
     },
 
+    // src: mr_fr_2021_ed3
     joachim_and_anne_parents_of_mary: {
       precedence: Precedences.ProperFeast_PrincipalPatronOfARegion_8c,
       customLocaleId: 'joachim_and_anne_patroness_of_the_province_of_quebec_parents_of_mary',
@@ -107,35 +123,42 @@ export class Canada extends CalendarDef {
       ],
     },
 
+    // src: mr_fr_2021_ed3
     frederic_janssoone_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 5 },
     },
 
+    // src: mr_fr_2021_ed3
     labour_day: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, nthWeekInMonth: 1, dayOfWeek: 1 },
     },
 
+    // src: mr_fr_2021_ed3
     andre_grasset_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 2 },
     },
 
+    // src: mr_fr_2021_ed3
     dina_belanger_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 4 },
     },
 
+    // src: mr_fr_2021_ed3
     emilie_tavernier_gamelin_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 24 },
     },
 
+    // src: mr_fr_2021_ed3
     cosmas_of_cilicia_and_damian_of_cilicia_martyrs: {
       dateDef: { month: 9, date: 25 },
     },
 
+    // src: mr_fr_2021_ed3
     john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
       customLocaleId: 'john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs_copatrons_of_canada',
       precedence: Precedences.ProperFeast_PrincipalPatronOfARegion_8c,
@@ -143,33 +166,38 @@ export class Canada extends CalendarDef {
       titles: { append: [PatronTitles.CopatronOfCanada] },
     },
 
+    // src: mr_fr_2021_ed3
     marie_rose_durocher_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 6 },
     },
 
+    // src: mr_fr_2021_ed3
     thanksgiving_day: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, nthWeekInMonth: 2, dayOfWeek: 1 },
     },
 
+    // src: mr_fr_2021_ed3
     marguerite_dyouville_religious: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 16 },
     },
 
+    // src: mr_fr_2021_ed3
     hedwig_of_silesia_religious: {
       dateDef: { month: 10, date: 20 },
     },
 
+    // src: mr_fr_2021_ed3
     margaret_mary_alacoque_virgin: {
       dateDef: { month: 10, date: 20 },
     },
 
+    // src: mr_fr_2021_ed3
     dedication_of_consecrated_churches_on_october_25: {
       dateDef: { month: 10, date: 25 },
     },
-
     dedication_of_consecrated_churches_on_last_sunday_of_october: {
       drop: true,
     },

--- a/lib/particular-calendars/canada.ts
+++ b/lib/particular-calendars/canada.ts
@@ -8,9 +8,9 @@ export class Canada extends CalendarDef {
   parentCalendar = Americas;
 
   particularConfig: ParticularConfig = {
-    epiphanyOnSunday: true,
-    ascensionOnSunday: true,
-    corpusChristiOnSunday: true,
+    epiphanyOnSunday: true, // src: mr_fr_2021_ed3
+    ascensionOnSunday: true, // src: https://www.cccb.ca/wp-content/uploads/2023/09/2023-2024.pdf#page=6
+    corpusChristiOnSunday: true, // src: https://www.cccb.ca/wp-content/uploads/2023/05/Ordo_Pastoral_Notes.pdf#page=92
   };
 
   inputs: Inputs = {
@@ -130,7 +130,7 @@ export class Canada extends CalendarDef {
     },
 
     // src: mr_fr_2021_ed3
-    labour_day: {
+    labor_day: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, nthWeekInMonth: 1, dayOfWeek: 1 },
     },
@@ -195,9 +195,6 @@ export class Canada extends CalendarDef {
     },
 
     // src: mr_fr_2021_ed3
-    dedication_of_consecrated_churches_on_october_25: {
-      dateDef: { month: 10, date: 25 },
-    },
     dedication_of_consecrated_churches_on_last_sunday_of_october: {
       drop: true,
     },


### PR DESCRIPTION
- Corrections of some errors defined in this proper calendar
- Addition of `particularConfig`. The French missal is a bit vague regarding the dates of _Ascension_ and _Corpus Christi_. It is only mentioned that _Corpus Christi_ is generally celebrated on the following Sunday in most French-speaking countries. In any case, having lived in Canada for several years, I can confirm that these two celebrations are indeed held on Sundays.
- Removal of some celebration entities and metadata if they are already defined in the GRC.

<details>
  <summary>Sources (from <code>mr_fr_2021_ed3</code>)</summary>
  <img src="https://github.com/romcal/romcal/assets/1045997/38fbbbea-8ef2-49c4-b147-f2b4b99a7ad4" />
</details>
