### PR TITLE
Re-introduce the OPTIONAL_MEMORIAL rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ The romcal v3 is a major rewrite of the core library, with performance and archi
 As a result, romcal v3 is now up to 10x faster than v2 and v1.
 The new architecture helped to introduce new features without performance and code quality impacts.
 
-### Added
+### v 3.0.0@dev-52
+
+#### Breaking change
+
+- The `OPTIONAL_MEMORIAL` `rank` is being reintroduced, which was previously available as `OPT_MEMORIAL` until Romcal v2. This re-introduction includes related localizations for all currently supported locales.
+
+### v 3.0.0@dev-1
+
+#### Added
 
 - Locales & Internationalization:
   - introducing a new internationalization library, [i18next](https://www.i18next.com/).
@@ -29,7 +37,7 @@ The new architecture helped to introduce new features without performance and co
   - When computing a calendar, the corresponding metadata are also integrated in the final `LiturgicalDay` object.
   - This is just a start, new metadata could be added or refined.
 
-### Changed
+#### Changed
 
 - Build: the build process have been completely rewritten.
   - The core library do not contain anymore all the calendar and localization files, to lightweight the size of the library (it only contain a lightweight version of the General Roman Calendar, without translation and extra metadata).
@@ -58,7 +66,7 @@ The new architecture helped to introduce new features without performance and co
   - `seasons` are now following closely the _General Norms for the Liturgical Year and the Calendar_. There is no more a Holy Week season (moved to the period metadata), Holy Thursday have 2 possible liturgical days (the Holy Thursday which is the last day of Lent, and the Thursday of the Lord's Supper which start the Paschal Triduum), Easter Sunday take place in 2 seasons (the Paschal Triduum and the Easter Time).
   - `periods` include additional information, like early/late ordinary time, and special liturgical periods coming from the monastic traditions.
 
-### Removed
+#### Removed
 
 - Options to group and filters `LiturgicalDay` objects by predefined criteria is now removed. The reason is that is now very easy to group or filter a JavaScript object, and hard to cover all possible user requirement. However, produced data is by default sorted and grouped by dates.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The new architecture helped to introduce new features without performance and co
 
 #### Breaking change
 
-- The `OPTIONAL_MEMORIAL` `rank` is being reintroduced, which was previously available as `OPT_MEMORIAL` until Romcal v2. This re-introduction includes related localizations for all currently supported locales.
+- The `OPTIONAL_MEMORIAL` rank is being reintroduced, which was previously available as `OPT_MEMORIAL` until Romcal v2. This re-introduction includes related localizations for all currently supported locales.
 
 ### v 3.0.0@dev-1
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/romcal/v/latest" target="_blank" rel="noopener noreferrer"><img alt="latest" src="https://img.shields.io/npm/v/romcal/latest?style=flat-square&logo=npm"></a>
-  <a href="https://www.npmjs.com/package/romcal/v/beta" target="_blank" rel="noopener noreferrer"><img alt="beta" src="https://img.shields.io/npm/v/romcal/beta?style=flat-square&logo=npm"></a>
   <a href="https://www.npmjs.com/package/romcal/v/dev" target="_blank" rel="noopener noreferrer"><img alt="dev" src="https://img.shields.io/npm/v/romcal/dev?style=flat-square&logo=npm"></a>
 </p>
+
+> **Note**
+> This project is still in beta (using the `dev` npm distribution tag) until it reaches final version 3.0.0. There could be breaking changes between minor versions. Please refer to the [changelog](CHANGELOG.md) for significant updates and breaking changes.
 
 ## Documentation
 

--- a/lib/constants/ranks.ts
+++ b/lib/constants/ranks.ts
@@ -31,25 +31,25 @@ export enum Ranks {
   Feast = 'FEAST',
 
   /**
-   * Obligatory Memorials are liturgical commemorations of saints, events, or aspects of the faith.
-   * Their observance is mandatory and integrated into the celebration of the occurring weekday,
-   * following the liturgical norms outlined in the General Instruction of the Roman Missal and the
-   * Liturgy of the Hours.
-   * When an Obligatory Memorial falls on a weekday during the liturgical season of Lent or a
-   * privileged weekday of Advent, it must only be celebrated as an Optional Memorial, as Lent and
-   * Advent have their own specific liturgical observances that take precedence.
+   * **Obligatory memorials** are liturgical commemorations of saints, events, or aspects of the
+   * faith. Their observance is mandatory and integrated into the celebration of the occurring
+   * weekday, following the liturgical norms outlined in the General Instruction of the Roman Missal
+   * and the Liturgy of the Hours.
+   * When an **obligatory memorial** falls on a weekday during the liturgical season of Lent or a
+   * privileged weekday of Advent, it must only be celebrated as an **optional memorial**, as Lent
+   * and Advent have their own specific liturgical observances that take precedence.
    */
   Memorial = 'MEMORIAL',
 
   /**
-   * Optional Memorials are liturgical commemorations of saints, events, or aspects of the faith,
-   * but they are not obligatory.
+   * **Optional memorials** are liturgical commemorations of saints, events, or aspects of the
+   * faith, but they are not obligatory.
    * Their observance is integrated into the celebration of the occurring weekday, adhering to the
    * liturgical norms provided in the General Instruction of the Roman Missal and the Liturgy of
    * the Hours.
-   * In cases where multiple Optional Memorials are designated on the same day in the liturgical
+   * In cases where multiple **optional memorials** are designated on the same day in the liturgical
    * calendar, only one of them may be celebrated, and the others must be omitted (UNLY #14).
-   * This allows for some flexibility in choosing which Optional Memorial to commemorate when
+   * This allows for some flexibility in choosing which optional memorial to commemorate when
    * multiple options are available.
    */
   OptionalMemorial = 'OPTIONAL_MEMORIAL',

--- a/lib/constants/ranks.ts
+++ b/lib/constants/ranks.ts
@@ -31,15 +31,28 @@ export enum Ranks {
   Feast = 'FEAST',
 
   /**
-   * Memorials are either obligatory or optional; their observance is integrated into
-   * the celebration of the occurring weekday in accordance with the norms set forth in the
-   * General Instruction of the Roman Missal and of the Liturgy of the Hours.
-   * Obligatory Memorials which fall on weekdays of Lent may only be celebrated as
-   * Optional Memorials.
-   * If several Optional Memorials are inscribed in the Calendar on the same day, only
-   * one may be celebrated, the others being omitted. (UNLY #14)
+   * Obligatory Memorials are liturgical commemorations of saints, events, or aspects of the faith.
+   * Their observance is mandatory and integrated into the celebration of the occurring weekday,
+   * following the liturgical norms outlined in the General Instruction of the Roman Missal and the
+   * Liturgy of the Hours.
+   * When an Obligatory Memorial falls on a weekday during the liturgical season of Lent or a
+   * privileged weekday of Advent, it must only be celebrated as an Optional Memorial, as Lent and
+   * Advent have their own specific liturgical observances that take precedence.
    */
   Memorial = 'MEMORIAL',
+
+  /**
+   * Optional Memorials are liturgical commemorations of saints, events, or aspects of the faith,
+   * but they are not obligatory.
+   * Their observance is integrated into the celebration of the occurring weekday, adhering to the
+   * liturgical norms provided in the General Instruction of the Roman Missal and the Liturgy of
+   * the Hours.
+   * In cases where multiple Optional Memorials are designated on the same day in the liturgical
+   * calendar, only one of them may be celebrated, and the others must be omitted (UNLY #14).
+   * This allows for some flexibility in choosing which Optional Memorial to commemorate when
+   * multiple options are available.
+   */
+  OptionalMemorial = 'OPTIONAL_MEMORIAL',
 
   /**
    * The days of the week that follow Sunday are called weekdays; however, they are
@@ -57,9 +70,14 @@ export enum Ranks {
   Weekday = 'WEEKDAY',
 }
 
-export const RANKS = Object.keys(Ranks).filter(
-  (key) => typeof Ranks[key as keyof typeof Ranks] === 'string',
-) as Uppercase<keyof typeof Ranks>[];
+export const RANKS = [
+  Ranks.Solemnity,
+  Ranks.Sunday,
+  Ranks.Feast,
+  Ranks.Memorial,
+  Ranks.OptionalMemorial,
+  Ranks.Weekday,
+] as const;
 
 export type Rank = (typeof RANKS)[number];
 
@@ -89,6 +107,6 @@ export const RanksFromPrecedence: Record<Precedence, Rank> = {
   [Precedences.GeneralMemorial_10]: Ranks.Memorial,
   [Precedences.ProperMemorial_SecondPatron_11a]: Ranks.Memorial,
   [Precedences.ProperMemorial_11b]: Ranks.Memorial,
-  [Precedences.OptionalMemorial_12]: Ranks.Memorial,
+  [Precedences.OptionalMemorial_12]: Ranks.OptionalMemorial,
   [Precedences.Weekday_13]: Ranks.Weekday,
 };

--- a/lib/locales/cs.ts
+++ b/lib/locales/cs.ts
@@ -56,6 +56,7 @@ export const locale: Locale = {
     sunday: 'neděle',
     feast: 'svátek',
     memorial: 'památka',
+    optional_memorial: 'nezávazná památka',
     weekday: 'ferie',
   },
 

--- a/lib/locales/en.ts
+++ b/lib/locales/en.ts
@@ -56,6 +56,7 @@ export const locale: Locale = {
     sunday: 'Sunday',
     feast: 'feast',
     memorial: 'memorial',
+    optional_memorial: 'optional memorial',
     weekday: 'weekday',
   },
 

--- a/lib/locales/es.ts
+++ b/lib/locales/es.ts
@@ -56,6 +56,7 @@ export const locale: Locale = {
     sunday: 'Domingo',
     feast: 'fiesta',
     memorial: 'memoria',
+    optional_memorial: 'memoria opcional',
     weekday: 'ferial',
   },
 

--- a/lib/locales/fr.ts
+++ b/lib/locales/fr.ts
@@ -56,11 +56,12 @@ export const locale: Locale = {
   },
 
   ranks: {
-    solemnity: 'Solennité',
-    sunday: 'Dimanche',
-    feast: 'Fête',
-    memorial: 'Mémoire',
-    weekday: 'Férie',
+    solemnity: 'solennité',
+    sunday: 'dimanche',
+    feast: 'fête',
+    memorial: 'mémoire',
+    optional_memorial: 'mémoire facultative',
+    weekday: 'férie',
   },
 
   cycles: {

--- a/lib/locales/it.ts
+++ b/lib/locales/it.ts
@@ -52,11 +52,12 @@ export const locale: Locale = {
   },
 
   ranks: {
-    solemnity: 'Solennità',
-    sunday: 'Domenica',
-    feast: 'Festa',
-    memorial: 'Memoria',
-    weekday: 'Feria',
+    solemnity: 'solennità',
+    sunday: 'domenica',
+    feast: 'festa',
+    memorial: 'memoria',
+    optional_memorial: 'memoria facoltativa',
+    weekday: 'feria',
   },
 
   cycles: {

--- a/lib/locales/la.ts
+++ b/lib/locales/la.ts
@@ -58,6 +58,7 @@ export const locale: Locale = {
     sunday: 'dominica',
     feast: 'festum',
     memorial: 'memoria',
+    optional_memorial: 'memoria ad libitum',
     weekday: 'feria',
   },
 

--- a/lib/locales/pl.ts
+++ b/lib/locales/pl.ts
@@ -56,6 +56,7 @@ export const locale: Locale = {
     sunday: 'niedziela',
     feast: 'święto',
     memorial: 'wspomnienie obowiązkowe',
+    optional_memorial: 'wspomnienie dowolne',
     weekday: 'dzień powszedni',
   },
 

--- a/lib/locales/pt-br.ts
+++ b/lib/locales/pt-br.ts
@@ -56,6 +56,7 @@ export const locale: Locale = {
     sunday: 'domingo',
     feast: 'festa',
     memorial: 'memória',
+    optional_memorial: 'memória facultativa',
     weekday: 'dia de semana',
   },
 

--- a/lib/locales/sk.ts
+++ b/lib/locales/sk.ts
@@ -56,6 +56,7 @@ export const locale: Locale = {
     sunday: 'nedeľa',
     feast: 'sviatok',
     memorial: 'spomienka',
+    optional_memorial: 'ľubovoľná spomienka',
     weekday: 'féria',
   },
 

--- a/lib/models/calendar.ts
+++ b/lib/models/calendar.ts
@@ -182,7 +182,9 @@ export class Calendar implements BaseCalendar {
            *    - Feasts: small hours are taken from the weekday.
            */
           const weekday: LiturgicalDay | null =
-            baseData && [Ranks.Feast, Ranks.Memorial].some((r) => r === def.rank) ? baseData : null;
+            baseData && [Ranks.Feast, Ranks.Memorial, Ranks.OptionalMemorial].some((r) => r === def.rank)
+              ? baseData
+              : null;
 
           // Create a new LiturgicalDay object, and add it to the builtData object.
           builtData.byIds[def.id] = [

--- a/lib/models/liturgical-day.ts
+++ b/lib/models/liturgical-day.ts
@@ -138,7 +138,10 @@ class LiturgicalDay implements BaseLiturgicalDay {
      * and all the weekdays of Lent have precedence over Obligatory Memorials.
      */
     this.colors =
-      weekday?.precedence === Precedences.PrivilegedWeekday_9 && this.rank === Ranks.Memorial ? [] : def.colors;
+      weekday?.precedence === Precedences.PrivilegedWeekday_9 &&
+      [Ranks.Memorial, Ranks.OptionalMemorial].includes(this.rank)
+        ? []
+        : def.colors;
 
     this.martyrology = def.martyrology;
     this.titles = def.titles;

--- a/lib/types/locale.ts
+++ b/lib/types/locale.ts
@@ -52,6 +52,7 @@ export interface Locale {
     sunday?: string;
     feast?: string;
     memorial?: string;
+    optional_memorial?: string;
     weekday?: string;
   };
   cycles?: {

--- a/tests/calendar-builder.test.ts
+++ b/tests/calendar-builder.test.ts
@@ -144,7 +144,9 @@ describe('Testing calendar generation functions', () => {
       defs
         .filter(
           (d) =>
-            d.rank === Ranks.Memorial && !d.titles.includes(Titles.Apostle) && !d.titles.includes(Titles.Evangelist),
+            [Ranks.Memorial, Ranks.OptionalMemorial].includes(d.rank) &&
+            !d.titles.includes(Titles.Apostle) &&
+            !d.titles.includes(Titles.Evangelist),
         )
         .forEach((d) => {
           if (isMartyr(d.titles)) {


### PR DESCRIPTION
**Reintroduction of the `OPTIONAL_MEMORIAL` rank to:**
- Distinguish obligatory memorials from optional memorials using the `rank` property.
- It is still possible to distinguish them using the `precedence` or `isOptional` properties.
- Provide specific localization for the `OPTIONAL_MEMORIAL` value.

**Notes:**
- Up until Romcal v2, this value was titled `OPT_MEMORIAL`. I prefer to state it without abbreviation for clarity.
- The translations here come from the git history of this project.
- All the `rank` translations are now all in lowercase.

Resolves https://github.com/romcal/romcal/issues/435.