### PR TITLE
ci: update dependabot prefix for commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,7 @@ updates:
       day: 'saturday'
       time: '00:00'
     commit-message:
-      prefix: 'chore'
-      prefix-development: 'dev'
-      include: 'scope'
+      prefix: 'ci'
     labels:
       - 'dependencies'
     open-pull-requests-limit: 10
@@ -24,8 +22,6 @@ updates:
       time: '00:00'
     commit-message:
       prefix: 'ci'
-      prefix-development: 'dev'
-      include: 'scope'
     labels:
       - 'dependencies'
     open-pull-requests-limit: 10

--- a/.github/workflows/dev-publishing.yml
+++ b/.github/workflows/dev-publishing.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Install Dependencies
+        run: npm -q --no-progress ci --no-audit
+
       - name: Validate with commitlint
         if: github.event_name == 'push'
         run: npx commitlint --last --verbose


### PR DESCRIPTION
I forgot to update the commit types for dependabot, so those PRs are failing on a step they shouldn't be failing on

also, forgot to add dependency install before commitlint, breaking the release workflow