### PR TITLE
feat(l10n): detect missing name in en.ts

### DIFF
--- a/rites/roman1969/build/bundle.ts
+++ b/rites/roman1969/build/bundle.ts
@@ -157,6 +157,11 @@ export const RomcalBundler = (): void => {
         .map((def) => def.i18nDef[0].substr(6))
         .reduce((obj: LocaleLiturgicalDayNames, id: string) => {
           const update: LocaleLiturgicalDayNames = { ...obj };
+          if (locales.En && !Object.prototype.hasOwnProperty.call(locales.En.names, id)) {
+            throw new Error(
+              `Locale ID 'names:${id}' is missing in the locale 'en'. Ensure the value is included in rites/roman1969/src/locales/en.ts.`
+            );
+          }
           if (locale.names && Object.prototype.hasOwnProperty.call(locale.names, id)) {
             update[id] = locale.names[id];
           } else if (locales.En.names && Object.prototype.hasOwnProperty.call(locales.En.names, id)) {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute a pull request! -->

<!-- Please fill out the following sections to help us understand your changes. -->

## What is the purpose of this pull request?

add check for missing name from en.ts (thanks, @RonaldoSCouto)
closes #877

<!-- What should the change be that this pull request is addressing? -->

## Concept

Localization

## Example code

<!-- Please include a code sample for your usage. -->

```typescript
// Comment anything from rites/roman1969/src/locales/en.ts#names
// ex. comment line 804 (most_holy_body_and_blood_of_christ)
// most_holy_body_and_blood_of_christ: 'The Most Holy Body and Blood of Christ',
```

run `npm run build`

```sh
Error: Locale ID 'names:most_holy_body_and_blood_of_christ' is missing in the locale 'en'. Ensure the value is included in rites/roman1969/src/locales/en.ts.
```

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
