### PR TITLE
fix(package): fix ts export mismatch error

### DIFF
--- a/rites/roman1969/build/build.ts
+++ b/rites/roman1969/build/build.ts
@@ -231,6 +231,7 @@ const buildPipeline = async (): Promise<void> => {
       main: './cjs/index.js',
       exports: {
         '.': {
+          types: './index.d.ts',
           import: './esm/index.js',
           require: './cjs/index.js',
         },


### PR DESCRIPTION
## What is the purpose of this pull request?
In current version, if you import any localized calendar typescript (at least in version 5.7.3 and moduleResolution set to bundler, haven't tested in any other settings) throws an error `There are types at 'node_modules/@romcal/calendar.poland/index.d.ts', but this result could not be resolved when respecting package.json "exports".`. This simple pr fixes this issue by adding additional export field with the correct types.

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
