### PR TITLE
test(calendar): clean up noisy 'console.log' from the terminal

### DIFF
--- a/rites/roman1969/__tests__/locales.test.ts
+++ b/rites/roman1969/__tests__/locales.test.ts
@@ -39,10 +39,6 @@ describe('Testing localization functionality', () => {
 
             if (day) {
               expect(day?.name).toBe(d.value);
-            } else {
-              console.log(
-                `\`${i.calendar.i18n.id}\`: \`${d.key}\` is not celebrated in ${new Date().getUTCFullYear()}`
-              );
             }
           });
         });


### PR DESCRIPTION
We shouldn't add `console.log` statements in tests.