### PR TITLE
feat(france.angers): add Diocese of Angers, France

### DIFF
--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -145,12 +145,34 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Alberto Hurtado',
       titles: [Title.Priest],
     },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Albinus_of_Angers
+    albinus_of_angers_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Albinus',
+      titles: [Title.Bishop],
+      dateOfBirth: 468,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '550-03-01',
+    },
     // src: mr_fr_2014_ed2_lyon
     alexander_of_lyon_martyr: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Alexander',
       dateOfDeath: 178,
       titles: [Title.Martyr],
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://fr.wikipedia.org/wiki/Liste_des_%C3%A9v%C3%AAques_d%27Angers
+    all_holy_bishops_of_the_diocese_of_angers: {
+      canonizationLevel: CanonizationLevels.Saint,
+      hideCanonizationLevel: true,
+      name: 'All Holy Bishops of the Diocese of Angers',
+      count: 'many',
+      titles: [Title.Bishop],
+      hideTitles: true,
     },
     // src:
     // - mr_fr_1982_ed2_coutances
@@ -188,11 +210,6 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'All Saints of the Archdiocese of Paris',
       count: 'many',
     },
-    all_saints_of_the_diocese_of_saint_denis: {
-      canonizationLevel: CanonizationLevels.Saint,
-      name: 'All Saints of the Diocese of Saint-Denis',
-      count: 'many',
-    },
     // src:
     // - mr_fr_1982_ed2_coutances
     // - https://www.diocese50.fr/les-paroisses-et-les-doyennes/notre-dame-coutances/les-saints-du-diocese/tous-les-saints-de-coutances-et-avranches
@@ -200,6 +217,11 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       hideCanonizationLevel: true,
       name: 'All Saints of the Diocese of Coutances and Avranches',
+      count: 'many',
+    },
+    all_saints_of_the_diocese_of_saint_denis: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'All Saints of the Diocese of Saint-Denis',
       count: 'many',
     },
     all_saints_of_wales: {
@@ -675,10 +697,21 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Virgin, Title.Martyr],
       dateOfDeath: 177,
     },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://fr.wikipedia.org/wiki/Martyrs_d%27Angers
+    blessed_martyrs_of_angers: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Martyrs of Angers',
+      count: 'many',
+      titles: [Title.Martyr],
+      hideTitles: true,
+    },
     blessed_martyrs_of_paris: {
       canonizationLevel: CanonizationLevels.Blessed,
-      name: 'Blessed martyrs of Paris',
+      name: 'Martyrs of Paris',
       count: 'many',
+      titles: [Title.Martyr],
       hideTitles: true,
     },
     bogumilus_of_dobrow_bishop: {
@@ -1139,6 +1172,12 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Apostle],
       count: 2,
     },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Angers_Cathedral
+    dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france: {
+      dateOfDedication: 1096,
+    },
     dedication_of_the_lateran_basilica: {
       name: 'Dedication of the Lateran Basilica',
     },
@@ -1470,6 +1509,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Flannan',
       titles: [Title.Bishop],
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://fr.wikipedia.org/wiki/Florent_d%27Anjou
+    florentius_of_anjou_abbot: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Florentius',
+      titles: [Title.Abbot],
+      dateOfDeath: { century: 5 },
     },
     florentius_of_strasbourg_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -1916,6 +1964,11 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'The Holy Guardian Angels',
       count: 'many',
     },
+    // src: mr_fr_2022_ed3_angers
+    holy_hermits_and_evangelists: {
+      titles: [Title.Hermit, Title.Evangelist],
+      count: 'many',
+    },
     holy_innocents_martyrs: {
       name: 'Holy Innocents',
       titles: [Title.Martyr],
@@ -2126,6 +2179,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Jarlath',
       titles: [Title.Bishop],
     },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/19_martyrs_of_Algeria
+    jean_chevillard_martyr: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Jean Chevillard',
+      titles: [Title.Religious, Title.Martyr],
+      dateOfBirth: '1925-08-27',
+      dateOfDeath: '1994-12-27',
+    },
     // src: mr_fr_2014_ed2_lyon
     jean_louis_bonnard_priest: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -2139,6 +2202,36 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Jean-Pierre Néel',
       titles: [Title.Priest, Title.Martyr],
       dateOfDeath: '1862-2-18',
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Holy_September_Martyrs
+    jean_robert_queneau_martyr: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Jean-Robert Queneau',
+      titles: [Title.Priest, Title.Martyr],
+      dateOfBirth: '1758-04-09',
+      dateOfDeath: '1792-09-02',
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Th%C3%A9ophane_V%C3%A9nard
+    jean_theophane_venard_priest: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Jean Théophane Venard',
+      titles: [Title.Priest, Title.Martyr],
+      dateOfBirth: '1829-11-21',
+      dateOfDeath: '1861-02-02',
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Jeanne_Delanoue
+    jeanne_delanoue_of_the_cross_religious: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Jeanne Delanoue',
+      titles: [Title.Religious],
+      dateOfBirth: '1666-06-18',
+      dateOfDeath: '1736-08-17',
     },
     jerome_de_angelis_priest: {
       canonizationLevel: CanonizationLevels.Blessed,
@@ -2731,6 +2824,18 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Leopold Mandić',
       titles: [Title.Priest],
     },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Licinius_of_Angers
+    licinius_of_angers_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Licinius',
+      titles: [Title.Bishop],
+      dateOfBirth: 540,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: 610,
+      dateOfDeathIsApproximative: true,
+    },
     louis_bertrand_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Louis Bertrand',
@@ -2742,15 +2847,14 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Priest, Title.Martyr],
     },
     // src:
-    // - mr_fr_1982_ed2_coutances
-    // - https://www.diocese50.fr/les-paroisses-et-les-doyennes/notre-dame-coutances/les-saints-du-diocese/saint-louis-marie-grignion-de-montfort-pretre
+    // - mr_fr_2021_ed3
     // - https://en.wikipedia.org/wiki/Louis_de_Montfort
     louis_grignion_de_montfort_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Louis Grignion de Montfort',
       titles: [Title.Priest],
       dateOfBirth: '1673-01-31',
-      dateOfDeath: '1716-4-28',
+      dateOfDeath: '1716-04-28',
     },
     louis_ix_of_france: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -3111,6 +3215,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       dateOfBirth: '1632-05-03',
       dateOfDeath: '1668-05-08',
     },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Mary_Euphrasia_Pelletier
+    mary_euphrasia_pelletier_religious: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Mary Euphrasia Pelletier',
+      titles: [Title.Religious],
+      dateOfBirth: '1796-07-31',
+      dateOfDeath: '1868-04-24',
+    },
     mary_magdalene: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Mary Magdalene',
@@ -3234,11 +3348,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Matthias',
       titles: [Title.Apostle],
     },
-    // src: mr_fr_2014_ed2_lyon
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - mr_fr_2014_ed2_lyon
+    // - https://en.wikipedia.org/wiki/Saint_Maurice
     maurice_of_agaunum_martyr: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Maurice',
       titles: [Title.Martyr],
+      dateOfBirth: { century: 3 },
+      dateOfBirthIsApproximative: true,
       dateOfDeath: 287,
       dateOfDeathIsApproximative: true,
     },
@@ -3246,6 +3365,27 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Blessed,
       name: 'Maurice Tornay',
       titles: [Title.Priest, Title.Martyr],
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Maurilius_of_Angers
+    maurilius_of_angers_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Maurilius',
+      titles: [Title.Bishop],
+      dateOfBirth: 363,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '453-09-13',
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Saint_Maurus
+    maurus_of_glanfeuil_abbot: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Maurus',
+      titles: [Title.Abbot],
+      dateOfBirth: '512-01-01',
+      dateOfDeath: '584-01-15',
     },
     maurus_of_pecs_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -3421,6 +3561,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Nicetius',
       titles: [Title.Bishop],
       dateOfDeath: '573-4-2',
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/No%C3%ABl_Pinot
+    noel_pinot_priest: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Noël Pinot',
+      titles: [Title.Priest, Title.Martyr],
+      dateOfBirth: '1747-12-19',
+      dateOfDeath: '1794-02-21',
     },
     norbert_of_xanten_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -3813,13 +3963,17 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Peter de Zúñiga',
       titles: [Title.Priest, Title.Martyr],
     },
-    // src: mr_fr_2014_ed2_lyon
+    // src:
+    // - mr_fr_2021_ed3
+    // - mr_fr_2022_ed3_angers
+    // - mr_fr_2014_ed2_lyon
+    // - https://en.wikipedia.org/wiki/Peter_Julian_Eymard
     peter_julian_eymard_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Peter Julian Eymard',
       titles: [Title.Priest],
-      dateOfBirth: 1811,
-      dateOfDeath: 1868,
+      dateOfBirth: '1811-02-04',
+      dateOfDeath: '1868-08-01',
     },
     peter_kibe_priest: {
       canonizationLevel: CanonizationLevels.Blessed,
@@ -4006,6 +4160,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Remigius',
       titles: [Title.Bishop],
       dateOfDeath: 530,
+    },
+    // src:
+    // - mr_fr_2022_ed3_angers
+    // - https://en.wikipedia.org/wiki/Ren%C3%A9_Goupil
+    rene_goupil_religious: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'René Goupil',
+      titles: [Title.Religious, Title.Martyr],
+      dateOfBirth: '1608-05-15',
+      dateOfDeath: '1642-09-29',
     },
     richard_gwyn_martyr: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/rites/roman1969/src/constants/martyrology-metadata.ts
+++ b/rites/roman1969/src/constants/martyrology-metadata.ts
@@ -108,6 +108,7 @@ export enum PatronTitle {
   PatronOfTheClergyOfTheArchdioceseOfLyon = 'PATRON_OF_THE_CLERGY_OF_THE_ARCHDIOCESE_OF_LYON',
   PatronOfTheCityOfLyon = 'PATRON_OF_THE_CITY_OF_LYON',
   PatronessOfCostaRica = 'PATRONESS_OF_COSTA_RICA',
+  SecondPatronOfTheDiocese = 'SECOND_PATRON_OF_THE_DIOCESE',
 }
 
 export const PATRON_TITLES = Object.keys(PatronTitle)

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -171,10 +171,12 @@ export const locale: Locale = {
     albert_chmielowski_religious: 'Saint Albert Chmielowski, Religious',
     albert_the_great_bishop: 'Saint Albert the Great, Bishop and Doctor of the Church',
     albertina_berkenbrock_virgin: 'Blessed Albertina Berkenbrock, Virgin and Martyr',
+    albinus_of_angers_bishop: 'Saint Albinus of Angers, Abbot', // mr_fr_2022_ed3_angers
     alberto_hurtado_priest: 'Saint Alberto Hurtado, Priest',
-    all_holy_bishops_of_the_archdiocese_of_lyon: 'All Holy Bishops of the Archdiocese of Lyon',
     all_holy_bishops_and_priests_of_the_diocese_of_coutances:
       'The Holy Bishops of the diocese of Coutances and Avranches, and the priests, their collaborators',
+    all_holy_bishops_of_the_archdiocese_of_lyon: 'All Holy Bishops of the Archdiocese of Lyon',
+    all_holy_bishops_of_the_diocese_of_angers: 'All Holy Bishops of the Diocese of Angers', // mr_fr_2022_ed3_angers
     all_saints: 'All Saints',
     all_saints_of_ireland: 'All Saints of Ireland',
     all_saints_of_the_archdiocese_of_lyon: 'All Saints of the Archdiocese of Lyon',
@@ -265,6 +267,7 @@ export const locale: Locale = {
     bernardine_of_siena_priest: 'Saint Bernardine of Siena, Priest',
     beuno_of_wales_abbot: 'Saint Beuno, Abbot',
     blaise_of_sebaste_bishop: 'Saint Blaise, Bishop and Martyr',
+    blessed_martyrs_of_angers: 'Blessed Martyrs of Angers', // mr_fr_2022_ed3_angers
     blessed_martyrs_of_paris: 'Blessed Martyrs of Paris',
     bogumilus_of_dobrow_bishop: 'Blessed Bogumilus, Bishop',
     boleslawa_mary_lament_virgin: 'Blessed Boleslawa Mary Lament, Virgin',
@@ -375,6 +378,8 @@ export const locale: Locale = {
       'The Dedication of the Cathedral of Notre-Dame of Strasbourg',
     dedication_of_the_cathedral_of_saint_john_the_baptist_lyon_france:
       'The Dedication of the Cathedral of Saint John the Baptist, Lyon',
+    dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france:
+      'The Dedication of the Cathedral Saint Maurice of Angers, France', // mr_fr_2022_ed3_angers
     dedication_of_the_lateran_basilica: 'The Dedication of the Lateran Basilica',
     dedication_of_the_notre_dame_de_paris_cathedral_paris_france:
       'The Dedication of the Notre-Dame de Paris Cathedral, Paris',
@@ -441,6 +446,7 @@ export const locale: Locale = {
     first_polish_martyrs: 'Saints Benedict, John, Matthew, Isaac and Christian, the First Polish Martyrs',
     five_wounds_of_the_lord: 'Five Wounds of the Lord',
     flannan_of_killaloe_bishop: 'Saint Flannan, Bishop',
+    florentius_of_anjou_abbot: 'Saint Florentius, Abbot', // mr_fr_2022_ed3_angers
     florentius_of_strasbourg_bishop: 'Saint Florentius, Bishop',
     florian_of_lorch_and_companions_martyrs: 'Saint Florian and Companions, Martyrs',
     florian_of_lorch_martyr: 'Saint Florian, Martyr',
@@ -519,6 +525,7 @@ export const locale: Locale = {
     holy_family_of_jesus_mary_and_joseph: 'The Holy Family of Jesus, Mary and Joseph',
     holy_guardian_angels: 'The Holy Guardian Angels',
     holy_innocents_martyrs: 'The Holy Innocents, Martyrs',
+    holy_hermits_and_evangelists: 'The Holy Hermits and Evangelists', // mr_fr_2022_ed3_angers
     holy_saturday: 'Holy Saturday/Easter Vigil',
     holy_thursday: 'Holy Thursday',
     honorat_kozminski_priest: 'Blessed Honorat Koźmiński, Priest',
@@ -565,8 +572,12 @@ export const locale: Locale = {
     jane_frances_de_chantal_religious: 'Saint Jane Frances de Chantal, Religious',
     januarius_i_of_benevento_bishop: 'Saint Januarius, Bishop and Martyr',
     jarlath_of_tuam_bishop: 'Saint Jarlath, Bishop',
+    jean_chevillard_and_companions_martyrs: 'Blessed Jean Chevillard and Companions, Religious and Martyrs', // mr_fr_2022_ed3_angers
     jean_louis_bonnard_priest: 'Saint Jean-Louis Bonnard, Priest and Martyr',
     jean_pierre_neel_priest: 'Saint Jean Pierre Néel, Priest and Martyr',
+    jean_robert_queneau_and_companions_martyrs: 'Blessed Jean-Robert Queneau, Priest, and Companions, Martyrs', // mr_fr_2022_ed3_angers
+    jean_theophane_venard_priest: 'Saint Théophane Vénard, Priest and Martyr', // mr_fr_2022_ed3_angers
+    jeanne_delanoue_of_the_cross_religious: 'Saint Jeanne Delanoue, Religious', // mr_fr_2022_ed3_angers
     jerome_emiliani: 'Saint Jerome Emiliani',
     jerome_of_stridon_priest: 'Saint Jerome, Priest and Doctor of the Church',
     joachim_and_anne_parents_of_mary: 'Saints Joachim and Anne, Parents of the Blessed Virgin Mary',
@@ -677,6 +688,7 @@ export const locale: Locale = {
     leonid_feodorov_priest: 'Blessed Leonid Feodorov, Priest and Martyr',
     leopold_iii_of_babenberg: 'Saint Leopold III of Babenberg',
     leopold_mandic_priest: 'Saint Leopold Mandić, Priest',
+    licinius_of_angers_bishop: 'Saint Licinius of Angers, Bishop', // mr_fr_2022_ed3_angers
     louis_bertrand_priest: 'Saint Louis Bertrand, Priest',
     louis_grignion_de_montfort_priest: 'Saint Louis Grignion de Montfort, Priest',
     louis_ix_of_france: 'Saint Louis',
@@ -739,6 +751,7 @@ export const locale: Locale = {
     mary_adeodata_pisani_virgin: 'Blessed Mary Adeodata Pisani, Virgin',
     mary_angela_truszkowska_virgin: 'Blessed Mary Angela Truszkowska, Virgin',
     mary_assunta_pallotta_virgin: 'Blessed Mary Assunta Pallotta, Virgin',
+    mary_euphrasia_pelletier_religious: 'Saint Mary Euphrasia Pelletier, Religious', // mr_fr_2022_ed3_angers
     mary_magdalene: 'Saint Mary Magdalene',
     mary_magdalene_de_pazzi_virgin: 'Saint Mary Magdalene de’ Pazzi, Virgin',
     mary_mother_of_god: 'The Octave Day of the Nativity of the Lord: Solemnity of Mary, the Holy Mother of God',
@@ -767,7 +780,12 @@ export const locale: Locale = {
     matthew_apostle: 'Saint Matthew, Apostle and Evangelist',
     matthias_apostle: 'Saint Matthias, Apostle',
     maurice_of_agaunum_and_companions_martyrs: 'Saint Maurice and Companions, Martyrs',
+    maurice_of_agaunum_and_companions_martyrs_patron_of_the_diocese_of_angers:
+      'Saint Maurice and Companions, Martyrs and Patrons of the city and the diocese of Angers', // mr_fr_2022_ed3_angers
     maurice_tornay_priest: 'Blessed Maurice Tornay, Priest and Martyr',
+    maurilius_of_angers_bishop_second_patron_of_the_diocese_of_angers:
+      'Saint Maurilius, Bishop and Copatron of the diocese of Angers', // mr_fr_2022_ed3_angers
+    maurus_of_glanfeuil_abbot: 'Saint Maurus, Abbot', // mr_fr_2022_ed3_angers
     maurus_of_pecs_bishop: 'Saint Maurus, Bishop',
     maximilian_mary_raymund_kolbe_priest: 'Saint Maximilian Mary Kolbe, Priest and Martyr',
     mederic_of_autun_and_droctoveus_of_autun_abbots: 'Saints Mederic and Droctoveus, Abbots',
@@ -804,6 +822,7 @@ export const locale: Locale = {
     nicholas_tavelic_priest: 'Saint Nicholas Tavelić, Priest and Martyr',
     ninian_of_whithorn_bishop: 'Saint Ninian, Bishop',
     nicetius_of_lyon_bishop: 'Saint Nicetius, Bishop',
+    noel_pinot_priest: 'Blessed Noël Pinot, Priest and Martyr', // mr_fr_2022_ed3_angers
     norbert_of_xanten_bishop: 'Saint Norbert, Bishop',
     nuno_of_saint_mary_pereira_religious: 'Saint Nuno of Saint Mary Pereira, Religious',
     nykyta_budka_and_vasyl_velychkovsky_bishops: 'Blesseds Nykyta Budka and Vasyl Velychkovsky, Bishops and Martyrs',
@@ -942,6 +961,7 @@ export const locale: Locale = {
     raphael_of_saint_joseph_kalinowski_priest: 'Saint Raphael of Saint Joseph Kalinowski, Priest',
     raymond_of_penyafort_priest: 'Saint Raymond of Penyafort, Priest',
     remigius_of_reims_bishop: 'Saint Remigius, Bishop',
+    rene_goupil_religious: 'Saint René Goupil, Religious and Martyr', // mr_fr_2022_ed3_angers
     richard_gwyn_martyr: 'Saint Richard Gwyn, Martyr',
     richard_of_chichester_bishop: 'Saint Richard of Chichester, Bishop',
     richardis_of_swabia_empress: 'Saint Richardis, Empress',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -164,9 +164,11 @@ export const locale: Locale = {
     agnes_of_rome_virgin: 'Sainte Agnès, vierge et martyre († v. 304)',
     albert_the_great_bishop:
       'Saint Albert le Grand, frère prêcheur, évêque de Ratisbonne, docteur de l’Église († 1280)',
-    all_holy_bishops_of_the_archdiocese_of_lyon: 'Tous les Saints Évêques du diocèse de Lyon',
+    albinus_of_angers_bishop: 'Saint Aubin, évêque († 550)', // mr_fr_2022_ed3_angers
     all_holy_bishops_and_priests_of_the_diocese_of_coutances:
       'Tous les Saints Évêques du diocèse de Coutances et Avranches, et les prêtres, leurs coopérateurs', // src: mr_fr_1982_ed2_coutances
+    all_holy_bishops_of_the_archdiocese_of_lyon: 'Tous les Saints Évêques du diocèse de Lyon',
+    all_holy_bishops_of_the_diocese_of_angers: 'Tous les Saints Évêques du diocèse d’Angers', // mr_fr_2022_ed3_angers
     all_saints: 'Tous les Saints',
     all_saints_of_the_archdiocese_of_lyon: 'Tous les Saints du diocèse de Lyon', // src: mr_fr_2014_ed2_lyon
     all_saints_of_the_archdiocese_of_paris: 'Tous les Saints du diocèse de Paris',
@@ -235,7 +237,8 @@ export const locale: Locale = {
     bernard_of_clairvaux_abbot: 'Saint Bernard de Clairvaux, abbé, docteur de l’Église († 1153)',
     bernardine_of_siena_priest: 'Saint Bernardin de Sienne, prêtre († 1444)',
     blaise_of_sebaste_bishop: 'Saint Blaise de Sébaste, évêque et martyr († 316)',
-    blessed_martyrs_of_paris: 'Bienheureux martyrs de Paris († du 2 au 6 septembre 1792)',
+    blessed_martyrs_of_angers: 'Bienheureux Martyrs d’Angers († 1793-1794)', // mr_fr_2022_ed3_angers
+    blessed_martyrs_of_paris: 'Bienheureux Martyrs de Paris († du 2 au 6 septembre 1792)',
     bonaventure_of_bagnoregio_bishop: 'Saint Bonaventure, évêque d’Albano et docteur de l’Église († 1274)',
     boniface_of_mainz_bishop: 'Saint Boniface, évêque et martyr († 754)',
     bridget_of_sweden_religious:
@@ -301,6 +304,7 @@ export const locale: Locale = {
     dedication_of_the_cathedral_of_notre_dame_of_coutances_france: 'Dédicace de la cathédrale de Coutances', // src: mr_fr_1982_ed2_coutances
     dedication_of_the_cathedral_of_notre_dame_de_strasbourg_france: 'Dédicace de la cathédrale de Strasbourg',
     dedication_of_the_cathedral_of_saint_john_the_baptist_lyon_france: 'Dédicace de la cathédrale primatiale', // src: mr_fr_2014_ed2_lyon
+    dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france: 'Dédicace de la Cathédrale Saint Maurice', // mr_fr_2022_ed3_angers
     dedication_of_the_lateran_basilica: 'Dédicace de la Basilique du Latran',
     dedication_of_the_notre_dame_de_paris_cathedral_paris_france: 'Dédicace de la cathédrale de Paris',
     denis_of_paris_bishop_and_companions_martyrs:
@@ -333,6 +337,7 @@ export const locale: Locale = {
     faustina_kowalska_virgin: 'Sainte Faustina Kowalska († 1938)',
     fidelis_of_sigmaringen_priest: 'Saint Fidèle de Sigmaringen, prêtre et martyr († 1622)',
     first_martyrs_of_the_holy_roman_church: 'Premiers martyrs de l’Église de Rome († 64)',
+    florentius_of_anjou_abbot: 'Saint Florent, abbé († Vème s.)', // mr_fr_2022_ed3_angers
     florentius_of_strasbourg_bishop: 'Saint Florent, évêque († VIIème s.)',
     floscellus_of_normandy_martyr: 'Saint Floscel, martyr († v. 296)', // src: mr_fr_1982_ed2_coutances
     frances_of_rome_religious: 'Sainte Françoise Romaine, religieuse († 1440)',
@@ -371,6 +376,7 @@ export const locale: Locale = {
     hildegard_of_bingen_abbess: 'Sainte Hildegarde de Bingen, abbesse et docteur de l’Église († 1179)',
     holy_family_of_jesus_mary_and_joseph: 'La Sainte Famille',
     holy_guardian_angels: 'Saints Anges gardiens',
+    holy_hermits_and_evangelists: 'Les saints ermites et évangélisateurs', // mr_fr_2022_ed3_angers
     holy_innocents_martyrs: 'Saints Innocents, martyrs († Ier s.)',
     holy_saturday: 'Samedi Saint',
     holy_thursday: 'Jeudi Saint',
@@ -393,8 +399,14 @@ export const locale: Locale = {
     james_apostle: 'Saint Jacques le Majeur, apôtre († 44)',
     jane_frances_de_chantal_religious: 'Sainte Jeanne-Françoise de Chantal, religieuse († 1641)',
     januarius_i_of_benevento_bishop: 'Saint Janvier, évêque de Bénévent et martyr († 305)',
+    jean_chevillard_and_companions_martyrs:
+      'Bienheureux Jean Chevillard et ses compagnons, religieux et martyrs († 1994-1996)', // mr_fr_2022_ed3_angers
     jean_louis_bonnard_priest: 'Saint Jean-Louis Bonnard, prêtre et martyr († 1841)', // src: mr_fr_2014_ed2_lyon
     jean_pierre_neel_priest: 'Saint Jean-Pierre Néel, prêtre et martyr († 1862)', // src: mr_fr_2014_ed2_lyon
+    jean_robert_queneau_and_companions_martyrs:
+      'Bienheureux Jean-Robert Queneau, prêtre, et ses compagnons, martyrs († 1792)', // mr_fr_2022_ed3_angers
+    jean_theophane_venard_priest: 'Saint Théophane Vénard, prêtre et martyr († 1861)', // mr_fr_2022_ed3_angers
+    jeanne_delanoue_of_the_cross_religious: 'Sainte Jeanne Delanoue, religieuse († 1736)', // mr_fr_2022_ed3_angers
     jerome_emiliani: 'Saint Jérôme Émilien, fondateur († 1537)',
     jerome_of_stridon_priest: 'Saint Jérôme, père et docteur de l’Église († 420)',
     joachim_and_anne_parents_of_mary: 'Saints Anne et Joachim, parents de la vierge Marie († Ier s.)',
@@ -454,7 +466,8 @@ export const locale: Locale = {
     leo_ix_pope: 'Saint Léon IX, pape († 540)',
     leodegar_of_autun_bishop: 'Saint Léger, évêque et martyr († 679 ou 680)',
     leon_de_carentan_bishop: 'Saint Léon de Carentan, évêque et martyr († 890)', // src: mr_fr_1982_ed2_coutances
-    louis_grignion_de_montfort_priest: 'Saint Louis-Marie Grignion de Montfort, prêtre († 1716)',
+    licinius_of_angers_bishop: 'Saint Lézin, évêque († 610)', // mr_fr_2022_ed3_angers
+    louis_grignion_de_montfort_priest: 'Saint Louis-Marie Grignion de Montfort, prêtre († 1716)', // mr_fr_2021_ed3
     louis_ix_of_france: 'Saint Louis, roi de France († 1270)',
     louis_zephirin_moreau_bishop: 'Bienheureux Louis Zéphyrin Moreau, évêque († 1901)',
     louise_de_marillac_religious: 'Sainte Louise de Marillac, religieuse († 1660)',
@@ -491,6 +504,7 @@ export const locale: Locale = {
     martin_de_porres_religious: 'Saint Martin de Porrès, religieux Dominicain à Lima († 1639)',
     martin_i_pope: 'Saint Martin Ier, pape et martyr († 656)',
     martin_of_tours_bishop: 'Saint Martin de Tours, évêque († 397)',
+    mary_euphrasia_pelletier_religious: 'Sainte Marie-Euphrasie Pelletier, religieuse († 1868)', // mr_fr_2022_ed3_angers
     mary_magdalene: 'Sainte Marie-Madeleine, disciple du Christ († Ier s.)',
     mary_magdalene_de_pazzi_virgin: 'Sainte Marie-Madeleine de Pazzi, vierge de l’Ordre du Carmel († 1607)',
     mary_mother_of_god: 'Sainte Marie, Mère de Dieu',
@@ -508,6 +522,11 @@ export const locale: Locale = {
     matthew_apostle: 'Saint Matthieu, apôtre et évangéliste',
     matthias_apostle: 'Saint Matthias, apôtre',
     maurice_of_agaunum_and_companions_martyrs: 'Saint Maurice et ses companions, martyrs († v. 287)', // src: mr_fr_2014_ed2_lyon
+    maurice_of_agaunum_and_companions_martyrs_patron_of_the_diocese_of_angers:
+      'Saint Maurice et ses compagnons, martyrs et patrons de la ville et du diocèse († 287)', // mr_fr_2022_ed3_angers
+    maurilius_of_angers_bishop_second_patron_of_the_diocese_of_angers:
+      'Saint Maurille, évêque et patron secondaire du diocèse († 453)', // mr_fr_2022_ed3_angers
+    maurus_of_glanfeuil_abbot: 'Saint Maur, abbé († 584)', // mr_fr_2022_ed3_angers
     maximilian_mary_raymund_kolbe_priest: 'Saint Maximilien-Marie Kolbe, prêtre et martyr († 1941)',
     mederic_of_autun_and_droctoveus_of_autun_abbots: 'Saint Merry et Saint Droctovée, Abbés',
     michael_gabriel_and_raphael_archangels: 'Saints Michel, Gabriel and Raphaël, archanges',
@@ -528,6 +547,7 @@ export const locale: Locale = {
     nicholas_barre_priest: 'Bienheureux. Nicolas Barré, prêtre († 1686 à Paris)',
     nicholas_of_myra_bishop: 'Saint Nicolas, évêque de Myre († v. 350)',
     nicetius_of_lyon_bishop: 'Saint Nizier, évêque († 573)', // src: mr_fr_2014_ed2_lyon
+    noel_pinot_priest: 'Bienheureux Noël Pinot, prêtre et martyr († 1794)', // mr_fr_2022_ed3_angers
     norbert_of_xanten_bishop: 'Saint Norbert, évêque († 1134)',
     nykyta_budka_and_vasyl_velychkovsky_bishops:
       'Bienheureux Nicétas Budka († 1949) et Vasyl Velychkowsky († 1973), évêques et martyrs',
@@ -571,7 +591,9 @@ export const locale: Locale = {
     peter_chrysologus_bishop: 'Saint Pierre Chrysologue, évêque de Ravenne et docteur de l’Église († 451)',
     peter_claver_priest: 'Saint Pierre Claver, prêtre Jésuite († 1654)',
     peter_damian_bishop: 'Saint Pierre Damien, évêque d’Ostie, docteur de l’Église († 1072)',
-    peter_julian_eymard_priest: 'Saint Pierre-Julien Eymard, prêtre, fondateur des Pères du Saint-Sacrement († 1868)',
+    peter_julian_eymard_priest:
+      // note: fondateur des Pères du Saint-Sacrement
+      'Saint Pierre-Julien Eymard, prêtre († 1868)', // mr_fr_2021_ed3
     philip_and_james_apostles: 'Saint Philippe et Saint Jacques le Mineur, apôtres',
     philip_neri_priest: 'Saint Philippe Néri, prêtre († 1595)',
     pirmin_of_hornbach_abbot: 'Saint Pirmin, abbé († 753)',
@@ -590,6 +612,7 @@ export const locale: Locale = {
     queenship_of_the_blessed_virgin_mary: 'Vierge Marie, reine',
     raymond_of_penyafort_priest: 'Saint Raymond de Peñafort, prêtre († 1275)',
     remigius_of_reims_bishop: 'Saint Remi, évêque de Reims († 530)',
+    rene_goupil_religious: 'Saint René Goupil, religieux et martyr († 1642)', // mr_fr_2022_ed3_angers
     richardis_of_swabia_empress: 'Sainte Richarde, impératrice († 894 ou 896)',
     rita_of_cascia_religious: 'Sainte Rita da Cascia, veuve puis religieuse († 1456)',
     robert_bellarmine_bishop: 'Saint Robert Bellarmin, Jésuite, évêque et docteur de l’Église († 1621)',

--- a/rites/roman1969/src/particular-calendars/france.angers.ts
+++ b/rites/roman1969/src/particular-calendars/france.angers.ts
@@ -1,0 +1,152 @@
+import { PatronTitle } from '../constants/martyrology-metadata';
+import { Precedences } from '../constants/precedences';
+import { CalendarDef } from '../models/calendar-def';
+import { Inputs } from '../types/calendar-def';
+
+import { France } from './france';
+
+// src:
+// - mr_fr_2022_ed3_angers
+// - https://foi.diocese49.org/IMG/pdf/2022-09-28_missel_propre_format_a5_.pdf
+// - https://en.wikipedia.org/wiki/Roman_Catholic_Diocese_of_Angers
+// - https://www.diocese49.org/mon-diocese/les-saints-de-lanjou/
+export class France_Angers extends CalendarDef {
+  ParentCalendar = France;
+
+  inputs: Inputs = {
+    // src: mr_fr_2022_ed3_angers
+    maurus_of_glanfeuil_abbot: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 1, date: 15 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    blessed_martyrs_of_angers: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 2, date: 1 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    jean_theophane_venard_priest: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 2, date: 3 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    licinius_of_angers_bishop: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 2, date: 13 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    noel_pinot_priest: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 2, date: 21 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    albinus_of_angers_bishop: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 3, date: 1 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    mary_euphrasia_pelletier_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 4, date: 24 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    jean_chevillard_and_companions_martyrs: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 5, date: 8 },
+      martyrology: ['jean_chevillard_martyr', 'companions_martyrs'],
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    holy_hermits_and_evangelists: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 7, date: 8 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    jeanne_delanoue_of_the_cross_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 8, date: 17 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    jean_robert_queneau_and_companions_martyrs: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 9, date: 2 },
+      martyrology: ['jean_robert_queneau_martyr', 'companions_martyrs'],
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    john_chrysostom_bishop: {
+      dateDef: { month: 9, date: 12 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    maurilius_of_angers_bishop_second_patron_of_the_diocese_of_angers: {
+      precedence: Precedences.ProperMemorial_SecondPatron_11a,
+      dateDef: { month: 9, date: 13 },
+      martyrology: [
+        {
+          id: 'maurilius_of_angers_bishop',
+          titles: { append: [PatronTitle.SecondPatronOfTheDiocese] },
+        },
+      ],
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    maurice_of_agaunum_and_companions_martyrs_patron_of_the_diocese_of_angers: {
+      precedence: Precedences.ProperFeast_PrincipalPatronOfADiocese_8a,
+      dateDef: { month: 9, date: 22 },
+      martyrology: [
+        {
+          id: 'maurice_of_agaunum_martyr',
+          titles: { append: [PatronTitle.PatronOfTheDiocese] },
+        },
+        {
+          id: 'companions_martyrs',
+          titles: { append: [PatronTitle.PatronOfTheDiocese] },
+        },
+      ],
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    florentius_of_anjou_abbot: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 9, date: 25 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    rene_goupil_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 9, date: 26 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    john_paul_ii_pope: {
+      dateDef: { month: 10, date: 21 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france: {
+      precedence: Precedences.ProperFeast_DedicationOfTheCathedralChurch_8b,
+      dateDef: { month: 10, date: 22 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    all_holy_bishops_of_the_diocese_of_angers: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 11, date: 12 },
+    },
+
+    // src: mr_fr_2022_ed3_angers
+    josaphat_kuntsevych_bishop: {
+      dateDef: { month: 11, date: 13 },
+    },
+  };
+}

--- a/rites/roman1969/src/particular-calendars/index.ts
+++ b/rites/roman1969/src/particular-calendars/index.ts
@@ -19,6 +19,7 @@ import { England } from './england';
 import { Europe } from './europe';
 import { Finland } from './finland';
 import { France } from './france';
+import { France_Angers } from './france.angers';
 import { France_Coutances } from './france.coutances';
 import { France_Lyon } from './france.lyon';
 import { France_Paris } from './france.paris';
@@ -82,6 +83,7 @@ export const particularCalendars: Record<string, typeof CalendarDef> = {
   Europe,
   Finland,
   France,
+  France_Angers,
   France_Coutances,
   France_Lyon,
   France_Paris,


### PR DESCRIPTION
**Sources:**
- [**Proper of the diocese of Angers, France** - 3nd edition, 2022](https://foi.diocese49.org/IMG/pdf/2022-09-28_missel_propre_format_a5_.pdf).
- https://www.diocese49.org/mon-diocese/les-saints-de-lanjou/

Luckily, all the liturgical books from this diocese are fully downloadable on their website (missal, lectionary, breviary): https://foi.diocese49.org/calendrier-et-livres-propres-de-l-eglise-d-angers
