### PR TITLE
feat(philippines): raise the rank of `ezequiel_moreno_bishop`

### DIFF
--- a/lib/particular-calendars/philippines.ts
+++ b/lib/particular-calendars/philippines.ts
@@ -50,7 +50,17 @@ export class Philippines extends CalendarDef {
     },
 
     ezequiel_moreno_bishop: {
-      precedence: Precedences.OptionalMemorial_12,
+      /*
+       * src: https://recoletos.ph/2024/02/01/cbcp-elevates-st-ezekiel-moreno-memorial-as-obligatory/;
+       * old:
+       *   rank: Precedences.OptionalMemorial_12
+       *   since: unknown
+       *   until: 28 Jan 2024
+       * new:
+       *   rank: Precedences.ProperMemorial_11b
+       *   since: 29 Jan 2024
+       */
+      precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 8, date: 19 },
     },
 


### PR DESCRIPTION
According to [this article](https://recoletos.ph/2024/02/01/cbcp-elevates-st-ezekiel-moreno-memorial-as-obligatory/), the celebration rank was raised to an obligatory memorial in the Philippines in late January 2024.

I’ve learnt about this change via an [update](https://en.wikipedia.org/w/index.php?title=National_calendars_of_the_Roman_Rite&diff=prev&oldid=1221643797) to the Wikipedia article of [National calendars of the Roman Rite](https://en.wikipedia.org/wiki/National_calendars_of_the_Roman_Rite).