### PR TITLE
fix(general-roman): the Passion of Saint John the Baptist should be celebrated in red

### DIFF
--- a/lib/catalog/martyrology.ts
+++ b/lib/catalog/martyrology.ts
@@ -3322,6 +3322,7 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     },
     passion_of_saint_john_the_baptist: {
       name: 'Passion of Saint John the Baptist',
+      titles: [Title.Martyr],
     },
     patrick_of_ireland_bishop: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/lib/catalog/martyrology.ts
+++ b/lib/catalog/martyrology.ts
@@ -3059,6 +3059,8 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       dateOfDeath: 1917,
     },
     nativity_of_john_the_baptist: {
+      // Note: The title of Martyr is not indicated here, as Saint John the Baptist is not yet a Martyr at his birth.
+      // Therefore, this celebration will be celebrated in white (src: GIRM, 308a).
       name: 'The Nativity of Saint John the Baptist',
     },
     nativity_of_the_blessed_virgin_mary: {
@@ -3321,6 +3323,8 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Religious],
     },
     passion_of_saint_john_the_baptist: {
+      // Note: unlike the celebration of the Nativity of Saint John the Baptist, here his title of Martyr is indeed indicated.
+      // Therefore, this celebration will be celebrated in red (src: GIRM, 308b).
       name: 'Passion of Saint John the Baptist',
       titles: [Title.Martyr],
     },


### PR DESCRIPTION
On August 29, Saint John the Baptist is celebrated as a martyr, so the celebration should be in red (unlike the Nativity of Saint John the Baptist, which is in white).

Therefore, I am adding the missing title for this liturgical day (so that Romcal automatically colors it red).

See § 308.b. of the [GIRM](https://www.catholicculture.org/culture/library/view.cfm?recnum=337): 
> Red is used on Passion Sunday (Palm Sunday) and Good Friday, Pentecost, celebrations of the Lord's passion, birthday feasts of the apostles and evangelists, and celebrations of martyrs.