### PR TITLE
fix: add export keys, file path for esm files

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/esm/romcal.js",
+    "require": "./dist/cjs/romcal.js"
+  },
   "scripts": {
     "clean": "rimraf coverage dist tmp",
     "lint": "eslint . --ext .ts",

--- a/scripts/bundle.ts
+++ b/scripts/bundle.ts
@@ -244,7 +244,7 @@ export const RomcalBundler = (): void => {
      */
     const indexImports = Object.entries(calVarObj).reduce((acc, [locale, varName]) => {
       const importFileName = locale.replace(/([A-Z])/g, '-$1').toLowerCase();
-      return acc + `import { ${varName} } from './${importFileName}';\n`;
+      return acc + `import { ${varName} } from './${importFileName}.js';\n`;
     }, '');
     const indexExports = Object.entries(calVarObj).reduce((acc, [, varName]) => acc + `    ${varName},\n`, '');
     const indexOutput =


### PR DESCRIPTION
- fixes error found on romcal/romcal-examples#1:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'rest-api-with-fastify/node_modules/@romcal/calendar.france/esm/cs' imported from @romcal/calendar.france/esm/index.js
```
- export keys are added to help resolve an error where node resolution thinks romcal is only CJS on node 18 (at least according to the config in the example app)