### PR TITLE
Checking and cleaning France calendar entries

### DIFF
--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -775,6 +775,7 @@ export const locale: Locale = {
     our_lady_of_hungary_patroness_of_hungary: 'Our Lady of Hungary, Patroness of Hungary',
     our_lady_of_itati: 'Our Lady of Itatí',
     our_lady_of_knock: 'Our Lady of Knock',
+    our_lady_of_la_salette: 'Our Lady of La Salette', // src: https://en.wikipedia.org/wiki/Our_Lady_of_La_Salette
     our_lady_of_lanka: 'Our Lady of Lanka',
     our_lady_of_lebanon: 'Our Lady of Lebanon',
     our_lady_of_loreto: 'Our Lady of Loreto',

--- a/lib/locales/fr.ts
+++ b/lib/locales/fr.ts
@@ -482,6 +482,7 @@ export const locale: Locale = {
     our_lady_of_good_counsel: 'Notre-Dame du Bon Conseil',
     our_lady_of_guadalupe: 'Notre-Dame de Guadalupé',
     our_lady_of_guadalupe_patroness_of_the_americas: 'Notre-Dame de Guadalupé, patronne des Amériques',
+    our_lady_of_la_salette: 'Bienheureuse Vierge Marie de La Salette', // src: mr_fr_2021_ed3
     our_lady_of_loreto: 'Notre-Dame de Lorette',
     our_lady_of_lourdes: 'Notre-Dame de Lourdes',
     our_lady_of_mount_carmel: 'Notre-Dame du Mont-Carmel',

--- a/lib/particular-calendars/france.paris.ts
+++ b/lib/particular-calendars/france.paris.ts
@@ -47,7 +47,6 @@ export class France_Paris extends CalendarDef {
     },
 
     louise_de_marillac_religious: {
-      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 15 },
     },
 

--- a/lib/particular-calendars/france.saint-denis.ts
+++ b/lib/particular-calendars/france.saint-denis.ts
@@ -22,7 +22,6 @@ export class France_SaintDenis extends CalendarDef {
     },
 
     louise_de_marillac_religious: {
-      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 15 },
     },
 

--- a/lib/particular-calendars/france.ts
+++ b/lib/particular-calendars/france.ts
@@ -4,7 +4,6 @@ import { CalendarDef } from '../models/calendar-def';
 import { Inputs, ParticularConfig } from '../types/calendar-def';
 import { Europe } from './europe';
 
-// src: mr_fr_2021_ed3
 export class France extends CalendarDef {
   parentCalendar = Europe;
 
@@ -15,31 +14,37 @@ export class France extends CalendarDef {
   };
 
   inputs: Inputs = {
+    // src: mr_fr_2021_ed3
     genevieve_of_paris_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 3 },
     },
 
+    // src: mr_fr_2021_ed3
     remigius_of_reims_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 15 },
     },
 
+    // src: mr_fr_2021_ed3
     bernadette_soubirous_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 18 },
     },
 
+    // src: mr_fr_2021_ed3
     louise_de_marillac_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 9 },
     },
 
+    // src: mr_fr_2021_ed3
     ivo_of_kermartin_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 19 },
     },
 
+    // src: mr_fr_2021_ed3
     joan_of_arc_virgin: {
       customLocaleId: 'joan_of_arc_virgin_copatroness_of_france',
       precedence: Precedences.ProperMemorial_SecondPatron_11a,
@@ -47,35 +52,42 @@ export class France extends CalendarDef {
       titles: { append: [PatronTitles.CopatronessOfFrance] },
     },
 
+    // src: mr_fr_2021_ed3
     pothinus_of_lyon_bishop_blandina_of_lyon_virgin_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 2 },
       martyrology: ['pothinus_of_lyon_bishop', 'blandina_of_lyon_virgin', 'companions_martyrs'],
     },
 
+    // src: mr_fr_2021_ed3
     clotilde_of_burgundy: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 4 },
     },
 
+    // src: mr_fr_2021_ed3
     louis_ix_of_france: {
       precedence: Precedences.ProperMemorial_11b,
     },
 
+    // src: mr_fr_2021_ed3
     joseph_of_calasanz_priest: {
       dateDef: { month: 8, date: 26 },
     },
 
+    // src: mr_fr_2021_ed3
     caesarius_of_arles_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 26 },
     },
 
+    // src: mr_fr_2021_ed3
     our_lady_of_la_salette: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 19 },
     },
 
+    // src: mr_fr_2021_ed3
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin: {
       customLocaleId: 'therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin_copatroness_of_france',
       titles: { append: [PatronTitles.CopatronessOfFrance] },

--- a/lib/particular-calendars/france.ts
+++ b/lib/particular-calendars/france.ts
@@ -4,6 +4,7 @@ import { CalendarDef } from '../models/calendar-def';
 import { Inputs, ParticularConfig } from '../types/calendar-def';
 import { Europe } from './europe';
 
+// src: mr_fr_2021_ed3
 export class France extends CalendarDef {
   parentCalendar = Europe;
 
@@ -29,6 +30,11 @@ export class France extends CalendarDef {
       dateDef: { month: 2, date: 18 },
     },
 
+    louise_de_marillac_religious: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 5, date: 9 },
+    },
+
     ivo_of_kermartin_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 19 },
@@ -52,9 +58,22 @@ export class France extends CalendarDef {
       dateDef: { month: 6, date: 4 },
     },
 
+    louis_ix_of_france: {
+      precedence: Precedences.ProperMemorial_11b,
+    },
+
+    joseph_of_calasanz_priest: {
+      dateDef: { month: 8, date: 26 },
+    },
+
     caesarius_of_arles_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 26 },
+    },
+
+    our_lady_of_la_salette: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 9, date: 19 },
     },
 
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin: {


### PR DESCRIPTION
- Validating calendar from the missal.
- Adding missing celebrations, or updating celebrations from the GRC.

<details>
  <summary>Sources (from <code>mr_fr_2021_ed3</code>)</summary>
  <img src="https://github.com/romcal/romcal/assets/1045997/4ae005d8-6cfe-4faa-90cf-32c05addd179" />
</details>

