### PR TITLE
fix(util): read romcal version from root package

### DIFF
--- a/rites/roman1969/src/index.ts
+++ b/rites/roman1969/src/index.ts
@@ -1,6 +1,5 @@
 import { calculateGregorianEasterDate, calculateJulianEasterDateToGregorianDate } from '@internal/easter';
-
-import { version } from '../package.json';
+import { version } from '@internal/package.json';
 
 import { CALENDAR_PKG_NAMES, CALENDAR_VAR_NAMES } from './constants/calendars';
 import { COLORS, Color, Colors, isColor } from './constants/colors';


### PR DESCRIPTION
The string returned by the `getVersion()` method was `0.0.0` because it was reading the version of the sub-package `@internal/roman1969`.

In the meantime, I'm fixing it so that the root `package.json` is used to retrieve the correct version number.

This raises two points (not too urgent to address from my point of view):
- It creates a warning during Romcal's build:
```
Error src/index.ts (2,25): File '../../package.json' is not under 'rootDir' '.'. 'rootDir' is expected to contain all source files.
```
- Ideally, when bumping Romcal's version, all sub-packages should probably be synchronized to the same version number.