### PR TITLE
feat(calendar): add a romcal option to promote optional memorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ const romcal = new Romcal({
   epiphanyOnSunday: true | false, // Epiphany always a Sunday (between January 2 - 8), or on January 6
   corpusChristiOnSunday: true | false, // Corpus Christi always a Sunday, or the Thursday after Trinity Sunday
   ascensionOnSunday: true | false, // Ascension always a Sunday, or the 40th day of Easter (a Thursday)
+  elevatedMemorialIds: ['john_paul_ii_pope', 'our_lady_of_fatima'], // List of optional memorials to be elevated to mandatory memorials
 });
 ```
 

--- a/rites/roman1969/src/constants/general-calendar-names.ts
+++ b/rites/roman1969/src/constants/general-calendar-names.ts
@@ -1,2 +1,3 @@
 export const PROPER_OF_TIME_NAME = 'ProperOfTime';
 export const GENERAL_ROMAN_NAME = 'GeneralRoman';
+export const GENERAL_ROMAN_ID = 'general_roman';

--- a/rites/roman1969/src/models/config.ts
+++ b/rites/roman1969/src/models/config.ts
@@ -40,6 +40,8 @@ export class RomcalConfig implements IRomcalConfig {
 
   ascensionOnSunday: boolean;
 
+  elevatedMemorialIds: string[] = [];
+
   easterCalculationType: EasterCalculationType;
 
   readonly scope: CalendarScope;
@@ -91,6 +93,8 @@ export class RomcalConfig implements IRomcalConfig {
       config?.corpusChristiOnSunday ?? this.localizedCalendar?.particularConfig.corpusChristiOnSunday ?? true;
     this.ascensionOnSunday =
       config?.ascensionOnSunday ?? this.localizedCalendar?.particularConfig.ascensionOnSunday ?? false;
+
+    this.elevatedMemorialIds = config?.elevatedMemorialIds ?? [];
 
     const localeObj: Locale | undefined = this.localizedCalendar?.i18n ?? locale;
     this.localeId = localeObj?.id ? sanitizeLocaleId(localeObj.id) : 'dev';
@@ -200,6 +204,7 @@ export class RomcalConfig implements IRomcalConfig {
       epiphanyOnSunday: this.epiphanyOnSunday,
       corpusChristiOnSunday: this.corpusChristiOnSunday,
       ascensionOnSunday: this.ascensionOnSunday,
+      elevatedMemorialIds: this.elevatedMemorialIds,
       localeId: this.localeId,
       calendarName: this.calendarName,
       easterCalculationType: this.easterCalculationType,

--- a/rites/roman1969/src/models/liturgical-day-def.ts
+++ b/rites/roman1969/src/models/liturgical-day-def.ts
@@ -1,6 +1,6 @@
 import { Color, Colors } from '../constants/colors';
 import { ProperCycles } from '../constants/cycles';
-import { GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
+import { GENERAL_ROMAN_ID, GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
 import { isMartyr } from '../constants/martyrology-metadata';
 import { Period } from '../constants/periods';
 import { Precedence, Precedences } from '../constants/precedences';
@@ -126,20 +126,28 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
       ? config.liturgicalDayDef[id]
       : undefined;
 
-    if (!input.dateDef && !previousDef) {
+    if (input.dateDef) {
+      this.dateDef = input.dateDef;
+    } else if (previousDef && previousDef.dateDef) {
+      this.dateDef = previousDef.dateDef;
+    } else {
       throw new Error(`In the '${fromCalendarId}' calendar, the property 'dateDef' for '${id}' must be defined.`);
     }
-    // TODO: refactor this to avoid non-null assertion
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.dateDef = input.dateDef ?? previousDef!.dateDef;
 
     this.dateExceptions = safeWrapArray(input.dateExceptions) ?? (previousDef ? previousDef.dateExceptions : []);
 
-    if (!input.precedence && !previousDef) {
+    if (input.precedence) {
+      this.precedence = input.precedence;
+    } else if (previousDef?.precedence) {
+      this.precedence = previousDef.precedence;
+    } else {
       throw new Error(`In the '${fromCalendarId}' calendar, the property 'precedence' for '${id}' must be defined.`);
     }
-    // eslint-disable-next-line  @typescript-eslint/no-non-null-assertion
-    this.precedence = input.precedence ?? previousDef!.precedence;
+
+    if (this.precedence === Precedences.OptionalMemorial_12 && this.#config.elevatedMemorialIds.includes(this.id)) {
+      this.precedence =
+        fromCalendarId === GENERAL_ROMAN_ID ? Precedences.GeneralMemorial_10 : Precedences.ProperMemorial_11b;
+    }
 
     this.rank = LiturgicalDayDef.precedenceToRank(this.precedence, id);
 

--- a/rites/roman1969/src/types/config.ts
+++ b/rites/roman1969/src/types/config.ts
@@ -39,6 +39,28 @@ export interface BaseRomcalConfig {
   readonly ascensionOnSunday?: boolean;
 
   /**
+   * The `elevatedMemorialIds` is a list of optional liturgical memorials that are to be elevated
+   * to the rank of mandatory memorials within the liturgical calendar.
+   * Each ID in the list corresponds to a specific optional memorial that, according
+   * to particular liturgical norms or decisions, must be celebrated as a mandatory memorial.
+   *
+   * Note:
+   * - If multiple optional memorials occur on the same day, and one of them is elevated,
+   *   then only the elevated memorial will be retained in the generated calendar. The other
+   *   optional memorials are removed, as the elevated (mandatory) memorial takes precedence over
+   *   the others.
+   * - If multiple memorials are elevated for the same day, only the first elevated memorial
+   *   defined in the calendar will be retained, as there can only be one mandatory memorial on a
+   *   given liturgical day.
+   *
+   * Example:
+   * ```ts
+   * elevatedMemorialIds = ['john_paul_ii_pope', 'our_lady_of_fatima'];
+   * ```
+   */
+  readonly elevatedMemorialIds?: string[];
+
+  /**
    * Determines if the date of Easter is calculated using the Gregorian calendar or the Julian calendar.
    */
   readonly easterCalculationType: EasterCalculationType;


### PR DESCRIPTION
The `elevatedMemorialIds` is a list of optional liturgical memorials that are to be elevated to the rank of mandatory memorials within the liturgical calendar, for a specific calendar.

Each ID in the list corresponds to a specific optional memorial that, according to particular liturgical norms or decisions, must be celebrated as a mandatory memorial.

```ts
const romcal = new Romcal({
  // List of optional memorials to be elevated to mandatory memorials
  elevatedMemorialIds: ['john_paul_ii_pope', 'our_lady_of_fatima'],
});
```

Note:
- If multiple optional memorials occur on the same day, and one of them is elevated, then only the elevated memorial will be retained in the generated calendar. The other optional memorials are removed, as the elevated (mandatory) memorial takes precedence over the others.
- If multiple memorials are elevated for the same day, only the first elevated memorial defined in the calendar will be retained, as there can only be one mandatory memorial on a given liturgical day.
