### PR TITLE
feat(calendar): remove dedication_of_consecrated_churches from GRC

### DIFF
--- a/rites/roman1969/__tests__/calendar-builder.test.ts
+++ b/rites/roman1969/__tests__/calendar-builder.test.ts
@@ -1,4 +1,5 @@
 import { England_En } from '@dist/rite-roman1969/bundles/england';
+import { France_Fr } from '@dist/rite-roman1969/bundles/france';
 import { GeneralRoman_En } from '@dist/rite-roman1969/bundles/general-roman';
 import { Germany_En } from '@dist/rite-roman1969/bundles/germany';
 import { Hungary_En } from '@dist/rite-roman1969/bundles/hungary';
@@ -406,6 +407,28 @@ describe('Testing calendar generation functions', () => {
       const easter = calendar.find((item) => item.id === 'easter_sunday');
       expect(easter?.date).toEqual('2019-04-28');
     });
+  });
+});
+
+describe('Testing the alternativeTransferDateDefs property', () => {
+  it('should not have a dedication_of_consecrated_churches defined on the General Roman Calendar', async () => {
+    const calendar = Object.values(await new Romcal().generateCalendar(2024)).flat();
+    const day = calendar.find((item) => item.id === 'dedication_of_consecrated_churches');
+    expect(day).toBeUndefined();
+  });
+
+  it('should have a dedication_of_consecrated_churches defined on the calendar of France with an alternative transfert date', async () => {
+    const calendar = Object.values(await new Romcal({ localizedCalendar: France_Fr }).generateCalendar(2024)).flat();
+    const day = calendar.find((item) => item.id === 'dedication_of_consecrated_churches');
+    expect(day?.date).toEqual('2024-10-25');
+    expect(day?.alternativeTransferDateDefs).toEqual([{ dateDef: { month: 10, lastDayOfWeekInMonth: 0 } }]);
+  });
+
+  it('should have a dedication_of_consecrated_churches defined on the calendar of Slovakia with no alternative transfert date', async () => {
+    const calendar = Object.values(await new Romcal({ localizedCalendar: Slovakia_Sk }).generateCalendar(2024)).flat();
+    const day = calendar.find((item) => item.id === 'dedication_of_consecrated_churches');
+    expect(day?.date).toEqual('2024-10-26');
+    expect(day?.alternativeTransferDateDefs).toEqual([]);
   });
 });
 

--- a/rites/roman1969/src/general-calendar/proper-of-saints.ts
+++ b/rites/roman1969/src/general-calendar/proper-of-saints.ts
@@ -1407,20 +1407,6 @@ export class GeneralRoman extends CalendarDef {
       commonsDef: [Common.Missionaries, Common.Bishops],
     },
 
-    dedication_of_consecrated_churches_on_october_25: {
-      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
-      customLocaleId: 'dedication_of_consecrated_churches',
-      dateDef: { month: 10, date: 25 },
-      isOptional: true,
-    },
-
-    dedication_of_consecrated_churches_on_last_sunday_of_october: {
-      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
-      customLocaleId: 'dedication_of_consecrated_churches',
-      dateDef: { month: 10, lastDayOfWeekInMonth: 0 },
-      isOptional: true,
-    },
-
     // src: mr_la_2008_ed3
     simon_and_jude_apostles: {
       precedence: Precedences.GeneralFeast_7,

--- a/rites/roman1969/src/models/calendar-def.ts
+++ b/rites/roman1969/src/models/calendar-def.ts
@@ -125,6 +125,7 @@ export class CalendarDef implements BaseCalendarDef {
       {
         dateDef: input.dateDef,
         dateExceptions: input.dateExceptions,
+        alternativeTransferDateDefs: input.alternativeTransferDateDefs,
         precedence: input.precedence,
         allowSimilarRankItems: input.allowSimilarRankItems,
         customLocaleId: input.customLocaleId,

--- a/rites/roman1969/src/models/liturgical-day-def.ts
+++ b/rites/roman1969/src/models/liturgical-day-def.ts
@@ -16,6 +16,7 @@ import {
   DateDef,
   DateDefException,
   FromCalendarId,
+  FullDateDefinition,
   LiturgicalDayBundleInput,
   LiturgicalDayInput,
   LiturgicalDayProperOfTimeInput,
@@ -39,6 +40,8 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
   readonly dateDef: DateDef;
 
   readonly dateExceptions: DateDefException[];
+
+  readonly alternativeTransferDateDefs: FullDateDefinition[] = [];
 
   readonly precedence: Precedence;
 
@@ -138,6 +141,10 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
     }
 
     this.dateExceptions = safeWrapArray(input.dateExceptions) ?? (previousDef ? previousDef.dateExceptions : []);
+
+    this.alternativeTransferDateDefs = isLiturgicalDayProperOfTimeInput(input)
+      ? []
+      : ([] as FullDateDefinition[]).concat(input.alternativeTransferDateDefs || []) || [];
 
     if (input.precedence) {
       this.precedence = input.precedence;
@@ -391,6 +398,11 @@ export class LiturgicalDayDef implements BaseLiturgicalDayDef {
       // dateExceptions
       ...(JSON.stringify(dayA.dateExceptions) !== JSON.stringify(dayB.dateExceptions)
         ? { dateExceptions: dayA.dateExceptions }
+        : {}),
+
+      // alternativeTransferDateDefs
+      ...(JSON.stringify(dayA.alternativeTransferDateDefs) !== JSON.stringify(dayB.alternativeTransferDateDefs)
+        ? { alternativeTransferDateDefs: dayA.alternativeTransferDateDefs }
         : {}),
 
       // precedence

--- a/rites/roman1969/src/models/liturgical-day.ts
+++ b/rites/roman1969/src/models/liturgical-day.ts
@@ -11,6 +11,7 @@ import {
   DateDef,
   DateDefException,
   FromCalendarId,
+  FullDateDefinition,
   LiturgyDayDiff,
   RomcalCalendarMetadata,
   RomcalTitles,
@@ -35,6 +36,8 @@ export class LiturgicalDay implements BaseLiturgicalDay {
   readonly dateDef: DateDef;
 
   readonly dateExceptions: DateDefException[];
+
+  readonly alternativeTransferDateDefs: FullDateDefinition[];
 
   readonly precedence: Precedence;
 
@@ -120,6 +123,7 @@ export class LiturgicalDay implements BaseLiturgicalDay {
     this.date = date.toISOString().substring(0, 10);
     this.dateDef = def.dateDef;
     this.dateExceptions = def.dateExceptions;
+    this.alternativeTransferDateDefs = def.alternativeTransferDateDefs;
     this.precedence = def.precedence;
     this.rank = def.rank;
     this.allowSimilarRankItems = def.allowSimilarRankItems;

--- a/rites/roman1969/src/particular-calendars/belgium.ts
+++ b/rites/roman1969/src/particular-calendars/belgium.ts
@@ -48,6 +48,14 @@ export class Belgium extends CalendarDef {
       dateDef: { month: 9, date: 17 },
     },
 
+    // src: mr_fr_2021_ed3
+    dedication_of_consecrated_churches: {
+      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
+      dateDef: { month: 10, date: 25 },
+      alternativeTransferDateDefs: [{ dateDef: { month: 10, lastDayOfWeekInMonth: 0 } }],
+      isOptional: true,
+    },
+
     hubert_of_liege_bishop: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 11, date: 3 },

--- a/rites/roman1969/src/particular-calendars/canada.ts
+++ b/rites/roman1969/src/particular-calendars/canada.ts
@@ -196,8 +196,10 @@ export class Canada extends CalendarDef {
     },
 
     // src: mr_fr_2021_ed3
-    dedication_of_consecrated_churches_on_last_sunday_of_october: {
-      drop: true,
+    dedication_of_consecrated_churches: {
+      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
+      dateDef: { month: 10, date: 25 },
+      isOptional: true,
     },
   };
 }

--- a/rites/roman1969/src/particular-calendars/france.ts
+++ b/rites/roman1969/src/particular-calendars/france.ts
@@ -93,5 +93,13 @@ export class France extends CalendarDef {
       customLocaleId: 'therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin_copatroness_of_france',
       titles: { append: [PatronTitle.CopatronessOfFrance] },
     },
+
+    // src: mr_fr_2021_ed3
+    dedication_of_consecrated_churches: {
+      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
+      dateDef: { month: 10, date: 25 },
+      alternativeTransferDateDefs: [{ dateDef: { month: 10, lastDayOfWeekInMonth: 0 } }],
+      isOptional: true,
+    },
   };
 }

--- a/rites/roman1969/src/particular-calendars/poland.ts
+++ b/rites/roman1969/src/particular-calendars/poland.ts
@@ -350,8 +350,10 @@ export class Poland extends CalendarDef {
       dateDef: { month: 10, date: 23 },
     },
 
-    dedication_of_consecrated_churches_on_october_25: {
-      drop: true,
+    dedication_of_consecrated_churches: {
+      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
+      dateDef: { month: 10, lastDayOfWeekInMonth: 0 },
+      isOptional: true,
     },
 
     first_polish_martyrs: {

--- a/rites/roman1969/src/particular-calendars/slovakia.ts
+++ b/rites/roman1969/src/particular-calendars/slovakia.ts
@@ -110,12 +110,10 @@ export class Slovakia extends CalendarDef {
       dateDef: { month: 10, date: 25 },
     },
 
-    dedication_of_consecrated_churches_on_october_25: {
+    dedication_of_consecrated_churches: {
+      precedence: Precedences.ProperSolemnity_DedicationOfTheOwnChurch_4b,
       dateDef: { month: 10, date: 26 },
-    },
-
-    dedication_of_consecrated_churches_on_last_sunday_of_october: {
-      drop: true,
+      isOptional: true,
     },
 
     commemoration_of_all_the_faithful_departed: {

--- a/rites/roman1969/src/types/liturgical-day.ts
+++ b/rites/roman1969/src/types/liturgical-day.ts
@@ -282,9 +282,9 @@ export type MartyrologyItemRedefined = {
 };
 
 /**
- * Base object extended by other derived Liturgical Day objects
+ * Date definition of a liturgical day
  */
-type LiturgicalDayRoot = {
+export type FullDateDefinition = {
   /**
    * Date definition
    */
@@ -294,6 +294,18 @@ type LiturgicalDayRoot = {
    * Date definition exception
    */
   dateExceptions?: DateDefException[];
+};
+
+/**
+ * Base object extended by other derived Liturgical Day objects
+ */
+type LiturgicalDayRoot = FullDateDefinition & {
+  /**
+   * Optional alternative transfer dates for this liturgical day.
+   *
+   * e.g. `dedication_of_consecrated_churches` on 25th October, or on the last Sunday of October.
+   */
+  alternativeTransferDateDefs?: FullDateDefinition[];
 
   /**
    * Computed date, in ISO 8601 format: YYYY-MM-DD
@@ -499,6 +511,7 @@ export type LiturgicalDayInput = Partial<
   Pick<
     LiturgicalDayRoot,
     | 'dateDef'
+    | 'alternativeTransferDateDefs'
     | 'precedence'
     | 'allowSimilarRankItems'
     | 'isHolyDayOfObligation'

--- a/rites/roman1969/src/utils/dates.ts
+++ b/rites/roman1969/src/utils/dates.ts
@@ -41,9 +41,9 @@ export const startOfWeek = (date: Date): Date => {
   return subtractsDays(date, date.getUTCDay());
 };
 
-export const isValidDate = (maybeDate: unknown): boolean => {
+export const isValidDate = (maybeDate: unknown): maybeDate is Date => {
   // it is a date
-  if (Object.prototype.toString.call(maybeDate) === '[object Date]') {
+  if (maybeDate && Object.prototype.toString.call(maybeDate) === '[object Date]') {
     if (isNaN((maybeDate as Date).getTime())) return false; // date is not valid
     return true; // date is valid
   }


### PR DESCRIPTION
The `dedication_of_consecrated_churches` liturgical day is not declared anywhere in the GRC, so I am removing it.

I am reintegrating it into the proper calendars of:
- Belgium – based on the 2021 French missal
- Canada – based on the 2021 French missal
- France – based on the 2021 French missal
- Poland – I don’t have the sources, but there was only a removal of `dedication_of_consecrated_churches_on_october_25`, not of `dedication_of_consecrated_churches_on_last_sunday_of_october`. So I assumed the latter was correct, but maybe it was an oversight to remove that as well? If in doubt, we can also remove this element from this calendar entirely (we can reintroduce it later if needed).
- Slovakia

For France and Belgium, the Missal also allows transferring the liturgical day to the last Sunday of the October. Since we don’t want to have this same liturgical day twice in the calendar, and I found it unfortunate to lose this information, I suggest adding a new optional property `alternativeTransferDateDefs`.

For now, the dates defined in this property `alternativeTransferDateDefs` are not calculated. I’m reserving this for a future PR.

Closes https://github.com/romcal/romcal/issues/136.