### PR TITLE
feat(calendar): add the initial Commons metadata

### DIFF
--- a/rites/roman1969/__tests__/calendar-builder.test.ts
+++ b/rites/roman1969/__tests__/calendar-builder.test.ts
@@ -15,6 +15,7 @@ import {
   Season,
 } from '@src/rite-roman1969';
 
+import { CommonDefinition } from '../src/constants/commons';
 import { Precedences } from '../src/constants/precedences';
 import { dateDifference } from '../src/utils/dates';
 
@@ -309,6 +310,24 @@ describe('Testing calendar generation functions', () => {
     // eslint-disable-next-line jest/expect-expect
     test('Testing calendar metadata in a liturgical scope, from 2010 to 2050', async () => {
       await testCalendarMetadata('liturgical');
+    });
+  });
+
+  describe('Testing Commons definition property', () => {
+    test('Saints Basil and Gregory Nazianzen have no Commons definition', async () => {
+      const allSaintsInGeneralCalendar: LiturgicalDay = (await new Romcal().getOneLiturgicalDay(
+        'basil_the_great_and_gregory_nazianzen_bishops'
+      ))!;
+      expect(allSaintsInGeneralCalendar.commonsDef).toEqual([CommonDefinition.None]);
+    });
+    test('Hilary of Poitiers has a Commons definition with two items', async () => {
+      const allSaintsInGeneralCalendar: LiturgicalDay = (await new Romcal().getOneLiturgicalDay(
+        'hilary_of_poitiers_bishop'
+      ))!;
+      expect(allSaintsInGeneralCalendar.commonsDef).toEqual([
+        CommonDefinition.Bishops,
+        CommonDefinition.DoctorsOfTheChurch,
+      ]);
     });
   });
 

--- a/rites/roman1969/src/constants/commons.ts
+++ b/rites/roman1969/src/constants/commons.ts
@@ -1,0 +1,96 @@
+export enum Common {
+  // No common
+  None = 'None',
+
+  // Dedication of a Church
+  DedicationAnniversary_Inside = 'DedicationAnniversary_Inside',
+  DedicationAnniversary_Outside = 'DedicationAnniversary_Outside',
+
+  // Blessed Virgin Mary
+  BlessedVirginMary_OrdinaryTime = 'BlessedVirginMary_OrdinaryTime',
+  BlessedVirginMary_Advent = 'BlessedVirginMary_Advent',
+  BlessedVirginMary_Christmas = 'BlessedVirginMary_Christmas',
+  BlessedVirginMary_Easter = 'BlessedVirginMary_Easter',
+
+  // Martyrs
+  Martyrs_OutsideEaster_Several = 'Martyrs_OutsideEaster_Several',
+  Martyrs_OutsideEaster_One = 'Martyrs_OutsideEaster_One',
+  Martyrs_Easter_Several = 'Martyrs_Easter_Several',
+  Martyrs_Easter_One = 'Martyrs_Easter_One',
+  Martyrs_Missionary_Several = 'Martyrs_Missionary_Several',
+  Martyrs_Missionary_One = 'Martyrs_Missionary_One',
+  Martyrs_Virgin = 'Martyrs_Virgin',
+  Martyrs_Woman = 'Martyrs_Woman',
+
+  // Pastors
+  Pastors_PopeOrBishop = 'Pastors_PopeOrBishop',
+  Pastors_Bishop = 'Pastors_Bishop',
+  Pastors_Several = 'Pastors_Several',
+  Pastors_One = 'Pastors_One',
+  Pastors_Founder_One = 'Pastors_Founder_One',
+  Pastors_Founder_Several = 'Pastors_Founder_Several',
+  Pastors_Missionary = 'Pastors_Missionary',
+
+  // Doctors of the Church
+  DoctorsOfTheChurch = 'DoctorsOfTheChurch',
+
+  // Virgins
+  Virgins_Several = 'Virgins_Several',
+  Virgins_One = 'Virgins_One',
+
+  // Holy Men and Women
+  Saints_All_Several = 'Saints_All_Several',
+  Saints_All_One = 'Saints_All_One',
+  Saints_Abbot = 'Saints_Abbot',
+  Saint_Monk = 'Saint_Monk',
+  Saints_Nun = 'Saints_Nun',
+  Saints_Religious = 'Saints_Religious',
+  Saints_MercyWorks = 'Saints_MercyWorks',
+  Saints_Educators = 'Saints_Educators',
+  Saints_HolyWomen = 'Saints_HolyWomen',
+}
+
+/**
+ * The **CommonDefinition** refers to a simplified version of the **Commons** enum.
+ * To be used in the martyrology metadata.
+ */
+export enum CommonDefinition {
+  // No common
+  None = 'None',
+
+  // Dedication of a Church
+  DedicationAnniversary_Inside = 'DedicationAnniversary_Inside',
+  DedicationAnniversary_Outside = 'DedicationAnniversary_Outside',
+
+  // Blessed Virgin Mary
+  BlessedVirginMary = 'BlessedVirginMary',
+
+  // Martyrs
+  Martyrs = 'Martyrs',
+  MissionaryMartyrs = 'MissionaryMartyrs',
+  VirginMartyrs = 'VirginMartyrs',
+  WomanMartyrs = 'WomanMartyrs',
+
+  // Pastors
+  Pastors = 'Pastors',
+  Popes = 'PopeOrBishop',
+  Bishops = 'Bishops',
+  Founders = 'Founders',
+  Missionaries = 'Missionaries',
+
+  // Doctors of the Church
+  DoctorsOfTheChurch = 'DoctorsOfTheChurch',
+
+  // Virgins
+  Virgins = 'Virgins',
+
+  // Holy Men and Women
+  Saints = 'Saints',
+  Abbots = 'Abbots',
+  Monks = 'Monks',
+  Nuns = 'Nuns',
+  Religious = 'Religious',
+  MercyWorkers = 'MercyWorkers',
+  Educators = 'Educators',
+  HolyWomen = 'HolyWomen',
+}

--- a/rites/roman1969/src/general-calendar/proper-of-saints.ts
+++ b/rites/roman1969/src/general-calendar/proper-of-saints.ts
@@ -22,7 +22,7 @@ export class GeneralRoman extends CalendarDef {
     basil_the_great_and_gregory_nazianzen_bishops: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 2 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['basil_the_great_bishop', 'gregory_nazianzen_bishop'],
     },
 
@@ -30,35 +30,35 @@ export class GeneralRoman extends CalendarDef {
     most_holy_name_of_jesus: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 3 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     raymond_of_penyafort_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 7 },
-      commons: Common.Pastors,
+      commonsDef: Common.Pastors,
     },
 
     // src: mr_la_2008_ed3
     hilary_of_poitiers_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 13 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     anthony_of_egypt_abbot: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 17 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     fabian_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 20 },
-      commons: [Common.Martyrs, Common.Popes],
+      commonsDef: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
@@ -66,7 +66,7 @@ export class GeneralRoman extends CalendarDef {
     sebastian_of_milan_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 20 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       colors: Colors.Red,
     },
 
@@ -74,7 +74,7 @@ export class GeneralRoman extends CalendarDef {
     agnes_of_rome_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 21 },
-      commons: [Common.VirginMartyrs, Common.Virgins],
+      commonsDef: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -82,7 +82,7 @@ export class GeneralRoman extends CalendarDef {
     vincent_of_saragossa_deacon: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 22 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       colors: Colors.Red,
     },
 
@@ -90,14 +90,14 @@ export class GeneralRoman extends CalendarDef {
     francis_de_sales_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 24 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     conversion_of_saint_paul_the_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 1, date: 25 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -105,7 +105,7 @@ export class GeneralRoman extends CalendarDef {
     timothy_of_ephesus_and_titus_of_crete_bishops: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 26 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['timothy_of_ephesus_bishop', 'titus_of_crete_bishop'],
     },
 
@@ -113,21 +113,21 @@ export class GeneralRoman extends CalendarDef {
     angela_merici_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 27 },
-      commons: [Common.Virgins, Common.Educators],
+      commonsDef: [Common.Virgins, Common.Educators],
     },
 
     // src: mr_la_2008_ed3
     thomas_aquinas_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 28 },
-      commons: [Common.DoctorsOfTheChurch, Common.Pastors],
+      commonsDef: [Common.DoctorsOfTheChurch, Common.Pastors],
     },
 
     // src: mr_la_2008_ed3
     john_bosco_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 31 },
-      commons: [Common.Pastors, Common.Educators],
+      commonsDef: [Common.Pastors, Common.Educators],
     },
 
     // src: mr_la_2008_ed3
@@ -135,7 +135,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralLordFeast_5,
       // 02-02
       dateDef: { dateFn: 'presentationOfTheLord' },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -143,7 +143,7 @@ export class GeneralRoman extends CalendarDef {
     blaise_of_sebaste_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 3 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -151,14 +151,14 @@ export class GeneralRoman extends CalendarDef {
     ansgar_of_hamburg_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 3 },
-      commons: [Common.Missionaries, Common.Bishops],
+      commonsDef: [Common.Missionaries, Common.Bishops],
     },
 
     // src: mr_la_2008_ed3
     agatha_of_sicily_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 5 },
-      commons: [Common.VirginMartyrs, Common.Virgins],
+      commonsDef: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -166,7 +166,7 @@ export class GeneralRoman extends CalendarDef {
     paul_miki_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 6 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['paul_miki_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -175,35 +175,35 @@ export class GeneralRoman extends CalendarDef {
     jerome_emiliani: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 8 },
-      commons: Common.Educators,
+      commonsDef: Common.Educators,
     },
 
     // src: mr_la_2008_ed3
     josephine_bakhita_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 8 },
-      commons: Common.Virgins,
+      commonsDef: Common.Virgins,
     },
 
     // src: mr_la_2008_ed3
     scholastica_of_nursia_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 10 },
-      commons: [Common.Virgins, Common.Nuns],
+      commonsDef: [Common.Virgins, Common.Nuns],
     },
 
     // src: mr_la_2008_ed3
     our_lady_of_lourdes: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 11 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
     cyril_constantine_the_philosopher_monk_and_methodius_michael_of_thessaloniki_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 14 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['cyril_constantine_the_philosopher_monk', 'methodius_michael_of_thessaloniki_bishop'],
     },
 
@@ -211,21 +211,21 @@ export class GeneralRoman extends CalendarDef {
     seven_holy_founders_of_the_servite_order: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 17 },
-      commons: Common.Religious,
+      commonsDef: Common.Religious,
     },
 
     // src: mr_la_2008_ed3
     peter_damian_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 21 },
-      commons: [Common.DoctorsOfTheChurch, Common.Bishops],
+      commonsDef: [Common.DoctorsOfTheChurch, Common.Bishops],
     },
 
     // src: mr_la_2008_ed3
     chair_of_saint_peter_the_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 2, date: 22 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -233,7 +233,7 @@ export class GeneralRoman extends CalendarDef {
     polycarp_of_smyrna_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 23 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -242,21 +242,21 @@ export class GeneralRoman extends CalendarDef {
     gregory_of_narek_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 27 },
-      commons: [Common.DoctorsOfTheChurch, Common.Abbots],
+      commonsDef: [Common.DoctorsOfTheChurch, Common.Abbots],
     },
 
     // src: mr_la_2008_ed3
     casimir_of_poland: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 4 },
-      commons: [Common.Saints],
+      commonsDef: [Common.Saints],
     },
 
     // src: mr_la_2008_ed3
     perpetua_of_carthage_and_felicity_of_carthage_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 3, date: 7 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['perpetua_of_carthage_martyr', 'felicity_of_carthage_martyr'],
       colors: Colors.Red,
     },
@@ -265,28 +265,28 @@ export class GeneralRoman extends CalendarDef {
     john_of_god_duarte_cidade_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 8 },
-      commons: [Common.Religious, Common.MercyWorkers],
+      commonsDef: [Common.Religious, Common.MercyWorkers],
     },
 
     // src: mr_la_2008_ed3
     frances_of_rome_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 9 },
-      commons: [Common.HolyWomen, Common.Religious],
+      commonsDef: [Common.HolyWomen, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     patrick_of_ireland_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 17 },
-      commons: [Common.Missionaries, Common.Bishops],
+      commonsDef: [Common.Missionaries, Common.Bishops],
     },
 
     // src: mr_la_2008_ed3
     cyril_of_jerusalem_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 18 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
@@ -304,7 +304,7 @@ export class GeneralRoman extends CalendarDef {
           setDate: { dateFn: 'palmSunday', subtractDay: 1 },
         },
       ],
-      commons: Common.None,
+      commonsDef: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
@@ -313,7 +313,7 @@ export class GeneralRoman extends CalendarDef {
     turibius_of_mogrovejo_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 23 },
-      commons: Common.Bishops,
+      commonsDef: Common.Bishops,
     },
 
     // src: mr_la_2008_ed3
@@ -321,7 +321,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralSolemnity_3,
       // 03-25
       dateDef: { dateFn: 'annunciation' },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -329,35 +329,35 @@ export class GeneralRoman extends CalendarDef {
     francis_of_paola_hermit: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 2 },
-      commons: Common.Religious,
+      commonsDef: Common.Religious,
     },
 
     // src: mr_la_2008_ed3
     isidore_of_seville_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 4 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     vincent_ferrer_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 5 },
-      commons: Common.Missionaries,
+      commonsDef: Common.Missionaries,
     },
 
     // src: mr_la_2008_ed3
     john_baptist_de_la_salle_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 4, date: 7 },
-      commons: [Common.Pastors, Common.Educators],
+      commonsDef: [Common.Pastors, Common.Educators],
     },
 
     // src: mr_la_2008_ed3
     stanislaus_of_szczepanow_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 4, date: 11 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -365,7 +365,7 @@ export class GeneralRoman extends CalendarDef {
     martin_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 13 },
-      commons: [Common.Martyrs, Common.Popes],
+      commonsDef: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
@@ -373,14 +373,14 @@ export class GeneralRoman extends CalendarDef {
     anselm_of_canterbury_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 21 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     george_of_lydda_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 23 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       colors: Colors.Red,
     },
 
@@ -388,7 +388,7 @@ export class GeneralRoman extends CalendarDef {
     adalbert_of_prague_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 23 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -396,7 +396,7 @@ export class GeneralRoman extends CalendarDef {
     fidelis_of_sigmaringen_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 24 },
-      commons: [Common.Martyrs, Common.Pastors],
+      commonsDef: [Common.Martyrs, Common.Pastors],
       colors: Colors.Red,
     },
 
@@ -404,7 +404,7 @@ export class GeneralRoman extends CalendarDef {
     mark_evangelist: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 4, date: 25 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -412,7 +412,7 @@ export class GeneralRoman extends CalendarDef {
     peter_chanel_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 28 },
-      commons: [Common.Martyrs, Common.Missionaries],
+      commonsDef: [Common.Martyrs, Common.Missionaries],
       colors: Colors.Red,
     },
 
@@ -420,42 +420,42 @@ export class GeneralRoman extends CalendarDef {
     louis_grignion_de_montfort_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 28 },
-      commons: Common.Pastors,
+      commonsDef: Common.Pastors,
     },
 
     // src: mr_la_2008_ed3
     catherine_of_siena_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 4, date: 29 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     pius_v_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 30 },
-      commons: Common.Popes,
+      commonsDef: Common.Popes,
     },
 
     // src: mr_la_2008_ed3
     joseph_the_worker: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 1 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     athanasius_of_alexandria_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 5, date: 2 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     philip_and_james_apostles: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 5, date: 3 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['philip_apostle', 'james_apostle'],
       colors: Colors.Red,
     },
@@ -465,14 +465,14 @@ export class GeneralRoman extends CalendarDef {
     john_of_avila_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 10 },
-      commons: [Common.Pastors, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Pastors, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     nereus_of_terracina_and_achilleus_of_terracina_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 12 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['nereus_of_terracina_martyr', 'achilleus_of_terracina_martyr'],
       colors: Colors.Red,
     },
@@ -481,7 +481,7 @@ export class GeneralRoman extends CalendarDef {
     pancras_of_rome_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 12 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       colors: Colors.Red,
     },
 
@@ -489,14 +489,14 @@ export class GeneralRoman extends CalendarDef {
     our_lady_of_fatima: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 13 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
     matthias_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 5, date: 14 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -504,7 +504,7 @@ export class GeneralRoman extends CalendarDef {
     john_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 18 },
-      commons: [Common.Martyrs, Common.Popes],
+      commonsDef: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
@@ -512,14 +512,14 @@ export class GeneralRoman extends CalendarDef {
     bernardine_of_siena_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 20 },
-      commons: [Common.Missionaries, Common.Religious],
+      commonsDef: [Common.Missionaries, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     christopher_magallanes_priest_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 21 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['christopher_magallanes_priest', { id: 'companions_martyrs', count: 24 }],
       colors: Colors.Red,
     },
@@ -528,42 +528,42 @@ export class GeneralRoman extends CalendarDef {
     rita_of_cascia_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 22 },
-      commons: Common.Religious,
+      commonsDef: Common.Religious,
     },
 
     // src: mr_la_2008_ed3
     bede_the_venerable_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 25 },
-      commons: [Common.DoctorsOfTheChurch, Common.Monks],
+      commonsDef: [Common.DoctorsOfTheChurch, Common.Monks],
     },
 
     // src: mr_la_2008_ed3
     gregory_vii_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 25 },
-      commons: Common.Popes,
+      commonsDef: Common.Popes,
     },
 
     // src: mr_la_2008_ed3
     mary_magdalene_de_pazzi_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 25 },
-      commons: [Common.Virgins, Common.Religious],
+      commonsDef: [Common.Virgins, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     philip_neri_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 5, date: 26 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     augustine_of_canterbury_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 27 },
-      commons: [Common.Missionaries, Common.Bishops],
+      commonsDef: [Common.Missionaries, Common.Bishops],
     },
 
     // Added on 2019-01-25: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20190125_decreto-celebrazione-paolovi_en.html
@@ -571,14 +571,14 @@ export class GeneralRoman extends CalendarDef {
     paul_vi_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 29 },
-      commons: [Common.Popes],
+      commonsDef: [Common.Popes],
     },
 
     // src: mr_la_2008_ed3
     visitation_of_mary: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 5, date: 31 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_fr_2021_ed3, mr_it_2020_ed3
@@ -587,7 +587,7 @@ export class GeneralRoman extends CalendarDef {
       // The Monday, after Pentecost Sunday
       dateDef: { dateFn: 'maryMotherOfTheChurch' },
       properCycle: ProperCycles.ProperOfTime,
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
@@ -600,14 +600,14 @@ export class GeneralRoman extends CalendarDef {
       allowSimilarRankItems: true,
       colors: Colors.White,
       properCycle: ProperCycles.ProperOfTime,
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     justin_martyr: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 1 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -615,7 +615,7 @@ export class GeneralRoman extends CalendarDef {
     marcellinus_of_rome_and_peter_the_exorcist_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 2 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['marcellinus_of_rome_martyr', 'peter_the_exorcist_martyr'],
       colors: Colors.Red,
     },
@@ -624,7 +624,7 @@ export class GeneralRoman extends CalendarDef {
     charles_lwanga_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 3 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['charles_lwanga_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -633,7 +633,7 @@ export class GeneralRoman extends CalendarDef {
     boniface_of_mainz_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 5 },
-      commons: [Common.Martyrs, Common.Missionaries],
+      commonsDef: [Common.Martyrs, Common.Missionaries],
       colors: Colors.Red,
     },
 
@@ -641,21 +641,21 @@ export class GeneralRoman extends CalendarDef {
     norbert_of_xanten_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 6 },
-      commons: [Common.Bishops, Common.Religious],
+      commonsDef: [Common.Bishops, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     ephrem_the_syrian_deacon: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 9 },
-      commons: Common.DoctorsOfTheChurch,
+      commonsDef: Common.DoctorsOfTheChurch,
     },
 
     // src: mr_la_2008_ed3
     barnabas_apostle: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 11 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -663,35 +663,35 @@ export class GeneralRoman extends CalendarDef {
     anthony_of_padua_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 13 },
-      commons: [Common.Pastors, Common.DoctorsOfTheChurch, Common.Religious],
+      commonsDef: [Common.Pastors, Common.DoctorsOfTheChurch, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     romuald_of_ravenna_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 19 },
-      commons: Common.Abbots,
+      commonsDef: Common.Abbots,
     },
 
     // src: mr_la_2008_ed3
     aloysius_gonzaga_religious: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 21 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     paulinus_of_nola_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 22 },
-      commons: Common.Bishops,
+      commonsDef: Common.Bishops,
     },
 
     // src: mr_la_2008_ed3
     john_fisher_bishop_and_thomas_more_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 22 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['john_fisher_bishop', 'thomas_more_martyr'],
       colors: Colors.Red,
     },
@@ -703,7 +703,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralSolemnity_3,
       // 06-24
       dateDef: { dateFn: 'nativityOfJohnTheBaptist' },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -711,14 +711,14 @@ export class GeneralRoman extends CalendarDef {
     cyril_of_alexandria_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 27 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     irenaeus_of_lyon_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 28 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -729,7 +729,7 @@ export class GeneralRoman extends CalendarDef {
       dateDef: { dateFn: 'peterAndPaulApostles' },
       isHolyDayOfObligation: true,
       colors: Colors.Red,
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['peter_apostle', 'paul_apostle'],
     },
 
@@ -737,7 +737,7 @@ export class GeneralRoman extends CalendarDef {
     first_martyrs_of_the_holy_roman_church: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 30 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       colors: Colors.Red,
     },
 
@@ -745,7 +745,7 @@ export class GeneralRoman extends CalendarDef {
     thomas_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 7, date: 3 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -753,21 +753,21 @@ export class GeneralRoman extends CalendarDef {
     elizabeth_of_portugal: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 4 },
-      commons: Common.MercyWorkers,
+      commonsDef: Common.MercyWorkers,
     },
 
     // src: mr_la_2008_ed3
     anthony_zaccaria_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 5 },
-      commons: [Common.Pastors, Common.Educators, Common.Religious],
+      commonsDef: [Common.Pastors, Common.Educators, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     maria_goretti_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 6 },
-      commons: [Common.VirginMartyrs, Common.Virgins],
+      commonsDef: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -775,7 +775,7 @@ export class GeneralRoman extends CalendarDef {
     augustine_zhao_rong_priest_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 9 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['augustine_zhao_rong_priest', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -784,42 +784,42 @@ export class GeneralRoman extends CalendarDef {
     benedict_of_nursia_abbot: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 11 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     henry_ii_emperor: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 13 },
-      commons: Common.Saints,
+      commonsDef: Common.Saints,
     },
 
     // src: mr_la_2008_ed3
     camillus_de_lellis_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 14 },
-      commons: Common.MercyWorkers,
+      commonsDef: Common.MercyWorkers,
     },
 
     // src: mr_la_2008_ed3
     bonaventure_of_bagnoregio_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 15 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     our_lady_of_mount_carmel: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 16 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
     apollinaris_of_ravenna_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 20 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -827,35 +827,35 @@ export class GeneralRoman extends CalendarDef {
     lawrence_of_brindisi_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 21 },
-      commons: [Common.Pastors, Common.DoctorsOfTheChurch, Common.Religious],
+      commonsDef: [Common.Pastors, Common.DoctorsOfTheChurch, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     mary_magdalene: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 7, date: 22 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     bridget_of_sweden_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 23 },
-      commons: [Common.HolyWomen, Common.Religious],
+      commonsDef: [Common.HolyWomen, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     sharbel_makhluf_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 24 },
-      commons: [Common.Pastors, Common.Monks],
+      commonsDef: [Common.Pastors, Common.Monks],
     },
 
     // src: mr_la_2008_ed3
     james_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 7, date: 25 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -863,7 +863,7 @@ export class GeneralRoman extends CalendarDef {
     joachim_and_anne_parents_of_mary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 26 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['joachim_father_of_mary', 'anne_mother_of_mary'],
     },
 
@@ -872,7 +872,7 @@ export class GeneralRoman extends CalendarDef {
     martha_of_bethany_mary_of_bethany_and_lazarus_of_bethany: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 29 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['martha_of_bethany', 'mary_of_bethany', 'lazarus_of_bethany'],
     },
 
@@ -880,49 +880,49 @@ export class GeneralRoman extends CalendarDef {
     peter_chrysologus_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 30 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     ignatius_of_loyola_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 31 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     alphonsus_mary_liguori_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 1 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     eusebius_of_vercelli_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 2 },
-      commons: Common.Bishops,
+      commonsDef: Common.Bishops,
     },
 
     // src: mr_la_2008_ed3
     peter_julian_eymard_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 2 },
-      commons: [Common.Religious, Common.Pastors],
+      commonsDef: [Common.Religious, Common.Pastors],
     },
 
     // src: mr_la_2008_ed3
     john_mary_vianney_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 4 },
-      commons: Common.Pastors,
+      commonsDef: Common.Pastors,
     },
 
     // src: mr_la_2008_ed3
     dedication_of_the_basilica_of_saint_mary_major: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 5 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
@@ -930,7 +930,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralLordFeast_5,
       // 08-06
       dateDef: { dateFn: 'transfiguration' },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -938,7 +938,7 @@ export class GeneralRoman extends CalendarDef {
     sixtus_ii_pope_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 7 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['sixtus_ii_pope', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -947,21 +947,21 @@ export class GeneralRoman extends CalendarDef {
     cajetan_of_thiene_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 7 },
-      commons: [Common.Pastors, Common.Religious],
+      commonsDef: [Common.Pastors, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     dominic_de_guzman_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 8 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     teresa_benedicta_of_the_cross_stein_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 9 },
-      commons: [Common.Martyrs, Common.Virgins],
+      commonsDef: [Common.Martyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -969,7 +969,7 @@ export class GeneralRoman extends CalendarDef {
     lawrence_of_rome_deacon: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 8, date: 10 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -977,21 +977,21 @@ export class GeneralRoman extends CalendarDef {
     clare_of_assisi_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 11 },
-      commons: [Common.Virgins, Common.Nuns],
+      commonsDef: [Common.Virgins, Common.Nuns],
     },
 
     // src: mr_la_2008_ed3
     jane_frances_de_chantal_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 12 },
-      commons: Common.Religious,
+      commonsDef: Common.Religious,
     },
 
     // src: mr_la_2008_ed3
     pontian_i_pope_and_hippolytus_of_rome_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 13 },
-      commons: [Common.Martyrs, Common.Pastors],
+      commonsDef: [Common.Martyrs, Common.Pastors],
       martyrology: ['pontian_i_pope', 'hippolytus_of_rome_priest'],
       colors: Colors.Red,
     },
@@ -1000,7 +1000,7 @@ export class GeneralRoman extends CalendarDef {
     maximilian_mary_raymund_kolbe_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 14 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1009,7 +1009,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.ProperOfTimeSolemnity_2,
       // 08-15
       dateDef: { dateFn: 'assumption' },
-      commons: Common.None,
+      commonsDef: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
@@ -1018,49 +1018,49 @@ export class GeneralRoman extends CalendarDef {
     stephen_i_of_hungary: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 16 },
-      commons: Common.Saints,
+      commonsDef: Common.Saints,
     },
 
     // src: mr_la_2008_ed3
     john_eudes_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 19 },
-      commons: [Common.Pastors, Common.Religious],
+      commonsDef: [Common.Pastors, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     bernard_of_clairvaux_abbot: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 20 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     pius_x_pope: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 21 },
-      commons: [Common.Popes],
+      commonsDef: [Common.Popes],
     },
 
     // src: mr_la_2008_ed3
     queenship_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 22 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     rose_of_lima_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 23 },
-      commons: Common.Virgins,
+      commonsDef: Common.Virgins,
     },
 
     // src: mr_la_2008_ed3
     bartholomew_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 8, date: 24 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1068,28 +1068,28 @@ export class GeneralRoman extends CalendarDef {
     louis_ix_of_france: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 25 },
-      commons: Common.Saints,
+      commonsDef: Common.Saints,
     },
 
     // src: mr_la_2008_ed3
     joseph_of_calasanz_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 25 },
-      commons: [Common.Educators, Common.Pastors],
+      commonsDef: [Common.Educators, Common.Pastors],
     },
 
     // src: mr_la_2008_ed3
     monica_of_hippo: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 27 },
-      commons: Common.HolyWomen,
+      commonsDef: Common.HolyWomen,
     },
 
     // src: mr_la_2008_ed3
     augustine_of_hippo_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 28 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
@@ -1098,7 +1098,7 @@ export class GeneralRoman extends CalendarDef {
       // in the name of this memorial. Therefore, we explicitly specify the red color, but omit the title of Martyr.
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 29 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1106,35 +1106,35 @@ export class GeneralRoman extends CalendarDef {
     gregory_i_the_great_pope: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 3 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     nativity_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 9, date: 8 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     peter_claver_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 9 },
-      commons: [Common.Pastors, Common.MercyWorkers],
+      commonsDef: [Common.Pastors, Common.MercyWorkers],
     },
 
     // src: mr_la_2008_ed3
     most_holy_name_of_mary: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 12 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     john_chrysostom_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 13 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
@@ -1142,7 +1142,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralLordFeast_5,
       // 09-14
       dateDef: { dateFn: 'exaltationOfTheHolyCross' },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1150,14 +1150,14 @@ export class GeneralRoman extends CalendarDef {
     our_lady_of_sorrows: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 15 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     cornelius_i_pope_and_cyprian_of_carthage_bishop_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 16 },
-      commons: [Common.Martyrs, Common.Pastors],
+      commonsDef: [Common.Martyrs, Common.Pastors],
       martyrology: ['cornelius_i_pope', 'cyprian_of_carthage_bishop'],
       colors: Colors.Red,
     },
@@ -1167,21 +1167,21 @@ export class GeneralRoman extends CalendarDef {
     hildegard_of_bingen_abbess: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 17 },
-      commons: [Common.Virgins, Common.Nuns],
+      commonsDef: [Common.Virgins, Common.Nuns],
     },
 
     // src: mr_la_2008_ed3
     robert_bellarmine_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 17 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     januarius_i_of_benevento_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 19 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -1189,7 +1189,7 @@ export class GeneralRoman extends CalendarDef {
     andrew_kim_tae_gon_priest_paul_chong_ha_sang_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 20 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['andrew_kim_tae_gon_priest', 'paul_chong_ha_sang_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -1198,7 +1198,7 @@ export class GeneralRoman extends CalendarDef {
     matthew_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 9, date: 21 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1206,14 +1206,14 @@ export class GeneralRoman extends CalendarDef {
     pius_francesco_forgione_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 23 },
-      commons: [Common.Pastors, Common.Religious],
+      commonsDef: [Common.Pastors, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     cosmas_of_cilicia_and_damian_of_cilicia_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 26 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['cosmas_of_cilicia_martyr', 'damian_of_cilicia_martyr'],
       colors: Colors.Red,
     },
@@ -1222,14 +1222,14 @@ export class GeneralRoman extends CalendarDef {
     vincent_de_paul_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 27 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     wenceslaus_i_of_bohemia_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 28 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       colors: Colors.Red,
     },
 
@@ -1237,7 +1237,7 @@ export class GeneralRoman extends CalendarDef {
     lawrence_ruiz_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 28 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['lawrence_ruiz_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -1246,7 +1246,7 @@ export class GeneralRoman extends CalendarDef {
     michael_gabriel_and_raphael_archangels: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 9, date: 29 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['michael_archangel', 'gabriel_archangel', 'raphael_archangel'],
     },
 
@@ -1254,28 +1254,28 @@ export class GeneralRoman extends CalendarDef {
     jerome_of_stridon_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 30 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 1 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     holy_guardian_angels: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 2 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     francis_of_assisi: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 4 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // Added on 2020-05-18: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20200518_decreto-celebrazione-santafaustina_en.html
@@ -1283,28 +1283,28 @@ export class GeneralRoman extends CalendarDef {
     faustina_kowalska_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 5 },
-      commons: [Common.Virgins, Common.Nuns],
+      commonsDef: [Common.Virgins, Common.Nuns],
     },
 
     // src: mr_la_2008_ed3
     bruno_of_cologne_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 6 },
-      commons: [Common.Monks, Common.Pastors],
+      commonsDef: [Common.Monks, Common.Pastors],
     },
 
     // src: mr_la_2008_ed3
     our_lady_of_the_rosary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 7 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     denis_of_paris_bishop_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 9 },
-      commons: Common.Martyrs,
+      commonsDef: Common.Martyrs,
       martyrology: ['denis_of_paris_bishop', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -1313,7 +1313,7 @@ export class GeneralRoman extends CalendarDef {
     john_leonardi_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 9 },
-      commons: [Common.Missionaries, Common.MercyWorkers],
+      commonsDef: [Common.Missionaries, Common.MercyWorkers],
     },
 
     // Added on 2014-05-29: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20140529_decreto-calendario-generale-gxxiii-gpii_en.html
@@ -1321,14 +1321,14 @@ export class GeneralRoman extends CalendarDef {
     john_xxiii_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 11 },
-      commons: Common.Popes,
+      commonsDef: Common.Popes,
     },
 
     // src: mr_la_2008_ed3
     callistus_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 14 },
-      commons: [Common.Martyrs, Common.Popes],
+      commonsDef: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
@@ -1336,28 +1336,28 @@ export class GeneralRoman extends CalendarDef {
     teresa_of_jesus_of_avila_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 15 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     hedwig_of_silesia_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 16 },
-      commons: [Common.Religious, Common.HolyWomen],
+      commonsDef: [Common.Religious, Common.HolyWomen],
     },
 
     // src: mr_la_2008_ed3
     margaret_mary_alacoque_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 16 },
-      commons: [Common.Virgins],
+      commonsDef: [Common.Virgins],
     },
 
     // src: mr_la_2008_ed3
     ignatius_of_antioch_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 17 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1365,7 +1365,7 @@ export class GeneralRoman extends CalendarDef {
     luke_evangelist: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 10, date: 18 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1373,7 +1373,7 @@ export class GeneralRoman extends CalendarDef {
     john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 19 },
-      commons: Common.MissionaryMartyrs,
+      commonsDef: Common.MissionaryMartyrs,
       martyrology: ['john_de_brebeuf_priest', 'isaac_jogues_priest', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -1382,7 +1382,7 @@ export class GeneralRoman extends CalendarDef {
     paul_of_the_cross_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 19 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // Added on 2014-05-29: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20140529_decreto-calendario-generale-gxxiii-gpii_en.html
@@ -1390,21 +1390,21 @@ export class GeneralRoman extends CalendarDef {
     john_paul_ii_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 22 },
-      commons: Common.Popes,
+      commonsDef: Common.Popes,
     },
 
     // src: mr_la_2008_ed3
     john_of_capistrano_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 23 },
-      commons: [Common.Missionaries, Common.Religious],
+      commonsDef: [Common.Missionaries, Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     anthony_mary_claret_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 24 },
-      commons: [Common.Missionaries, Common.Bishops],
+      commonsDef: [Common.Missionaries, Common.Bishops],
     },
 
     dedication_of_consecrated_churches_on_october_25: {
@@ -1425,7 +1425,7 @@ export class GeneralRoman extends CalendarDef {
     simon_and_jude_apostles: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 10, date: 28 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['simon_apostle', 'jude_apostle'],
       colors: Colors.Red,
     },
@@ -1435,7 +1435,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralSolemnity_3,
       // 11-01
       dateDef: { dateFn: 'allSaints' },
-      commons: Common.None,
+      commonsDef: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
@@ -1444,7 +1444,7 @@ export class GeneralRoman extends CalendarDef {
     commemoration_of_all_the_faithful_departed: {
       precedence: Precedences.GeneralSolemnity_3,
       dateDef: { month: 11, date: 2 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: [Colors.Purple, Colors.Black],
     },
 
@@ -1452,42 +1452,42 @@ export class GeneralRoman extends CalendarDef {
     martin_de_porres_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 3 },
-      commons: [Common.Religious],
+      commonsDef: [Common.Religious],
     },
 
     // src: mr_la_2008_ed3
     charles_borromeo_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 4 },
-      commons: Common.Bishops,
+      commonsDef: Common.Bishops,
     },
 
     // src: mr_la_2008_ed3
     dedication_of_the_lateran_basilica: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 11, date: 9 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     leo_i_the_great_pope: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 10 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     martin_of_tours_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 11 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     josaphat_kuntsevych_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 12 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1495,49 +1495,49 @@ export class GeneralRoman extends CalendarDef {
     albert_the_great_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 15 },
-      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     margaret_of_scotland: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 16 },
-      commons: Common.MercyWorkers,
+      commonsDef: Common.MercyWorkers,
     },
 
     // src: mr_la_2008_ed3
     gertrude_the_great_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 16 },
-      commons: [Common.Virgins, Common.Nuns],
+      commonsDef: [Common.Virgins, Common.Nuns],
     },
 
     // src: mr_la_2008_ed3
     elizabeth_of_hungary_religious: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 17 },
-      commons: Common.MercyWorkers,
+      commonsDef: Common.MercyWorkers,
     },
 
     // src: mr_la_2008_ed3
     dedication_of_the_basilicas_of_saints_peter_and_paul_apostles: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 18 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     presentation_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 21 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
     cecilia_of_rome_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 22 },
-      commons: [Common.VirginMartyrs, Common.Virgins],
+      commonsDef: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -1545,7 +1545,7 @@ export class GeneralRoman extends CalendarDef {
     clement_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 23 },
-      commons: [Common.Martyrs, Common.Popes],
+      commonsDef: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
@@ -1553,14 +1553,14 @@ export class GeneralRoman extends CalendarDef {
     columban_of_luxeuil_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 23 },
-      commons: [Common.Missionaries, Common.Abbots],
+      commonsDef: [Common.Missionaries, Common.Abbots],
     },
 
     // src: mr_la_2008_ed3
     andrew_dung_lac_priest_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 24 },
-      commons: Common.None,
+      commonsDef: Common.None,
       martyrology: ['andrew_dung_lac_priest', 'companions_martyrs'],
       colors: Colors.Red,
     },
@@ -1569,7 +1569,7 @@ export class GeneralRoman extends CalendarDef {
     catherine_of_alexandria_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 25 },
-      commons: [Common.VirginMartyrs, Common.Virgins],
+      commonsDef: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -1577,7 +1577,7 @@ export class GeneralRoman extends CalendarDef {
     andrew_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 11, date: 30 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1585,28 +1585,28 @@ export class GeneralRoman extends CalendarDef {
     francis_xavier_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 3 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     john_damascene_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 4 },
-      commons: [Common.Pastors, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Pastors, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     nicholas_of_myra_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 6 },
-      commons: Common.Bishops,
+      commonsDef: Common.Bishops,
     },
 
     // src: mr_la_2008_ed3
     ambrose_of_milan_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 7 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
@@ -1614,7 +1614,7 @@ export class GeneralRoman extends CalendarDef {
       precedence: Precedences.GeneralSolemnity_3,
       // 12-08
       dateDef: { dateFn: 'immaculateConceptionOfMary' },
-      commons: Common.None,
+      commonsDef: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
@@ -1623,7 +1623,7 @@ export class GeneralRoman extends CalendarDef {
     juan_diego_cuauhtlatoatzin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 9 },
-      commons: Common.Saints,
+      commonsDef: Common.Saints,
     },
 
     // Added on 2019-10-07: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20191007_decreto-celebrazione-verginediloreto_en.html
@@ -1631,28 +1631,28 @@ export class GeneralRoman extends CalendarDef {
     our_lady_of_loreto: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 10 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
     damasus_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 11 },
-      commons: Common.Popes,
+      commonsDef: Common.Popes,
     },
 
     // src: mr_la_2008_ed3
     our_lady_of_guadalupe: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 12 },
-      commons: Common.BlessedVirginMary,
+      commonsDef: Common.BlessedVirginMary,
     },
 
     // src: mr_la_2008_ed3
     lucy_of_syracuse_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 13 },
-      commons: [Common.VirginMartyrs, Common.Virgins],
+      commonsDef: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
@@ -1660,28 +1660,28 @@ export class GeneralRoman extends CalendarDef {
     john_of_the_cross_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 14 },
-      commons: Common.None,
+      commonsDef: Common.None,
     },
 
     // src: mr_la_2008_ed3
     peter_canisius_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 21 },
-      commons: [Common.Pastors, Common.DoctorsOfTheChurch],
+      commonsDef: [Common.Pastors, Common.DoctorsOfTheChurch],
     },
 
     // src: mr_la_2008_ed3
     john_of_kanty_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 23 },
-      commons: [Common.Pastors, Common.MercyWorkers],
+      commonsDef: [Common.Pastors, Common.MercyWorkers],
     },
 
     // src: mr_la_2008_ed3
     stephen_the_first_martyr: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 12, date: 26 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1689,7 +1689,7 @@ export class GeneralRoman extends CalendarDef {
     john_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 12, date: 27 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.White,
     },
 
@@ -1697,7 +1697,7 @@ export class GeneralRoman extends CalendarDef {
     holy_innocents_martyrs: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 12, date: 28 },
-      commons: Common.None,
+      commonsDef: Common.None,
       colors: Colors.Red,
     },
 
@@ -1705,7 +1705,7 @@ export class GeneralRoman extends CalendarDef {
     thomas_becket_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 29 },
-      commons: [Common.Martyrs, Common.Bishops],
+      commonsDef: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
@@ -1713,7 +1713,7 @@ export class GeneralRoman extends CalendarDef {
     sylvester_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 31 },
-      commons: [Common.Popes],
+      commonsDef: [Common.Popes],
     },
   };
 }

--- a/rites/roman1969/src/general-calendar/proper-of-saints.ts
+++ b/rites/roman1969/src/general-calendar/proper-of-saints.ts
@@ -1,4 +1,5 @@
 import { Colors } from '../constants/colors';
+import { CommonDefinition as Common } from '../constants/commons';
 import { ProperCycles } from '../constants/cycles';
 import { Precedences } from '../constants/precedences';
 import { CalendarDef } from '../models/calendar-def';
@@ -17,204 +18,278 @@ export class GeneralRoman extends CalendarDef {
   };
 
   inputs: Inputs = {
+    // src: mr_la_2008_ed3
     basil_the_great_and_gregory_nazianzen_bishops: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 2 },
+      commons: Common.None,
       martyrology: ['basil_the_great_bishop', 'gregory_nazianzen_bishop'],
     },
 
+    // src: mr_la_2008_ed3
     most_holy_name_of_jesus: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 3 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     raymond_of_penyafort_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 7 },
+      commons: Common.Pastors,
     },
 
+    // src: mr_la_2008_ed3
     hilary_of_poitiers_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 13 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     anthony_of_egypt_abbot: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 17 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     fabian_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 20 },
+      commons: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     sebastian_of_milan_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 20 },
+      commons: Common.Martyrs,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     agnes_of_rome_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 21 },
+      commons: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     vincent_of_saragossa_deacon: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 22 },
+      commons: Common.Martyrs,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     francis_de_sales_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 24 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     conversion_of_saint_paul_the_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 1, date: 25 },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     timothy_of_ephesus_and_titus_of_crete_bishops: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 26 },
+      commons: Common.None,
       martyrology: ['timothy_of_ephesus_bishop', 'titus_of_crete_bishop'],
     },
 
+    // src: mr_la_2008_ed3
     angela_merici_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 1, date: 27 },
+      commons: [Common.Virgins, Common.Educators],
     },
 
+    // src: mr_la_2008_ed3
     thomas_aquinas_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 28 },
+      commons: [Common.DoctorsOfTheChurch, Common.Pastors],
     },
 
+    // src: mr_la_2008_ed3
     john_bosco_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 1, date: 31 },
+      commons: [Common.Pastors, Common.Educators],
     },
 
+    // src: mr_la_2008_ed3
     presentation_of_the_lord: {
       precedence: Precedences.GeneralLordFeast_5,
       // 02-02
       dateDef: { dateFn: 'presentationOfTheLord' },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     blaise_of_sebaste_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 3 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     ansgar_of_hamburg_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 3 },
+      commons: [Common.Missionaries, Common.Bishops],
     },
 
+    // src: mr_la_2008_ed3
     agatha_of_sicily_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 5 },
+      commons: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     paul_miki_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 6 },
+      commons: Common.Martyrs,
       martyrology: ['paul_miki_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     jerome_emiliani: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 8 },
+      commons: Common.Educators,
     },
 
+    // src: mr_la_2008_ed3
     josephine_bakhita_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 8 },
+      commons: Common.Virgins,
     },
 
+    // src: mr_la_2008_ed3
     scholastica_of_nursia_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 10 },
+      commons: [Common.Virgins, Common.Nuns],
     },
 
+    // src: mr_la_2008_ed3
     our_lady_of_lourdes: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 11 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     cyril_constantine_the_philosopher_monk_and_methodius_michael_of_thessaloniki_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 14 },
+      commons: Common.None,
       martyrology: ['cyril_constantine_the_philosopher_monk', 'methodius_michael_of_thessaloniki_bishop'],
     },
 
+    // src: mr_la_2008_ed3
     seven_holy_founders_of_the_servite_order: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 17 },
+      commons: Common.Religious,
     },
 
+    // src: mr_la_2008_ed3
     peter_damian_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 21 },
+      commons: [Common.DoctorsOfTheChurch, Common.Bishops],
     },
 
+    // src: mr_la_2008_ed3
     chair_of_saint_peter_the_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 2, date: 22 },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     polycarp_of_smyrna_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 2, date: 23 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // Added on 2021-01-25: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20210125_decreto-dottori_en.html
+    // src: mr_fr_2021_ed3
     gregory_of_narek_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 2, date: 27 },
+      commons: [Common.DoctorsOfTheChurch, Common.Abbots],
     },
 
+    // src: mr_la_2008_ed3
     casimir_of_poland: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 4 },
+      commons: [Common.Saints],
     },
 
+    // src: mr_la_2008_ed3
     perpetua_of_carthage_and_felicity_of_carthage_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 3, date: 7 },
+      commons: Common.None,
       martyrology: ['perpetua_of_carthage_martyr', 'felicity_of_carthage_martyr'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     john_of_god_duarte_cidade_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 8 },
+      commons: [Common.Religious, Common.MercyWorkers],
     },
 
+    // src: mr_la_2008_ed3
     frances_of_rome_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 9 },
+      commons: [Common.HolyWomen, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     patrick_of_ireland_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 17 },
+      commons: [Common.Missionaries, Common.Bishops],
     },
 
+    // src: mr_la_2008_ed3
     cyril_of_jerusalem_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 18 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     joseph_spouse_of_mary: {
       precedence: Precedences.GeneralSolemnity_3,
       dateDef: { month: 3, date: 19 },
@@ -229,215 +304,293 @@ export class GeneralRoman extends CalendarDef {
           setDate: { dateFn: 'palmSunday', subtractDay: 1 },
         },
       ],
+      commons: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     turibius_of_mogrovejo_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 3, date: 23 },
+      commons: Common.Bishops,
     },
 
+    // src: mr_la_2008_ed3
     annunciation_of_the_lord: {
       precedence: Precedences.GeneralSolemnity_3,
       // 03-25
       dateDef: { dateFn: 'annunciation' },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     francis_of_paola_hermit: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 2 },
+      commons: Common.Religious,
     },
 
+    // src: mr_la_2008_ed3
     isidore_of_seville_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 4 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     vincent_ferrer_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 5 },
+      commons: Common.Missionaries,
     },
 
+    // src: mr_la_2008_ed3
     john_baptist_de_la_salle_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 4, date: 7 },
+      commons: [Common.Pastors, Common.Educators],
     },
 
+    // src: mr_la_2008_ed3
     stanislaus_of_szczepanow_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 4, date: 11 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     martin_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 13 },
+      commons: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     anselm_of_canterbury_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 21 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     george_of_lydda_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 23 },
+      commons: Common.Martyrs,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     adalbert_of_prague_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 23 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     fidelis_of_sigmaringen_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 24 },
+      commons: [Common.Martyrs, Common.Pastors],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     mark_evangelist: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 4, date: 25 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     peter_chanel_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 28 },
+      commons: [Common.Martyrs, Common.Missionaries],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     louis_grignion_de_montfort_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 28 },
+      commons: Common.Pastors,
     },
 
+    // src: mr_la_2008_ed3
     catherine_of_siena_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 4, date: 29 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     pius_v_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 4, date: 30 },
+      commons: Common.Popes,
     },
 
+    // src: mr_la_2008_ed3
     joseph_the_worker: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 1 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     athanasius_of_alexandria_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 5, date: 2 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     philip_and_james_apostles: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 5, date: 3 },
+      commons: Common.None,
       martyrology: ['philip_apostle', 'james_apostle'],
       colors: Colors.Red,
     },
 
+    // Added on 2021-01-25: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20210125_decreto-dottori_en.html
+    // src: mr_fr_2021_ed3
     john_of_avila_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 10 },
+      commons: [Common.Pastors, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     nereus_of_terracina_and_achilleus_of_terracina_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 12 },
+      commons: Common.Martyrs,
       martyrology: ['nereus_of_terracina_martyr', 'achilleus_of_terracina_martyr'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     pancras_of_rome_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 12 },
+      commons: Common.Martyrs,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     our_lady_of_fatima: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 13 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     matthias_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 5, date: 14 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     john_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 18 },
+      commons: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     bernardine_of_siena_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 20 },
+      commons: [Common.Missionaries, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     christopher_magallanes_priest_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 21 },
+      commons: Common.Martyrs,
       martyrology: ['christopher_magallanes_priest', { id: 'companions_martyrs', count: 24 }],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     rita_of_cascia_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 22 },
+      commons: Common.Religious,
     },
 
+    // src: mr_la_2008_ed3
     bede_the_venerable_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 25 },
+      commons: [Common.DoctorsOfTheChurch, Common.Monks],
     },
 
+    // src: mr_la_2008_ed3
     gregory_vii_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 25 },
+      commons: Common.Popes,
     },
 
+    // src: mr_la_2008_ed3
     mary_magdalene_de_pazzi_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 25 },
+      commons: [Common.Virgins, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     philip_neri_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 5, date: 26 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     augustine_of_canterbury_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 27 },
+      commons: [Common.Missionaries, Common.Bishops],
     },
 
+    // Added on 2019-01-25: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20190125_decreto-celebrazione-paolovi_en.html
+    // src: mr_fr_2021_ed3, mr_it_2020_ed3
     paul_vi_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 5, date: 29 },
+      commons: [Common.Popes],
     },
 
+    // src: mr_la_2008_ed3
     visitation_of_mary: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 5, date: 31 },
+      commons: Common.None,
     },
 
+    // src: mr_fr_2021_ed3, mr_it_2020_ed3
     mary_mother_of_the_church: {
       precedence: Precedences.GeneralMemorial_10,
       // The Monday, after Pentecost Sunday
       dateDef: { dateFn: 'maryMotherOfTheChurch' },
       properCycle: ProperCycles.ProperOfTime,
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     immaculate_heart_of_mary: {
       precedence: Precedences.GeneralMemorial_10,
       // The Saturday, after the Solemnity of the Most Sacred Heart of Jesus
@@ -447,595 +600,811 @@ export class GeneralRoman extends CalendarDef {
       allowSimilarRankItems: true,
       colors: Colors.White,
       properCycle: ProperCycles.ProperOfTime,
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     justin_martyr: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 1 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     marcellinus_of_rome_and_peter_the_exorcist_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 2 },
+      commons: Common.Martyrs,
       martyrology: ['marcellinus_of_rome_martyr', 'peter_the_exorcist_martyr'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     charles_lwanga_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 3 },
+      commons: Common.None,
       martyrology: ['charles_lwanga_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     boniface_of_mainz_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 5 },
+      commons: [Common.Martyrs, Common.Missionaries],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     norbert_of_xanten_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 6 },
+      commons: [Common.Bishops, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     ephrem_the_syrian_deacon: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 9 },
+      commons: Common.DoctorsOfTheChurch,
     },
 
+    // src: mr_la_2008_ed3
     barnabas_apostle: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 11 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     anthony_of_padua_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 13 },
+      commons: [Common.Pastors, Common.DoctorsOfTheChurch, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     romuald_of_ravenna_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 19 },
+      commons: Common.Abbots,
     },
 
+    // src: mr_la_2008_ed3
     aloysius_gonzaga_religious: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 21 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     paulinus_of_nola_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 22 },
+      commons: Common.Bishops,
     },
 
+    // src: mr_la_2008_ed3
     john_fisher_bishop_and_thomas_more_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 22 },
+      commons: Common.Martyrs,
       martyrology: ['john_fisher_bishop', 'thomas_more_martyr'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     nativity_of_john_the_baptist: {
       // Note: The title of Martyr is not indicated here, as Saint John the Baptist is not yet a Martyr at his birth.
       // Therefore, this celebration will be celebrated in white (src: GIRM, 308a).
       precedence: Precedences.GeneralSolemnity_3,
       // 06-24
       dateDef: { dateFn: 'nativityOfJohnTheBaptist' },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     cyril_of_alexandria_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 27 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     irenaeus_of_lyon_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 6, date: 28 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     peter_and_paul_apostles: {
       precedence: Precedences.GeneralSolemnity_3,
       // 06-29
       dateDef: { dateFn: 'peterAndPaulApostles' },
       isHolyDayOfObligation: true,
       colors: Colors.Red,
+      commons: Common.None,
       martyrology: ['peter_apostle', 'paul_apostle'],
     },
 
+    // src: mr_la_2008_ed3
     first_martyrs_of_the_holy_roman_church: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 6, date: 30 },
+      commons: Common.Martyrs,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     thomas_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 7, date: 3 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     elizabeth_of_portugal: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 4 },
+      commons: Common.MercyWorkers,
     },
 
+    // src: mr_la_2008_ed3
     anthony_zaccaria_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 5 },
+      commons: [Common.Pastors, Common.Educators, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     maria_goretti_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 6 },
+      commons: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     augustine_zhao_rong_priest_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 9 },
+      commons: Common.Martyrs,
       martyrology: ['augustine_zhao_rong_priest', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     benedict_of_nursia_abbot: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 11 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     henry_ii_emperor: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 13 },
+      commons: Common.Saints,
     },
 
+    // src: mr_la_2008_ed3
     camillus_de_lellis_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 14 },
+      commons: Common.MercyWorkers,
     },
 
+    // src: mr_la_2008_ed3
     bonaventure_of_bagnoregio_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 15 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     our_lady_of_mount_carmel: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 16 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     apollinaris_of_ravenna_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 20 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     lawrence_of_brindisi_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 21 },
+      commons: [Common.Pastors, Common.DoctorsOfTheChurch, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     mary_magdalene: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 7, date: 22 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     bridget_of_sweden_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 23 },
+      commons: [Common.HolyWomen, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     sharbel_makhluf_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 24 },
+      commons: [Common.Pastors, Common.Monks],
     },
 
+    // src: mr_la_2008_ed3
     james_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 7, date: 25 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     joachim_and_anne_parents_of_mary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 26 },
+      commons: Common.None,
       martyrology: ['joachim_father_of_mary', 'anne_mother_of_mary'],
     },
 
+    // Modified on 2021-01-26: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20210126_decreto-santi_en.html
+    // src: mr_fr_2021_ed3
     martha_of_bethany_mary_of_bethany_and_lazarus_of_bethany: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 29 },
+      commons: Common.None,
       martyrology: ['martha_of_bethany', 'mary_of_bethany', 'lazarus_of_bethany'],
     },
 
+    // src: mr_la_2008_ed3
     peter_chrysologus_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 7, date: 30 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     ignatius_of_loyola_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 7, date: 31 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     alphonsus_mary_liguori_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 1 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     eusebius_of_vercelli_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 2 },
+      commons: Common.Bishops,
     },
 
+    // src: mr_la_2008_ed3
     peter_julian_eymard_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 2 },
+      commons: [Common.Religious, Common.Pastors],
     },
 
+    // src: mr_la_2008_ed3
     john_mary_vianney_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 4 },
+      commons: Common.Pastors,
     },
 
+    // src: mr_la_2008_ed3
     dedication_of_the_basilica_of_saint_mary_major: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 5 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     transfiguration_of_the_lord: {
       precedence: Precedences.GeneralLordFeast_5,
       // 08-06
       dateDef: { dateFn: 'transfiguration' },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     sixtus_ii_pope_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 7 },
+      commons: Common.Martyrs,
       martyrology: ['sixtus_ii_pope', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     cajetan_of_thiene_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 7 },
+      commons: [Common.Pastors, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     dominic_de_guzman_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 8 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     teresa_benedicta_of_the_cross_stein_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 9 },
+      commons: [Common.Martyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     lawrence_of_rome_deacon: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 8, date: 10 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     clare_of_assisi_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 11 },
+      commons: [Common.Virgins, Common.Nuns],
     },
 
+    // src: mr_la_2008_ed3
     jane_frances_de_chantal_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 12 },
+      commons: Common.Religious,
     },
 
+    // src: mr_la_2008_ed3
     pontian_i_pope_and_hippolytus_of_rome_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 13 },
+      commons: [Common.Martyrs, Common.Pastors],
       martyrology: ['pontian_i_pope', 'hippolytus_of_rome_priest'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     maximilian_mary_raymund_kolbe_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 14 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     assumption_of_the_blessed_virgin_mary: {
       precedence: Precedences.ProperOfTimeSolemnity_2,
       // 08-15
       dateDef: { dateFn: 'assumption' },
+      commons: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     stephen_i_of_hungary: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 16 },
+      commons: Common.Saints,
     },
 
+    // src: mr_la_2008_ed3
     john_eudes_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 19 },
+      commons: [Common.Pastors, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     bernard_of_clairvaux_abbot: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 20 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     pius_x_pope: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 21 },
+      commons: [Common.Popes],
     },
 
+    // src: mr_la_2008_ed3
     queenship_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 22 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     rose_of_lima_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 23 },
+      commons: Common.Virgins,
     },
 
+    // src: mr_la_2008_ed3
     bartholomew_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 8, date: 24 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     louis_ix_of_france: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 25 },
+      commons: Common.Saints,
     },
 
+    // src: mr_la_2008_ed3
     joseph_of_calasanz_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 8, date: 25 },
+      commons: [Common.Educators, Common.Pastors],
     },
 
+    // src: mr_la_2008_ed3
     monica_of_hippo: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 27 },
+      commons: Common.HolyWomen,
     },
 
+    // src: mr_la_2008_ed3
     augustine_of_hippo_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 28 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     passion_of_saint_john_the_baptist: {
       // Note: here we consider Saint John the Baptist as a martyr, although the title of Martyr is not indicated
       // in the name of this memorial. Therefore, we explicitly specify the red color, but omit the title of Martyr.
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 8, date: 29 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     gregory_i_the_great_pope: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 3 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     nativity_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 9, date: 8 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     peter_claver_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 9 },
+      commons: [Common.Pastors, Common.MercyWorkers],
     },
 
+    // src: mr_la_2008_ed3
     most_holy_name_of_mary: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 12 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     john_chrysostom_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 13 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     exaltation_of_the_holy_cross: {
       precedence: Precedences.GeneralLordFeast_5,
       // 09-14
       dateDef: { dateFn: 'exaltationOfTheHolyCross' },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     our_lady_of_sorrows: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 15 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     cornelius_i_pope_and_cyprian_of_carthage_bishop_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 16 },
+      commons: [Common.Martyrs, Common.Pastors],
       martyrology: ['cornelius_i_pope', 'cyprian_of_carthage_bishop'],
       colors: Colors.Red,
     },
 
+    // Added on 2021-01-25: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20210125_decreto-dottori_en.html
+    // src: mr_fr_2021_ed3
     hildegard_of_bingen_abbess: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 17 },
+      commons: [Common.Virgins, Common.Nuns],
     },
 
+    // src: mr_la_2008_ed3
     robert_bellarmine_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 17 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     januarius_i_of_benevento_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 19 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     andrew_kim_tae_gon_priest_paul_chong_ha_sang_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 20 },
+      commons: Common.None,
       martyrology: ['andrew_kim_tae_gon_priest', 'paul_chong_ha_sang_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     matthew_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 9, date: 21 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     pius_francesco_forgione_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 23 },
+      commons: [Common.Pastors, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     cosmas_of_cilicia_and_damian_of_cilicia_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 26 },
+      commons: Common.Martyrs,
       martyrology: ['cosmas_of_cilicia_martyr', 'damian_of_cilicia_martyr'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     vincent_de_paul_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 27 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     wenceslaus_i_of_bohemia_martyr: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 28 },
+      commons: Common.Martyrs,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     lawrence_ruiz_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 9, date: 28 },
+      commons: Common.Martyrs,
       martyrology: ['lawrence_ruiz_martyr', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     michael_gabriel_and_raphael_archangels: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 9, date: 29 },
+      commons: Common.None,
       martyrology: ['michael_archangel', 'gabriel_archangel', 'raphael_archangel'],
     },
 
+    // src: mr_la_2008_ed3
     jerome_of_stridon_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 9, date: 30 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 1 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     holy_guardian_angels: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 2 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     francis_of_assisi: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 4 },
+      commons: Common.None,
     },
 
+    // Added on 2020-05-18: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20200518_decreto-celebrazione-santafaustina_en.html
+    // src: mr_fr_2021_ed3
     faustina_kowalska_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 5 },
+      commons: [Common.Virgins, Common.Nuns],
     },
 
+    // src: mr_la_2008_ed3
     bruno_of_cologne_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 6 },
+      commons: [Common.Monks, Common.Pastors],
     },
 
+    // src: mr_la_2008_ed3
     our_lady_of_the_rosary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 7 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     denis_of_paris_bishop_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 9 },
+      commons: Common.Martyrs,
       martyrology: ['denis_of_paris_bishop', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     john_leonardi_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 9 },
+      commons: [Common.Missionaries, Common.MercyWorkers],
     },
 
+    // Added on 2014-05-29: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20140529_decreto-calendario-generale-gxxiii-gpii_en.html
+    // src: mr_fr_2021_ed3, mr_it_2020_ed3
     john_xxiii_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 11 },
+      commons: Common.Popes,
     },
 
-    john_paul_ii_pope: {
-      precedence: Precedences.OptionalMemorial_12,
-      dateDef: { month: 10, date: 22 },
-    },
-
+    // src: mr_la_2008_ed3
     callistus_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 14 },
+      commons: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     teresa_of_jesus_of_avila_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 15 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     hedwig_of_silesia_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 16 },
+      commons: [Common.Religious, Common.HolyWomen],
     },
 
+    // src: mr_la_2008_ed3
     margaret_mary_alacoque_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 16 },
+      commons: [Common.Virgins],
     },
 
+    // src: mr_la_2008_ed3
     ignatius_of_antioch_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 10, date: 17 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     luke_evangelist: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 10, date: 18 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 19 },
+      commons: Common.MissionaryMartyrs,
       martyrology: ['john_de_brebeuf_priest', 'isaac_jogues_priest', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     paul_of_the_cross_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 19 },
+      commons: Common.None,
     },
 
+    // Added on 2014-05-29: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20140529_decreto-calendario-generale-gxxiii-gpii_en.html
+    // src: mr_fr_2021_ed3, mr_it_2020_ed3
+    john_paul_ii_pope: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 10, date: 22 },
+      commons: Common.Popes,
+    },
+
+    // src: mr_la_2008_ed3
     john_of_capistrano_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 23 },
+      commons: [Common.Missionaries, Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     anthony_mary_claret_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 24 },
+      commons: [Common.Missionaries, Common.Bishops],
     },
 
     dedication_of_consecrated_churches_on_october_25: {
@@ -1052,220 +1421,299 @@ export class GeneralRoman extends CalendarDef {
       isOptional: true,
     },
 
+    // src: mr_la_2008_ed3
     simon_and_jude_apostles: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 10, date: 28 },
+      commons: Common.None,
       martyrology: ['simon_apostle', 'jude_apostle'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     all_saints: {
       precedence: Precedences.GeneralSolemnity_3,
       // 11-01
       dateDef: { dateFn: 'allSaints' },
+      commons: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     commemoration_of_all_the_faithful_departed: {
       precedence: Precedences.GeneralSolemnity_3,
       dateDef: { month: 11, date: 2 },
+      commons: Common.None,
       colors: [Colors.Purple, Colors.Black],
     },
 
+    // src: mr_la_2008_ed3
     martin_de_porres_religious: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 3 },
+      commons: [Common.Religious],
     },
 
+    // src: mr_la_2008_ed3
     charles_borromeo_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 4 },
+      commons: Common.Bishops,
     },
 
+    // src: mr_la_2008_ed3
     dedication_of_the_lateran_basilica: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 11, date: 9 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     leo_i_the_great_pope: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 10 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     martin_of_tours_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 11 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     josaphat_kuntsevych_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 12 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     albert_the_great_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 15 },
+      commons: [Common.Bishops, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     margaret_of_scotland: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 16 },
+      commons: Common.MercyWorkers,
     },
 
+    // src: mr_la_2008_ed3
     gertrude_the_great_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 16 },
+      commons: [Common.Virgins, Common.Nuns],
     },
 
+    // src: mr_la_2008_ed3
     elizabeth_of_hungary_religious: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 17 },
+      commons: Common.MercyWorkers,
     },
 
+    // src: mr_la_2008_ed3
     dedication_of_the_basilicas_of_saints_peter_and_paul_apostles: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 18 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     presentation_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 21 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     cecilia_of_rome_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 22 },
+      commons: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     clement_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 23 },
+      commons: [Common.Martyrs, Common.Popes],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     columban_of_luxeuil_abbot: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 23 },
+      commons: [Common.Missionaries, Common.Abbots],
     },
 
+    // src: mr_la_2008_ed3
     andrew_dung_lac_priest_and_companions_martyrs: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 11, date: 24 },
+      commons: Common.None,
       martyrology: ['andrew_dung_lac_priest', 'companions_martyrs'],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     catherine_of_alexandria_virgin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 25 },
+      commons: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     andrew_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 11, date: 30 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     francis_xavier_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 3 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     john_damascene_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 4 },
+      commons: [Common.Pastors, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     nicholas_of_myra_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 6 },
+      commons: Common.Bishops,
     },
 
+    // src: mr_la_2008_ed3
     ambrose_of_milan_bishop: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 7 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     immaculate_conception_of_the_blessed_virgin_mary: {
       precedence: Precedences.GeneralSolemnity_3,
       // 12-08
       dateDef: { dateFn: 'immaculateConceptionOfMary' },
+      commons: Common.None,
       isHolyDayOfObligation: true,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     juan_diego_cuauhtlatoatzin: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 9 },
+      commons: Common.Saints,
     },
 
+    // Added on 2019-10-07: https://www.vatican.va/roman_curia/congregations/ccdds/documents/rc_con_ccdds_doc_20191007_decreto-celebrazione-verginediloreto_en.html
+    // src: mr_fr_2021_ed3, mr_it_2020_ed3
     our_lady_of_loreto: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 10 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     damasus_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 11 },
+      commons: Common.Popes,
     },
 
+    // src: mr_la_2008_ed3
     our_lady_of_guadalupe: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 12 },
+      commons: Common.BlessedVirginMary,
     },
 
+    // src: mr_la_2008_ed3
     lucy_of_syracuse_virgin: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 13 },
+      commons: [Common.VirginMartyrs, Common.Virgins],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     john_of_the_cross_priest: {
       precedence: Precedences.GeneralMemorial_10,
       dateDef: { month: 12, date: 14 },
+      commons: Common.None,
     },
 
+    // src: mr_la_2008_ed3
     peter_canisius_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 21 },
+      commons: [Common.Pastors, Common.DoctorsOfTheChurch],
     },
 
+    // src: mr_la_2008_ed3
     john_of_kanty_priest: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 23 },
+      commons: [Common.Pastors, Common.MercyWorkers],
     },
 
+    // src: mr_la_2008_ed3
     stephen_the_first_martyr: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 12, date: 26 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     john_apostle: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 12, date: 27 },
+      commons: Common.None,
       colors: Colors.White,
     },
 
+    // src: mr_la_2008_ed3
     holy_innocents_martyrs: {
       precedence: Precedences.GeneralFeast_7,
       dateDef: { month: 12, date: 28 },
+      commons: Common.None,
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     thomas_becket_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 29 },
+      commons: [Common.Martyrs, Common.Bishops],
       colors: Colors.Red,
     },
 
+    // src: mr_la_2008_ed3
     sylvester_i_pope: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 12, date: 31 },
+      commons: [Common.Popes],
     },
   };
 }

--- a/rites/roman1969/src/models/calendar-def.ts
+++ b/rites/roman1969/src/models/calendar-def.ts
@@ -129,6 +129,7 @@ export class CalendarDef implements BaseCalendarDef {
         allowSimilarRankItems: input.allowSimilarRankItems,
         customLocaleId: input.customLocaleId,
         isHolyDayOfObligation: input.isHolyDayOfObligation,
+        commonsDef: input.commonsDef,
         isOptional: input.isOptional,
         colors: input.colors,
         martyrology: input.martyrology,

--- a/rites/roman1969/src/models/liturgical-day-def.ts
+++ b/rites/roman1969/src/models/liturgical-day-def.ts
@@ -1,4 +1,5 @@
 import { Color, Colors } from '../constants/colors';
+import { CommonDefinition } from '../constants/commons';
 import { ProperCycles } from '../constants/cycles';
 import { GENERAL_ROMAN_ID, GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
 import { isMartyr } from '../constants/martyrology-metadata';
@@ -42,6 +43,8 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
   readonly precedence: Precedence;
 
   readonly rank: Rank;
+
+  readonly commonsDefinition: CommonDefinition[];
 
   readonly isHolyDayOfObligation: boolean;
 
@@ -147,6 +150,13 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
     if (this.precedence === Precedences.OptionalMemorial_12 && this.#config.elevatedMemorialIds.includes(this.id)) {
       this.precedence =
         fromCalendarId === GENERAL_ROMAN_ID ? Precedences.GeneralMemorial_10 : Precedences.ProperMemorial_11b;
+    }
+
+    if (isLiturgicalDayProperOfTimeInput(input)) {
+      this.commonsDefinition = previousDef?.commonsDefinition || [];
+    } else {
+      const commonsInput = input.commons ? ([] as CommonDefinition[]).concat(input.commons) : undefined;
+      this.commonsDefinition = commonsInput || previousDef?.commonsDefinition || [];
     }
 
     this.rank = LiturgicalDayDef.precedenceToRank(this.precedence, id);

--- a/rites/roman1969/src/models/liturgical-day-def.ts
+++ b/rites/roman1969/src/models/liturgical-day-def.ts
@@ -44,7 +44,7 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
 
   readonly rank: Rank;
 
-  readonly commonsDefinition: CommonDefinition[];
+  readonly commonsDef: CommonDefinition[];
 
   readonly isHolyDayOfObligation: boolean;
 
@@ -152,16 +152,16 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
         fromCalendarId === GENERAL_ROMAN_ID ? Precedences.GeneralMemorial_10 : Precedences.ProperMemorial_11b;
     }
 
-    if (isLiturgicalDayProperOfTimeInput(input)) {
-      this.commonsDefinition = previousDef?.commonsDefinition || [];
-    } else {
-      const commonsInput = input.commons ? ([] as CommonDefinition[]).concat(input.commons) : undefined;
-      this.commonsDefinition = commonsInput || previousDef?.commonsDefinition || [];
-    }
-
     this.rank = LiturgicalDayDef.precedenceToRank(this.precedence, id);
 
     this.allowSimilarRankItems = input.allowSimilarRankItems ?? previousDef?.allowSimilarRankItems ?? false;
+
+    if (isLiturgicalDayProperOfTimeInput(input)) {
+      this.commonsDef = previousDef?.commonsDef || [];
+    } else {
+      const commonsInput = input.commonsDef ? ([] as CommonDefinition[]).concat(input.commonsDef) : undefined;
+      this.commonsDef = commonsInput || previousDef?.commonsDef || [];
+    }
 
     this.isHolyDayOfObligation = input.isHolyDayOfObligation ?? previousDef?.isHolyDayOfObligation ?? false;
 
@@ -398,6 +398,9 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
 
       // rank
       ...(dayA.rank !== dayB.rank ? { rank: dayA.rank } : {}),
+
+      // commonsDef
+      ...(JSON.stringify(dayA.commonsDef) !== JSON.stringify(dayB.commonsDef) ? { commonsDef: dayA.commonsDef } : {}),
 
       // isHolyDayOfObligation
       ...(dayA.isHolyDayOfObligation !== dayB.isHolyDayOfObligation

--- a/rites/roman1969/src/models/liturgical-day.ts
+++ b/rites/roman1969/src/models/liturgical-day.ts
@@ -1,4 +1,5 @@
 import { Color } from '../constants/colors';
+import { CommonDefinition } from '../constants/commons';
 import { PROPER_OF_TIME_NAME } from '../constants/general-calendar-names';
 import { Period } from '../constants/periods';
 import { Precedence, Precedences } from '../constants/precedences';
@@ -52,6 +53,8 @@ export class LiturgicalDay implements BaseLiturgicalDay {
   readonly periods: Period[];
 
   readonly colors: Color[];
+
+  readonly commonsDef: CommonDefinition[];
 
   readonly martyrology: MartyrologyItem[];
 
@@ -120,6 +123,7 @@ export class LiturgicalDay implements BaseLiturgicalDay {
     this.precedence = def.precedence;
     this.rank = def.rank;
     this.allowSimilarRankItems = def.allowSimilarRankItems;
+    this.commonsDef = def.commonsDef;
     this.isHolyDayOfObligation = calendar.dayOfWeek === 0 ? true : def.isHolyDayOfObligation;
     this.isOptional = def.isOptional;
     this.i18nDef = def.i18nDef;

--- a/rites/roman1969/src/types/liturgical-day.ts
+++ b/rites/roman1969/src/types/liturgical-day.ts
@@ -1,6 +1,7 @@
 import { StringMap } from 'i18next';
 
 import { Color } from '../constants/colors';
+import { CommonDefinition } from '../constants/commons';
 import { ProperCycle } from '../constants/cycles';
 import { PatronTitle, Title } from '../constants/martyrology-metadata';
 import { MonthIndex } from '../constants/months';
@@ -505,6 +506,14 @@ export type LiturgicalDayInput = Partial<
   dateExceptions?: DateDefException | DateDefException[];
 
   /**
+   * The **Common** refers to a set of prayers, readings, and chants used for celebrating saints or
+   * feasts that belong to a specific category, such as martyrs, virgins, pastors, or the Blessed
+   * Virgin Mary.
+   * These prayers are used when no specific texts (Proper) are assigned for a particular feast day.
+   */
+  commons?: CommonDefinition | CommonDefinition[];
+
+  /**
    * The liturgical color(s) of the liturgical day.
    */
   colors?: Color | Color[];
@@ -577,6 +586,5 @@ export type LiturgyDayDiff = Pick<LiturgicalDayDef, 'fromCalendarId'> &
  * Check if the provided object is a [LiturgicalDayProperOfTimeInput] object
  * @param maybeObj
  */
-export const isLiturgicalDayProperOfTimeInput = (maybeObj: unknown): boolean => {
-  return typeof maybeObj === 'object' && Object.prototype.hasOwnProperty.call(maybeObj, 'periods');
-};
+export const isLiturgicalDayProperOfTimeInput = (maybeObj: unknown): maybeObj is LiturgicalDayProperOfTimeInput =>
+  typeof maybeObj === 'object' && Object.prototype.hasOwnProperty.call(maybeObj, 'periods');

--- a/rites/roman1969/src/types/liturgical-day.ts
+++ b/rites/roman1969/src/types/liturgical-day.ts
@@ -393,6 +393,14 @@ type LiturgicalDayRoot = {
   titles: RomcalTitles;
 
   /**
+   * The **Common** refers to a set of prayers, readings, and chants used for celebrating saints or
+   * feasts that belong to a specific category, such as martyrs, virgins, pastors, or the Blessed
+   * Virgin Mary.
+   * These prayers are used when no specific texts (Proper) are assigned for a particular feast day.
+   */
+  commonsDef?: CommonDefinition[];
+
+  /**
    * Cycle metadata of a liturgical day.
    */
   cycles: BaseCyclesMetadata;
@@ -511,7 +519,7 @@ export type LiturgicalDayInput = Partial<
    * Virgin Mary.
    * These prayers are used when no specific texts (Proper) are assigned for a particular feast day.
    */
-  commons?: CommonDefinition | CommonDefinition[];
+  commonsDef?: CommonDefinition | CommonDefinition[];
 
   /**
    * The liturgical color(s) of the liturgical day.


### PR DESCRIPTION
Related to https://github.com/romcal/romcal/issues/587.

This PR introduces two new enums to define the liturgical **_Commons_** for each liturgical day (if applicable):
- `Common`: Specifies precisely the liturgical _Common_ to use, taking into account, when applicable, the number of entities (one/several) and the liturgical season. This will be automatically calculated when generating the calendar (PR to follow) based on the `CommonDefinition` enum described below.
- `CommonDefinition`: A simplified version of the enum, to be used only in calendar definitions.

Some liturgical days do not have a defined _Common_ because a specific proper content (prayers, collects, etc.) is already provided in the missal. In such cases, the property `commons: Common.None` is proposed, to explicitly indicate that no _Common_ is to be used for that particular liturgical day.

This PR also adds the `commons` property to each element of the _General Roman Calendar_. The sources have been verified and updated based on the 3rd amended edition of the Roman Missal in Latin (2008), and on the latest versions of the Italian (2020) and French (2021) missals for sanctoral elements added after 2008. When multiple _commons_ are available for the same sanctoral entity, they are defined in Romcal following the exact order written in the Missal.

To-do for future PRs:
- Add the `commons` property to the final `LiturgicalDay` objects calculated and returned by Romcal, considering as mentioned earlier, the number of entities (one/several) and the liturgical season.
- Provide l10n for every value of this new `commons` property.
- Provide CLI tasks to check that commons are correctly defined for a calendar.

I initially considered defining this new property in the martyrology catalog. In fact, I began doing so before deciding to roll it back and define them only within the calendar definitions. In any case, if these _commons_ were defined in the catalog, some would still need to be defined in the calendar, especially for groups of people, since the recommended _commons_ can differ depending on whether a single person or a group is being commemorated. Additionally, by defining commons directly in the calendars, it prevents the issue of sharing _commons_ definitions between different proper calendars through the martyrology catalog, which could lead to cases where a _common_ is suggested in one proper calendar while another proper calendar omits it because a specific proper content is provided. Ultimately, defining the _Commons_ solely within the calendar simplifies the code that handles this metadata, makes the property easier to edit and review, and allows them to be strictly defined as indicated in the respective missals. 