### PR TITLE
fix(package): required dependencies not bundled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: '/'
+    directories:
+      - '/'
+      - '/packages/config'
+      - '/packages/easter'
+      - 'rites/roman1962'
+      - 'rites/roman1969'
     schedule:
       interval: 'weekly'
       day: 'saturday'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "rites/*",
         "packages/*"
       ],
+      "dependencies": {
+        "i18next": "^21.6.0"
+      },
       "devDependencies": {
         "husky": "^9.0.11",
         "prettier": "~3.4.1",
@@ -6290,6 +6293,8 @@
     },
     "node_modules/i18next": {
       "version": "21.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-21.10.0.tgz",
+      "integrity": "sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==",
       "funding": [
         {
           "type": "individual",
@@ -11782,14 +11787,6 @@
         "typescript": ">=4.2.0"
       }
     },
-    "node_modules/ts-deepmerge": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.2.tgz",
-      "integrity": "sha512-akcpDTPuez4xzULo5NwuoKwYRtjQJ9eoNfBACiBMaXwNAx7B1PKfe5wqUFJuW5uKzQ68YjDFwPaWHDG1KnFGsA==",
-      "engines": {
-        "node": ">=14.13.1"
-      }
-    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "dev": true,
@@ -12674,6 +12671,15 @@
         "remark-stringify": "^11.0.0",
         "type-fest": "^4.10.3",
         "unified": "^11.0.5"
+      }
+    },
+    "rites/roman1969/node_modules/ts-deepmerge": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.1.tgz",
+      "integrity": "sha512-JBFCmNenZdUCc+TRNCtXVM6N8y/nDQHAcpj5BlwXG/gnogjam1NunulB9ia68mnqYI446giMfpqeBFFkOleh+g==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.13.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "doc": "npm run doc -w=@internal/rite-roman1969",
     "docs:check-links": "npm run docs:check-links -w=@internal/rite-roman1969",
     "docs:sort-glossary": "npm run docs:sort-glossary -w=@internal/rite-roman1969",
-    "lint": "npm run lint -w=@internal/easter -w=@internal/rite-roman1969",
-    "lint:fix": "npm run lint -w=@internal/easter -w=@internal/rite-roman1969 -- --fix",
+    "lint": "npm run lint --workspaces --if-present",
+    "lint:fix": "npm run lint --workspaces --if-present -- --fix",
     "prepare": "husky",
     "prettier": "prettier -c .",
     "prettier:fix": "prettier -w .",
-    "test": "npm run test -w=@internal/easter -w=@internal/rite-roman1969",
+    "test": "npm run test --workspaces --if-present",
     "test:snapshot:update": "npm run test:snapshot:update -w=@internal/rite-roman1969",
     "test:watch": "npm run test:watch -w=@internal/rite-roman1969",
     "test:without-coverage": "npm run test:without-coverage -w=@internal/rite-roman1969"
@@ -71,6 +71,9 @@
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",
     "typescript": "~5.2.2"
+  },
+  "dependencies": {
+    "i18next": "^21.6.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/config/.eslintrc.js
+++ b/packages/config/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
     project: '../../tsconfig.base.json',
     sourceType: 'module',
   },
-  ignorePatterns: ['node_modules', 'dist', 'coverage', 'tmp', '__snapshots__', '*.js', '*.json'],
+  ignorePatterns: ['node_modules', 'dist', 'coverage', 'tmp', '__snapshots__', '*.json'],
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   plugins: ['unused-imports'],
   rules: {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
-    "prettier": "prettier -c .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "prettier": "prettier -c ."
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.7",

--- a/packages/config/packages.json
+++ b/packages/config/packages.json
@@ -1,6 +1,0 @@
-{
-  "name": "@internal/config",
-  "version": "0.0.0",
-  "private": true,
-  "license": "MIT"
-}

--- a/rites/roman1962/package.json
+++ b/rites/roman1962/package.json
@@ -3,9 +3,7 @@
   "version": "0.0.0",
   "description": "Liturgical calendar for the Roman Rite according to the 1962 reform",
   "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "scripts": {},
   "dependencies": {},
   "devDependencies": {},
   "license": "MIT"


### PR DESCRIPTION
fix an issue where we'd have to install `i18next` as part of any consumers because it's missing from the bundle (encountered this upgrading romcal-examples