### PR TITLE
feat(calendar): enforce full hierarchy for particular calendar definitions

### DIFF
--- a/rites/roman1969/__tests__/calendar-date-overrides.test.ts
+++ b/rites/roman1969/__tests__/calendar-date-overrides.test.ts
@@ -1,11 +1,16 @@
+import { AsianRussia_En } from '@dist/rite-roman1969/bundles/asian-russia';
 import { CzechRepublic_Cs } from '@dist/rite-roman1969/bundles/czech-republic';
 import { England_En } from '@dist/rite-roman1969/bundles/england';
+import { Europe_En } from '@dist/rite-roman1969/bundles/europe';
+import { EuropeanRussia_En } from '@dist/rite-roman1969/bundles/european-russia';
 import { France_Fr } from '@dist/rite-roman1969/bundles/france';
+import { France_Paris_Fr } from '@dist/rite-roman1969/bundles/france.paris';
 import { Germany_En } from '@dist/rite-roman1969/bundles/germany';
 import { Hungary_En } from '@dist/rite-roman1969/bundles/hungary';
 import { Ireland_En } from '@dist/rite-roman1969/bundles/ireland';
 import { Malta_En } from '@dist/rite-roman1969/bundles/malta';
 import { Mexico_Es } from '@dist/rite-roman1969/bundles/mexico';
+import { Russia_En } from '@dist/rite-roman1969/bundles/russia';
 import { Slovakia_Sk } from '@dist/rite-roman1969/bundles/slovakia';
 import { Spain_Es } from '@dist/rite-roman1969/bundles/spain';
 import { Wales_En } from '@dist/rite-roman1969/bundles/wales';
@@ -329,6 +334,87 @@ describe('Testing national calendar overrides', () => {
       const ourLadyOfSorrowsPatronessOfSlovakia = slovakiaDates.find((d) => d.id === 'our_lady_of_sorrows');
       expect(ourLadyOfSorrowsPatronessOfSlovakia?.precedence).toEqual(Precedences.ProperSolemnity_PrincipalPatron_4a);
       expect(ourLadyOfSorrowsPatronessOfSlovakia?.date === '2018-09-15').toBeTruthy();
+    });
+  });
+
+  describe('Parent calendar inheritance for Russia and its regions', () => {
+    let europeanRussiaDates: LiturgicalDay[];
+    let asianRussiaDates: LiturgicalDay[];
+    let europeDates: LiturgicalDay[];
+    let russiaDates: LiturgicalDay[];
+
+    beforeAll(async () => {
+      europeanRussiaDates = Object.values(
+        await new Romcal({ localizedCalendar: EuropeanRussia_En }).generateCalendar(2025)
+      ).flat();
+      asianRussiaDates = Object.values(
+        await new Romcal({ localizedCalendar: AsianRussia_En }).generateCalendar(2025)
+      ).flat();
+      europeDates = Object.values(await new Romcal({ localizedCalendar: Europe_En }).generateCalendar(2025)).flat();
+      russiaDates = Object.values(await new Romcal({ localizedCalendar: Russia_En }).generateCalendar(2025)).flat();
+    });
+
+    test('"catherine_of_siena_virgin" is present in all calendars, but with the correct precedence according to the calendar hierarchy', () => {
+      const inEurope = europeDates.find((d) => d.id === 'catherine_of_siena_virgin');
+      const inEuropeanRussia = europeanRussiaDates.find((d) => d.id === 'catherine_of_siena_virgin');
+      const inAsianRussia = asianRussiaDates.find((d) => d.id === 'catherine_of_siena_virgin');
+      expect(inEurope).toBeTruthy();
+      expect(inEuropeanRussia).toBeTruthy();
+      expect(inAsianRussia).toBeTruthy();
+      expect(inEurope?.precedence).toEqual(Precedences.ProperFeast_PrincipalPatronOfARegion_8c);
+      expect(inEuropeanRussia?.precedence).toEqual(Precedences.ProperFeast_PrincipalPatronOfARegion_8c);
+      expect(inAsianRussia?.precedence).toEqual(Precedences.GeneralMemorial_10);
+    });
+
+    test('"george_matulaitis_bishop" is present in Russia, EuropeanRussia, and AsianRussia', () => {
+      const inRussia = russiaDates.some((d) => d.id === 'george_matulaitis_bishop');
+      const inEuropeanRussia = europeanRussiaDates.some((d) => d.id === 'george_matulaitis_bishop');
+      const inAsianRussia = asianRussiaDates.some((d) => d.id === 'george_matulaitis_bishop');
+      expect(inRussia).toBeTruthy();
+      expect(inEuropeanRussia).toBeTruthy();
+      expect(inAsianRussia).toBeTruthy();
+    });
+  });
+
+  describe('Parent calendar inheritance for France and the Diocese of Paris', () => {
+    let generalDates: LiturgicalDay[];
+    let franceDates: LiturgicalDay[];
+    let franceParisDates: LiturgicalDay[];
+
+    beforeAll(async () => {
+      generalDates = Object.values(await new Romcal().generateCalendar(2025)).flat();
+      franceDates = Object.values(await new Romcal({ localizedCalendar: France_Fr }).generateCalendar(2025)).flat();
+      franceParisDates = Object.values(
+        await new Romcal({ localizedCalendar: France_Paris_Fr }).generateCalendar(2025)
+      ).flat();
+    });
+
+    test('"most_holy_name_of_jesus" is present on January 3 in the general and France calendars', () => {
+      const mhnojGeneral = generalDates.find((d) => d.id === 'most_holy_name_of_jesus');
+      const mhnojFrance = franceDates.find((d) => d.id === 'most_holy_name_of_jesus');
+      expect(mhnojGeneral).toBeTruthy();
+      expect(mhnojFrance).toBeTruthy();
+      expect(mhnojGeneral?.date).toMatch(/-01-03$/);
+      expect(mhnojFrance?.date).toMatch(/-01-03$/);
+    });
+
+    test('"most_holy_name_of_jesus" is present on January 4 in the Diocese of Paris calendar (France_Paris)', () => {
+      const mhnojParis = franceParisDates.find((d) => d.id === 'most_holy_name_of_jesus');
+      expect(mhnojParis).toBeTruthy();
+      expect(mhnojParis?.date).toMatch(/-01-04$/);
+    });
+
+    test('"genevieve_of_paris_virgin" is only present in the France and Diocese of Paris calendars, with correct date and precedence', () => {
+      const genevieveGeneral = generalDates.find((d) => d.id === 'genevieve_of_paris_virgin');
+      const genevieveFrance = franceDates.find((d) => d.id === 'genevieve_of_paris_virgin');
+      const genevieveParis = franceParisDates.find((d) => d.id === 'genevieve_of_paris_virgin');
+      expect(genevieveGeneral).toBeFalsy();
+      expect(genevieveFrance).toBeTruthy();
+      expect(genevieveFrance?.date).toMatch(/-01-03$/);
+      expect(genevieveFrance?.precedence).toEqual(Precedences.OptionalMemorial_12);
+      expect(genevieveParis).toBeTruthy();
+      expect(genevieveParis?.date).toMatch(/-01-03$/);
+      expect(genevieveParis?.precedence).toEqual(Precedences.ProperSolemnity_PrincipalPatron_4a);
     });
   });
 });

--- a/rites/roman1969/src/calendars/countries/argentina/index.ts
+++ b/rites/roman1969/src/calendars/countries/argentina/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Argentina extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     laura_vicuna_virgin: {

--- a/rites/roman1969/src/calendars/countries/austria/index.ts
+++ b/rites/roman1969/src/calendars/countries/austria/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Austria extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     john_nepomucene_priest: {

--- a/rites/roman1969/src/calendars/countries/belgium/index.ts
+++ b/rites/roman1969/src/calendars/countries/belgium/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Belgium extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     mutien_marie_wiaux_religious: {

--- a/rites/roman1969/src/calendars/countries/bolivia/index.ts
+++ b/rites/roman1969/src/calendars/countries/bolivia/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Bolivia extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     philip_of_jesus_de_las_casas_paul_miki_and_companions_martyrs: {

--- a/rites/roman1969/src/calendars/countries/bosnia-herzegovina/index.ts
+++ b/rites/roman1969/src/calendars/countries/bosnia-herzegovina/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class BosniaHerzegovina extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     scholastica_of_nursia_virgin: {

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Brazil extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     joseph_de_anchieta_priest: {

--- a/rites/roman1969/src/calendars/countries/canada/index.ts
+++ b/rites/roman1969/src/calendars/countries/canada/index.ts
@@ -6,7 +6,7 @@ import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Canada extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: true, // src: mr_fr_2021_ed3

--- a/rites/roman1969/src/calendars/countries/chile/index.ts
+++ b/rites/roman1969/src/calendars/countries/chile/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Chile extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     laura_vicuna_virgin: {

--- a/rites/roman1969/src/calendars/countries/costa-rica/index.ts
+++ b/rites/roman1969/src/calendars/countries/costa-rica/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class CostaRica extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/croatia/index.ts
+++ b/rites/roman1969/src/calendars/countries/croatia/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Croatia extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     aloysius_stepinac_bishop: {

--- a/rites/roman1969/src/calendars/countries/czech-republic/index.ts
+++ b/rites/roman1969/src/calendars/countries/czech-republic/index.ts
@@ -6,7 +6,7 @@ import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class CzechRepublic extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: false,

--- a/rites/roman1969/src/calendars/countries/denmark/index.ts
+++ b/rites/roman1969/src/calendars/countries/denmark/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Denmark extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/england/index.ts
+++ b/rites/roman1969/src/calendars/countries/england/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class England extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     aelred_of_rievaulx_abbot: {

--- a/rites/roman1969/src/calendars/countries/finland/index.ts
+++ b/rites/roman1969/src/calendars/countries/finland/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Finland extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     henry_of_finland_bishop: {

--- a/rites/roman1969/src/calendars/countries/france/archdiocese-of-lyon.ts
+++ b/rites/roman1969/src/calendars/countries/france/archdiocese-of-lyon.ts
@@ -2,11 +2,12 @@ import { PatronTitle, Title } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
 
 import { France } from '.';
 
 export class France_Lyon extends CalendarDef {
-  ParentCalendar = France;
+  ParentCalendars = [Europe, France];
 
   inputs: Inputs = {
     // src: mr_fr_2014_ed2_lyon

--- a/rites/roman1969/src/calendars/countries/france/archdiocese-of-paris.ts
+++ b/rites/roman1969/src/calendars/countries/france/archdiocese-of-paris.ts
@@ -2,11 +2,12 @@ import { PatronTitle, Title } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
 
 import { France } from '.';
 
 export class France_Paris extends CalendarDef {
-  ParentCalendar = France;
+  ParentCalendars = [Europe, France];
 
   inputs: Inputs = {
     genevieve_of_paris_virgin: {

--- a/rites/roman1969/src/calendars/countries/france/diocese-of-angers.ts
+++ b/rites/roman1969/src/calendars/countries/france/diocese-of-angers.ts
@@ -2,6 +2,7 @@ import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
 
 import { France } from '.';
 
@@ -10,9 +11,8 @@ import { France } from '.';
 // - https://foi.diocese49.org/IMG/pdf/2022-09-28_missel_propre_format_a5_.pdf
 // - https://en.wikipedia.org/wiki/Roman_Catholic_Diocese_of_Angers
 // - https://www.diocese49.org/mon-diocese/les-saints-de-lanjou/
-
 export class France_Angers extends CalendarDef {
-  ParentCalendar = France;
+  ParentCalendars = [Europe, France];
 
   inputs: Inputs = {
     // src: mr_fr_2022_ed3_angers

--- a/rites/roman1969/src/calendars/countries/france/diocese-of-coutances.ts
+++ b/rites/roman1969/src/calendars/countries/france/diocese-of-coutances.ts
@@ -2,6 +2,7 @@ import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
 
 import { France } from '.';
 
@@ -9,9 +10,8 @@ import { France } from '.';
 // - mr_fr_1982_ed2_coutances
 // - https://en.wikipedia.org/wiki/Roman_Catholic_Diocese_of_Coutances
 // - https://www.diocese50.fr/les-paroisses-et-les-doyennes/notre-dame-coutances/les-saints-du-diocese
-
 export class France_Coutances extends CalendarDef {
-  ParentCalendar = France;
+  ParentCalendars = [Europe, France];
 
   inputs: Inputs = {
     // src: mr_fr_1982_ed2_coutances

--- a/rites/roman1969/src/calendars/countries/france/diocese-of-saint-denis.ts
+++ b/rites/roman1969/src/calendars/countries/france/diocese-of-saint-denis.ts
@@ -2,11 +2,12 @@ import { PatronTitle, Title } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
 
 import { France } from '.';
 
 export class France_SaintDenis extends CalendarDef {
-  ParentCalendar = France;
+  ParentCalendars = [Europe, France];
 
   inputs: Inputs = {
     genevieve_of_paris_virgin: {

--- a/rites/roman1969/src/calendars/countries/france/diocese-of-strasbourg.ts
+++ b/rites/roman1969/src/calendars/countries/france/diocese-of-strasbourg.ts
@@ -2,11 +2,12 @@ import { PatronTitle, Title } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
 
 import { France } from '.';
 
 export class France_Strasbourg extends CalendarDef {
-  ParentCalendar = France;
+  ParentCalendars = [Europe, France];
 
   inputs: Inputs = {
     amarin_of_alsace_abbot: {

--- a/rites/roman1969/src/calendars/countries/france/index.ts
+++ b/rites/roman1969/src/calendars/countries/france/index.ts
@@ -13,7 +13,7 @@ import { France_SaintDenis } from './diocese-of-saint-denis';
 import { France_Strasbourg } from './diocese-of-strasbourg';
 
 export class France extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: true,

--- a/rites/roman1969/src/calendars/countries/germany/index.ts
+++ b/rites/roman1969/src/calendars/countries/germany/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Germany extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     john_nepomucene_neumann_bishop: {

--- a/rites/roman1969/src/calendars/countries/greece/index.ts
+++ b/rites/roman1969/src/calendars/countries/greece/index.ts
@@ -4,7 +4,7 @@ import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Greece extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   particularConfig: ParticularConfig = {
     easterCalculationType: 'julian',

--- a/rites/roman1969/src/calendars/countries/guatemala/index.ts
+++ b/rites/roman1969/src/calendars/countries/guatemala/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Guatemala extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/hungary/index.ts
+++ b/rites/roman1969/src/calendars/countries/hungary/index.ts
@@ -7,7 +7,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Hungary extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     paul_of_thebes_hermit: {

--- a/rites/roman1969/src/calendars/countries/ireland/index.ts
+++ b/rites/roman1969/src/calendars/countries/ireland/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Ireland extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     munchin_of_limerick_bishop: {

--- a/rites/roman1969/src/calendars/countries/italy/index.ts
+++ b/rites/roman1969/src/calendars/countries/italy/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Italy extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     catherine_of_siena_virgin: {

--- a/rites/roman1969/src/calendars/countries/lithuania/index.ts
+++ b/rites/roman1969/src/calendars/countries/lithuania/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Lithuania extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     george_matulaitis_bishop: {

--- a/rites/roman1969/src/calendars/countries/malta/index.ts
+++ b/rites/roman1969/src/calendars/countries/malta/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Malta extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     publius_of_malta_bishop: {

--- a/rites/roman1969/src/calendars/countries/mexico/index.ts
+++ b/rites/roman1969/src/calendars/countries/mexico/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Mexico extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     philip_of_jesus_de_las_casas_martyr: {

--- a/rites/roman1969/src/calendars/countries/netherlands/index.ts
+++ b/rites/roman1969/src/calendars/countries/netherlands/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Netherlands extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/norway/index.ts
+++ b/rites/roman1969/src/calendars/countries/norway/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Norway extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     thorfinn_of_hamar_bishop: {

--- a/rites/roman1969/src/calendars/countries/panama/index.ts
+++ b/rites/roman1969/src/calendars/countries/panama/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Panama extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/paraguay/index.ts
+++ b/rites/roman1969/src/calendars/countries/paraguay/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Paraguay extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/peru/index.ts
+++ b/rites/roman1969/src/calendars/countries/peru/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Peru extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     finding_of_the_holy_cross: {

--- a/rites/roman1969/src/calendars/countries/poland/index.ts
+++ b/rites/roman1969/src/calendars/countries/poland/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Poland extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     joseph_sebastian_pelczar_bishop: {

--- a/rites/roman1969/src/calendars/countries/portugal/index.ts
+++ b/rites/roman1969/src/calendars/countries/portugal/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Portugal extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     gundisalvus_of_amarante_priest: {

--- a/rites/roman1969/src/calendars/countries/puerto-rico/index.ts
+++ b/rites/roman1969/src/calendars/countries/puerto-rico/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class PuertoRico extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     most_holy_name_of_jesus: {

--- a/rites/roman1969/src/calendars/countries/romania/index.ts
+++ b/rites/roman1969/src/calendars/countries/romania/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Romania extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     john_cassian_priest: {

--- a/rites/roman1969/src/calendars/countries/russia/asian-russia.ts
+++ b/rites/roman1969/src/calendars/countries/russia/asian-russia.ts
@@ -1,0 +1,8 @@
+import { CalendarDef } from '../../../models/calendar-def';
+import { Asia } from '../../regions/asia';
+
+import { Russia } from '.';
+
+export class AsianRussia extends CalendarDef {
+  ParentCalendars = [Asia, Russia];
+}

--- a/rites/roman1969/src/calendars/countries/russia/european-russia.ts
+++ b/rites/roman1969/src/calendars/countries/russia/european-russia.ts
@@ -1,0 +1,8 @@
+import { CalendarDef } from '../../../models/calendar-def';
+import { Europe } from '../../regions/europe';
+
+import { Russia } from '.';
+
+export class EuropeanRussia extends CalendarDef {
+  ParentCalendars = [Europe, Russia];
+}

--- a/rites/roman1969/src/calendars/countries/russia/index.ts
+++ b/rites/roman1969/src/calendars/countries/russia/index.ts
@@ -2,10 +2,12 @@ import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
 import { Inputs } from '../../../types/calendar-def';
-import { Europe } from '../../regions/europe';
+
+import { AsianRussia } from './asian-russia';
+import { EuropeanRussia } from './european-russia';
 
 export class Russia extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [];
 
   inputs: Inputs = {
     george_matulaitis_bishop: {
@@ -110,3 +112,5 @@ export class Russia extends CalendarDef {
     },
   };
 }
+
+export { AsianRussia, EuropeanRussia };

--- a/rites/roman1969/src/calendars/countries/scotland/index.ts
+++ b/rites/roman1969/src/calendars/countries/scotland/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Scotland extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     kentigern_of_scotland_bishop: {

--- a/rites/roman1969/src/calendars/countries/slovakia/index.ts
+++ b/rites/roman1969/src/calendars/countries/slovakia/index.ts
@@ -7,7 +7,7 @@ import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Slovakia extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: false,

--- a/rites/roman1969/src/calendars/countries/slovenia/index.ts
+++ b/rites/roman1969/src/calendars/countries/slovenia/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Slovenia extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     john_nepomucene_priest: {

--- a/rites/roman1969/src/calendars/countries/spain/index.ts
+++ b/rites/roman1969/src/calendars/countries/spain/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Spain extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     eulogius_of_cordoba_bishop: {

--- a/rites/roman1969/src/calendars/countries/sweden/index.ts
+++ b/rites/roman1969/src/calendars/countries/sweden/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Sweden extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     elizabeth_hesselblad_religious: {

--- a/rites/roman1969/src/calendars/countries/switzerland/index.ts
+++ b/rites/roman1969/src/calendars/countries/switzerland/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Switzerland extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     john_nepomucene_priest: {

--- a/rites/roman1969/src/calendars/countries/ukraine/index.ts
+++ b/rites/roman1969/src/calendars/countries/ukraine/index.ts
@@ -4,7 +4,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Ukraine extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     marcelina_darowska_religious: {

--- a/rites/roman1969/src/calendars/countries/united-states/index.ts
+++ b/rites/roman1969/src/calendars/countries/united-states/index.ts
@@ -5,7 +5,7 @@ import { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class UnitedStates extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   particularConfig: ParticularConfig = {
     epiphanyOnSunday: true,

--- a/rites/roman1969/src/calendars/countries/uruguay/index.ts
+++ b/rites/roman1969/src/calendars/countries/uruguay/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Uruguay extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/venezuela/index.ts
+++ b/rites/roman1969/src/calendars/countries/venezuela/index.ts
@@ -5,7 +5,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Americas } from '../../regions/americas';
 
 export class Venezuela extends CalendarDef {
-  ParentCalendar = Americas;
+  ParentCalendars = [Americas];
 
   inputs: Inputs = {
     our_lord_jesus_christ_the_eternal_high_priest: {

--- a/rites/roman1969/src/calendars/countries/wales/index.ts
+++ b/rites/roman1969/src/calendars/countries/wales/index.ts
@@ -6,7 +6,7 @@ import { Inputs } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 export class Wales extends CalendarDef {
-  ParentCalendar = Europe;
+  ParentCalendars = [Europe];
 
   inputs: Inputs = {
     teilo_of_llandaff_bishop: {

--- a/rites/roman1969/src/calendars/index.ts
+++ b/rites/roman1969/src/calendars/index.ts
@@ -48,7 +48,7 @@ import { Poland } from './countries/poland';
 import { Portugal } from './countries/portugal';
 import { PuertoRico } from './countries/puerto-rico';
 import { Romania } from './countries/romania';
-import { Russia } from './countries/russia';
+import { AsianRussia, EuropeanRussia, Russia } from './countries/russia';
 import { Scotland } from './countries/scotland';
 import { Slovakia } from './countries/slovakia';
 import { Slovenia } from './countries/slovenia';
@@ -63,11 +63,15 @@ import { Venezuela } from './countries/venezuela';
 import { Vietnam } from './countries/vietnam';
 import { Wales } from './countries/wales';
 import { GeneralRoman } from './general-roman';
+import { Africa } from './regions/africa';
 import { Americas } from './regions/americas';
+import { Asia } from './regions/asia';
 import { Europe } from './regions/europe';
 
 export const calendarDefinitions: Record<string, typeof CalendarDef> = {
+  Africa,
   Americas,
+  Asia,
   Argentina,
   Australia,
   Austria,
@@ -117,6 +121,8 @@ export const calendarDefinitions: Record<string, typeof CalendarDef> = {
   PuertoRico,
   Romania,
   Russia,
+  AsianRussia,
+  EuropeanRussia,
   Scotland,
   Slovakia,
   Slovenia,

--- a/rites/roman1969/src/calendars/regions/africa.ts
+++ b/rites/roman1969/src/calendars/regions/africa.ts
@@ -1,0 +1,6 @@
+import { CalendarDef } from '../../models/calendar-def';
+import { Inputs } from '../../types/calendar-def';
+
+export class Africa extends CalendarDef {
+  inputs: Inputs = {};
+}

--- a/rites/roman1969/src/calendars/regions/asia.ts
+++ b/rites/roman1969/src/calendars/regions/asia.ts
@@ -1,0 +1,6 @@
+import { CalendarDef } from '../../models/calendar-def';
+import { Inputs } from '../../types/calendar-def';
+
+export class Asia extends CalendarDef {
+  inputs: Inputs = {};
+}

--- a/rites/roman1969/src/models/calendar-def.ts
+++ b/rites/roman1969/src/models/calendar-def.ts
@@ -18,9 +18,9 @@ export class CalendarDef implements BaseCalendarDef {
 
   readonly dates: typeof Dates;
 
-  ParentCalendar?: CalendarDefInstance | null;
+  ParentCalendars?: CalendarDefInstance[] | null;
 
-  parentCalendarInstance?: InstanceType<CalendarDefInstance>;
+  parentCalendarInstances?: InstanceType<CalendarDefInstance>[];
 
   readonly particularConfig?: ParticularConfig;
 
@@ -56,11 +56,14 @@ export class CalendarDef implements BaseCalendarDef {
    */
   updateConfig(input?: RomcalConfigInput): void {
     // Init the parent calendar
-    if (this.ParentCalendar) {
-      this.parentCalendarInstance = new this.ParentCalendar(this.#config);
+    if (this.ParentCalendars) {
+      this.parentCalendarInstances = this.ParentCalendars.map((ParentCal) => {
+        const parentCalInstance = new ParentCal(this.#config);
 
-      // Update first the configuration from the parent calendar(s)
-      this.parentCalendarInstance.updateConfig(input);
+        // Update first the configuration from the parent calendar(s)
+        parentCalInstance.updateConfig(input);
+        return parentCalInstance;
+      });
     }
 
     // Combine the provided user configuration,
@@ -86,8 +89,10 @@ export class CalendarDef implements BaseCalendarDef {
    * @private
    */
   #retrieveParentCalInputs(parentCal: InstanceType<CalendarDefInstance>): void {
-    if (parentCal.parentCalendarInstance) {
-      this.#retrieveParentCalInputs(parentCal.parentCalendarInstance);
+    if (parentCal.parentCalendarInstances) {
+      parentCal.parentCalendarInstances.forEach((parent) => {
+        this.#retrieveParentCalInputs(parent);
+      });
     }
 
     parentCal.buildAllDefinitions();
@@ -98,8 +103,10 @@ export class CalendarDef implements BaseCalendarDef {
 
     const inputs = Object.keys(this.inputs);
 
-    if (this.parentCalendarInstance) {
-      this.#retrieveParentCalInputs(this.parentCalendarInstance);
+    if (this.parentCalendarInstances) {
+      this.parentCalendarInstances.forEach((parent) => {
+        this.#retrieveParentCalInputs(parent);
+      });
     }
 
     inputs.forEach((id) => {

--- a/rites/roman1969/src/types/calendar-def.ts
+++ b/rites/roman1969/src/types/calendar-def.ts
@@ -25,9 +25,26 @@ export type LiturgicalDayDefinitions = Record<Id, LiturgicalDayDef>;
  * Base [CalendarDef] interface
  */
 export interface BaseCalendarDef {
-  ParentCalendar?: CalendarDefInstance | null;
-  parentCalendarInstance?: InstanceType<CalendarDefInstance>;
+  /**
+   * List of all parent CalendarDef definitions (excluding the general Roman calendar)
+   * that serve as the base for the current calendar. The order of this list is important,
+   * as it determines the priority of calendars (from the most general to the most local).
+   * This hierarchy allows for proper inheritance and overriding of liturgical definitions.
+   */
+  ParentCalendars?: CalendarDefInstance[] | null;
+  parentCalendarInstances?: InstanceType<CalendarDefInstance>[];
+  /**
+   * Configuration options specific to this calendar.
+   * These settings can override or extend the default Romcal configuration or any parent calendar
+   * configuration.
+   */
   particularConfig?: ParticularConfig;
+  /**
+   * Collection of liturgical day definitions specific to this calendar.
+   * Each entry is identified by a unique ID and describes the date, precedence, commons, and other
+   * attributes. This collection may also include definitions that supplement or override those from
+   * parent calendars.
+   */
   inputs: CalendarDefInputs;
   dates: typeof Dates;
   updateConfig: (config?: RomcalConfigInput) => void;


### PR DESCRIPTION
Follow-up to this PR: [https://github.com/romcal/romcal/pull/834](https://github.com/romcal/romcal/pull/834) (so do not review the first commit).

Previously, only the parent calendar definition was required.
Now, the full hierarchy must be explicitly specified. This is slightly more verbose (since the complete hierarchy must be defined in each calendar), but it should help clarify and better modularize calendar definitions.

💡 Of course, in the `parentCalendars` property, the `GeneralRoman` calendar doesn't need to be specified, as it is the default base for all particular calendars.

This change allows, for example, handling the case of the calendar for Russia, which spans two continents (Europe and Asia). With this, it's now possible to define:

* A calendar for `Russia`
* An `EuropeanRussia` calendar (containing Europe-specific celebrations, included in the Russia calendar)
* An `AsianRussia` calendar (same idea for Asia)
