### PR TITLE
feat(france.toulouse): add Archdiocese of Toulouse, France

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
   },
   "eslint.format.enable": false, // let prettier do it, it is faster and safer
   // Jest extension settings
-  "jest.runMode": "on-demand"
+  "jest.runMode": "on-demand",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/docs/calendar-plugins.md
+++ b/docs/calendar-plugins.md
@@ -18,7 +18,9 @@ Below the list of all available calendar plugins:
 
 | Name                 | NPM Package name                          |
 | -------------------- | ----------------------------------------- |
+| Africa               | `@romcal/calendar.africa@dev`             |
 | Americas             | `@romcal/calendar.americas@dev`           |
+| Asia                 | `@romcal/calendar.asia@dev`               |
 | Argentina            | `@romcal/calendar.argentina@dev`          |
 | Australia            | `@romcal/calendar.australia@dev`          |
 | Austria              | `@romcal/calendar.austria@dev`            |
@@ -43,6 +45,7 @@ Below the list of all available calendar plugins:
 | France / Paris       | `@romcal/calendar.france.paris@dev`       |
 | France / Saint Denis | `@romcal/calendar.france.saint-denis@dev` |
 | France / Strasbourg  | `@romcal/calendar.france.strasbourg@dev`  |
+| France / Toulouse    | `@romcal/calendar.france.toulouse@dev`    |
 | General Roman        | `@romcal/calendar.general-roman@dev`      |
 | Germany              | `@romcal/calendar.germany@dev`            |
 | Greece               | `@romcal/calendar.greece@dev`             |
@@ -68,6 +71,8 @@ Below the list of all available calendar plugins:
 | Puerto Rico          | `@romcal/calendar.puerto-rico@dev`        |
 | Romania              | `@romcal/calendar.romania@dev`            |
 | Russia               | `@romcal/calendar.russia@dev`             |
+| Asian Russia         | `@romcal/calendar.asian-russia@dev`       |
+| European Russia      | `@romcal/calendar.european-russia@dev`    |
 | Scotland             | `@romcal/calendar.scotland@dev`           |
 | Slovakia             | `@romcal/calendar.slovakia@dev`           |
 | Slovenia             | `@romcal/calendar.slovenia@dev`           |

--- a/rites/roman1969/src/calendars/countries/france/archdiocese-of-toulouse.ts
+++ b/rites/roman1969/src/calendars/countries/france/archdiocese-of-toulouse.ts
@@ -1,0 +1,109 @@
+import { PatronTitle, Title } from '../../../constants/martyrology-metadata';
+import { Precedences } from '../../../constants/precedences';
+import { CalendarDef } from '../../../models/calendar-def';
+import type { Inputs } from '../../../types/calendar-def';
+import { Europe } from '../../regions/europe';
+
+import { France } from '.';
+
+// src:
+// - mr_fr_1974_ed1_region_apostolique_du_midi
+// - https://en.wikipedia.org/wiki/Roman_Catholic_Archdiocese_of_Toulouse
+export class France_Toulouse extends CalendarDef {
+  ParentCalendars = [Europe, France];
+
+  inputs: Inputs = {
+    thomas_aquinas_priest: {
+      precedence: Precedences.ProperFeast_8f,
+    },
+
+    peter_nolasco_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 1, date: 30 },
+    },
+
+    erembert_of_toulouse_bishop: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 5, date: 15 },
+    },
+
+    hilarius_of_toulouse_bishop_and_sylvius_of_toulouse_bishops: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 5, date: 20 },
+      martyrology: ['hilarius_of_toulouse_bishop', 'sylvius_of_toulouse_bishop'],
+    },
+
+    raymond_costeran_and_companions_martyrs: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 5, date: 29 },
+      martyrology: ['raymond_costeran_martyr', 'companions_martyrs'],
+    },
+
+    aventin_of_larboust_martyr: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 6, date: 13 },
+    },
+
+    germaine_cousin_virgin: {
+      precedence: Precedences.ProperFeast_8f,
+      dateDef: { month: 6, date: 15 },
+    },
+
+    john_francis_regis_priest: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 6, date: 16 },
+      titles: [Title.Priest],
+    },
+
+    raymond_gayrard_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 7, date: 4 },
+    },
+
+    urban_ii_pope: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 7, date: 28 },
+    },
+
+    louis_of_toulouse_bishop: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 8, date: 19 },
+    },
+
+    dedication_of_the_cathedral_of_saint_stephen_of_toulouse_france: {
+      precedence: Precedences.ProperFeast_DedicationOfTheCathedralChurch_8b,
+      dateDef: { month: 8, date: 30 },
+    },
+
+    exuperius_of_toulouse_bishop: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 9, date: 28 },
+    },
+
+    bertrand_of_comminges_bishop: {
+      precedence: Precedences.ProperFeast_8f,
+      dateDef: { month: 10, date: 16 },
+    },
+
+    urban_v_pope: {
+      precedence: Precedences.OptionalMemorial_12,
+      dateDef: { month: 11, date: 7 },
+    },
+
+    saturnin_of_toulouse_bishop: {
+      precedence: Precedences.ProperFeast_8f,
+      dateDef: { month: 11, date: 29 },
+    },
+
+    paul_of_narbonne_bishop: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 12, date: 11 },
+    },
+
+    stephen_the_first_martyr: {
+      customLocaleId: 'stephen_the_first_martyr_and_principal_patron_of_the_archdiocese_of_toulouse',
+      precedence: Precedences.ProperFeast_PrincipalPatronOfADiocese_8a,
+      titles: { append: [PatronTitle.PrincipalPatronOfTheDiocese] },
+    },
+  };
+}

--- a/rites/roman1969/src/calendars/countries/france/index.ts
+++ b/rites/roman1969/src/calendars/countries/france/index.ts
@@ -2,11 +2,12 @@ import { CommonDefinition as Common } from '../../../constants/commons';
 import { PatronTitle } from '../../../constants/martyrology-metadata';
 import { Precedences } from '../../../constants/precedences';
 import { CalendarDef } from '../../../models/calendar-def';
-import { Inputs, ParticularConfig } from '../../../types/calendar-def';
+import type { Inputs, ParticularConfig } from '../../../types/calendar-def';
 import { Europe } from '../../regions/europe';
 
 import { France_Lyon } from './archdiocese-of-lyon';
 import { France_Paris } from './archdiocese-of-paris';
+import { France_Toulouse } from './archdiocese-of-toulouse';
 import { France_Angers } from './diocese-of-angers';
 import { France_Coutances } from './diocese-of-coutances';
 import { France_SaintDenis } from './diocese-of-saint-denis';
@@ -140,4 +141,12 @@ export class France extends CalendarDef {
   };
 }
 
-export { France_Lyon, France_Paris, France_Angers, France_Coutances, France_SaintDenis, France_Strasbourg };
+export {
+  France_Lyon,
+  France_Paris,
+  France_Angers,
+  France_Coutances,
+  France_SaintDenis,
+  France_Strasbourg,
+  France_Toulouse,
+};

--- a/rites/roman1969/src/calendars/index.ts
+++ b/rites/roman1969/src/calendars/index.ts
@@ -1,4 +1,4 @@
-import { CalendarDef } from '../models/calendar-def';
+import type { CalendarDef } from '../models/calendar-def';
 
 import { Argentina } from './countries/argentina';
 import { Australia } from './countries/australia';
@@ -24,6 +24,7 @@ import {
   France_Paris,
   France_SaintDenis,
   France_Strasbourg,
+  France_Toulouse,
 } from './countries/france';
 import { Germany } from './countries/germany';
 import { Greece } from './countries/greece';
@@ -96,6 +97,7 @@ export const calendarDefinitions: Record<string, typeof CalendarDef> = {
   France_Paris,
   France_SaintDenis,
   France_Strasbourg,
+  France_Toulouse,
   GeneralRoman,
   Germany,
   Greece,

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1,5 +1,5 @@
 import { CanonizationLevels, Title } from '../constants/martyrology-metadata';
-import { MartyrologyCatalog } from '../types/martyrology';
+import type { MartyrologyCatalog } from '../types/martyrology';
 
 export const Martyrology: { catalog: MartyrologyCatalog } = {
   catalog: {
@@ -580,6 +580,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Aurelia',
       titles: [Title.Virgin],
     },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Aventin
+    aventin_of_larboust_martyr: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Aventin',
+      titles: [Title.Martyr],
+      dateOfDeath: { century: 8 },
+    },
     // src: mr_fr_2014_ed2_lyon
     baldomerus_of_lyon_religious: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -679,6 +688,20 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Bernardine of Siena',
       titles: [Title.Priest],
       dateOfDeath: 1444,
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Bertrand_of_Comminges
+    bertrand_of_comminges_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Bertrand of Comminges',
+      titles: [Title.Bishop],
+      dateOfBirth: 1050,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: 1126,
+      dateOfBeatification: 1220,
+      dateOfBeatificationIsApproximative: true,
+      dateOfCanonization: 1309,
     },
     beuno_of_wales_abbot: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -1178,6 +1201,12 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france: {
       dateOfDedication: 1096,
     },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Toulouse_Cathedral
+    dedication_of_the_cathedral_of_saint_stephen_of_toulouse_france: {
+      dateOfDedication: '1592-08-30',
+    },
     dedication_of_the_lateran_basilica: {
       name: 'Dedication of the Lateran Basilica',
     },
@@ -1346,6 +1375,18 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       dateOfDeath: 178,
       titles: [Title.Martyr],
     },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Erembert_of_Toulouse
+    erembert_of_toulouse_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Erembert',
+      titles: [Title.Bishop],
+      dateOfBirth: 615,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: 672,
+      dateOfDeathIsApproximative: true,
+    },
     eric_ix_of_sweden_martyr: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Eric IX of Sweden',
@@ -1416,6 +1457,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     },
     exaltation_of_the_holy_cross: {
       name: 'The Exaltation of the Holy Cross',
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Exuperius
+    exuperius_of_toulouse_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Exuperius',
+      titles: [Title.Bishop],
+      dateOfDeath: 410,
+      dateOfDeathIsApproximative: true,
     },
     eysteinn_of_nidaros_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -1748,6 +1799,18 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Bishop],
       dateOfDeath: 576,
     },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Germaine_Cousin
+    germaine_cousin_virgin: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Germaine Cousin',
+      titles: [Title.Virgin],
+      dateOfBirth: 1579,
+      dateOfDeath: 1601,
+      dateOfBeatification: '1854-05-07',
+      dateOfCanonization: '1867-06-29',
+    },
     germanus_of_auxerre_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Germanus of Auxerre',
@@ -1931,6 +1994,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Hermenegild',
       titles: [Title.Martyr],
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Roman_Catholic_Archdiocese_of_Toulouse
+    hilarius_of_toulouse_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Hilarius',
+      titles: [Title.Bishop],
+      dateOfDeath: 360,
+      dateOfDeathIsApproximative: true,
     },
     hilary_of_poitiers_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -2366,13 +2439,18 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Bishop, Title.Martyr],
       dateOfDeath: '1535-06-22',
     },
-    // src: mr_fr_2014_ed2_lyon
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - mr_fr_2014_ed2_lyon
+    // - https://en.wikipedia.org/wiki/John_Francis_Regis
     john_francis_regis_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'John Francis Regis',
       titles: [Title.Priest, Title.Missionary],
-      dateOfBirth: 1597,
+      dateOfBirth: '1597-01-31',
       dateOfDeath: '1640-12-31',
+      dateOfBeatification: '1716-05-18',
+      dateOfCanonization: '1737-04-05',
     },
     john_gabriel_perboyre_priest: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -2861,6 +2939,17 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Louis',
       titles: [Title.King],
       dateOfDeath: 1270,
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Louis_of_Toulouse
+    louis_of_toulouse_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Louis of Toulouse',
+      titles: [Title.Bishop],
+      dateOfBirth: '1274-02-09',
+      dateOfDeath: '1297-08-19',
+      dateOfCanonization: '1317-04-07',
     },
     louis_zephirin_moreau_bishop: {
       canonizationLevel: CanonizationLevels.Blessed,
@@ -3846,6 +3935,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Martyr],
       dateOfDeath: 1597,
     },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Paul_of_Narbonne
+    paul_of_narbonne_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Paul of Narbonne',
+      titles: [Title.Bishop],
+      dateOfDeath: { century: 3 },
+    },
     paul_of_the_cross_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Paul of the Cross',
@@ -3984,6 +4082,17 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Peter Liu Wenyuan',
       titles: [Title.Martyr],
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Peter_Nolasco
+    peter_nolasco_religious: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Peter Nolasco',
+      titles: [Title.Religious],
+      dateOfBirth: 1189,
+      dateOfDeath: '1256-05-06',
+      dateOfCanonization: '1628-09-30',
     },
     peter_of_alcantara_priest: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -4149,11 +4258,27 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Raphael of Saint Joseph Kalinowski',
       titles: [Title.Priest],
     },
+    // src: mr_fr_1974_ed1_region_apostolique_du_midi
+    raymond_costeran_martyr: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Raymond Costeran',
+      titles: [Title.Martyr],
+      dateOfDeath: '1242-05-29',
+    },
     raymond_of_penyafort_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Raymond of Penyafort',
       titles: [Title.Priest],
       dateOfDeath: 1275,
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Raymond_of_Toulouse_(saint)
+    raymond_gayrard_religious: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Raymond Gayrard',
+      titles: [Title.Religious],
+      dateOfDeath: '1118-07-03',
     },
     remigius_of_reims_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -4267,6 +4392,17 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Blessed,
       name: 'Sára Salkaházi',
       titles: [Title.Virgin, Title.Martyr],
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Saturnin
+    saturnin_of_toulouse_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Saturnin',
+      titles: [Title.Bishop, Title.Martyr],
+      dateOfBirth: { century: 3 },
+      dateOfDeath: 257,
+      dateOfDeathIsApproximative: true,
     },
     scholastica_of_nursia_virgin: {
       canonizationLevel: CanonizationLevels.Saint,
@@ -4408,6 +4544,7 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Stephen Pongrácz',
       titles: [Title.Priest, Title.Martyr],
     },
+    // src: https://en.wikipedia.org/wiki/Stephen_of_Toulouse
     stephen_the_first_martyr: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Stephen',
@@ -4432,6 +4569,16 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Sylvester I',
       titles: [Title.Pope],
       dateOfDeath: 335,
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Sylvius_of_Toulouse
+    sylvius_of_toulouse_bishop: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Sylvius',
+      titles: [Title.Bishop],
+      dateOfDeath: 400,
+      dateOfDeathIsApproximative: true,
     },
     szilard_bogdanffy_bishop: {
       canonizationLevel: CanonizationLevels.Blessed,
@@ -4514,11 +4661,18 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       name: 'Thomas',
       titles: [Title.Apostle],
     },
+    // src:
+    // - mr_fr_2021_ed3
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Thomas_Aquinas
     thomas_aquinas_priest: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Thomas Aquinas',
       titles: [Title.Priest, Title.DoctorOfTheChurch],
-      dateOfDeath: 1274,
+      dateOfBirth: 1225,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '1274-03-07',
+      dateOfCanonization: '1323-07-19',
     },
     // src:
     // - mr_fr_1982_ed2_coutances
@@ -4619,6 +4773,28 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       dateOfDeath: {
         century: 3,
       },
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Pope_Urban_II
+    urban_ii_pope: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Urban II',
+      titles: [Title.Pope],
+      dateOfBirth: 1035,
+      dateOfBirthIsApproximative: true,
+      dateOfDeath: '1099-07-29',
+    },
+    // src:
+    // - mr_fr_1974_ed1_region_apostolique_du_midi
+    // - https://en.wikipedia.org/wiki/Pope_Urban_V
+    urban_v_pope: {
+      canonizationLevel: CanonizationLevels.Blessed,
+      name: 'Urban V',
+      titles: [Title.Pope],
+      dateOfBirth: 1310,
+      dateOfDeath: '1370-12-19',
+      dateOfBeatification: '1870-05-10',
     },
     ursula_of_cologne_virgin: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/rites/roman1969/src/constants/martyrology-metadata.ts
+++ b/rites/roman1969/src/constants/martyrology-metadata.ts
@@ -1,5 +1,5 @@
-import { ScreamingSnakeCase } from '../types/common';
-import { RomcalTitles } from '../types/liturgical-day';
+import type { ScreamingSnakeCase } from '../types/common';
+import type { RomcalTitles } from '../types/liturgical-day';
 import { toScreamingSnakeCase } from '../utils/string';
 
 /**
@@ -108,6 +108,7 @@ export enum PatronTitle {
   PatronOfTheClergyOfTheArchdioceseOfLyon = 'PATRON_OF_THE_CLERGY_OF_THE_ARCHDIOCESE_OF_LYON',
   PatronOfTheCityOfLyon = 'PATRON_OF_THE_CITY_OF_LYON',
   PatronessOfCostaRica = 'PATRONESS_OF_COSTA_RICA',
+  PrincipalPatronOfTheDiocese = 'PRINCIPAL_PATRON_OF_THE_DIOCESE',
   SecondPatronOfTheDiocese = 'SECOND_PATRON_OF_THE_DIOCESE',
 }
 

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -1,4 +1,4 @@
-import { Locale } from '../types/locale';
+import type { Locale } from '../types/locale';
 
 export const locale: Locale = {
   id: 'en',
@@ -237,6 +237,7 @@ export const locale: Locale = {
     athanasius_of_alexandria_bishop: 'Saint Athanasius, Bishop and Doctor of the Church',
     attracta_of_killaraght_virgin: 'Saint Attracta, Virgin',
     aubert_of_avranches_bishop: 'Saint Aubert, Bishop',
+    aventin_of_larboust_martyr: 'Saint Aventin of Larboust, Martyr',
     audoen_of_rouen_bishop: 'Saint Audoen, Bishop',
     audomar_of_therouanne_bishop: 'Saint Audomar, Bishop',
     augustine_kazotic_bishop: 'Blessed Augustine Kažotić, Bishop and Martyr',
@@ -265,6 +266,7 @@ export const locale: Locale = {
     bernadette_soubirous_virgin: 'Saint Bernadette Soubirous, Virgin',
     bernard_of_clairvaux_abbot: 'Saint Bernard, Abbot and Doctor of the Church',
     bernardine_of_siena_priest: 'Saint Bernardine of Siena, Priest',
+    bertrand_of_comminges_bishop: 'Saint Bertrand of Comminges, Bishop',
     beuno_of_wales_abbot: 'Saint Beuno, Abbot',
     blaise_of_sebaste_bishop: 'Saint Blaise, Bishop and Martyr',
     blessed_martyrs_of_angers: 'Blessed Martyrs of Angers', // mr_fr_2022_ed3_angers
@@ -380,6 +382,8 @@ export const locale: Locale = {
       'The Dedication of the Cathedral of Saint John the Baptist, Lyon',
     dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france:
       'The Dedication of the Cathedral Saint Maurice of Angers, France', // mr_fr_2022_ed3_angers
+    dedication_of_the_cathedral_of_saint_stephen_of_toulouse_france:
+      'The Dedication of the Cathedral of Saint Stephen of Toulouse, France',
     dedication_of_the_lateran_basilica: 'The Dedication of the Lateran Basilica',
     dedication_of_the_notre_dame_de_paris_cathedral_paris_france:
       'The Dedication of the Notre-Dame de Paris Cathedral, Paris',
@@ -419,6 +423,7 @@ export const locale: Locale = {
     epiphany_of_the_lord: 'The Epiphany of the Lord',
     epipodius_of_lyon_and_alexander_of_lyon_martyrs: 'Saints Epipodius and Alexander, Martyrs',
     eric_ix_of_sweden_martyr: 'Saint Eric IX of Sweden, Martyr',
+    erembert_of_toulouse_bishop: 'Saint Erembert of Toulouse, Bishop',
     etheldreda_of_ely_abbess: 'Saint Etheldreda, Abbess',
     eucherius_of_lyon_bishop: 'Saint Eucherius, Bishop',
     eucharius_of_trier_bishop: 'Saint Eucharius, Bishop',
@@ -429,6 +434,7 @@ export const locale: Locale = {
     eusebius_of_esztergom_priest: 'Blessed Eusebius of Esztergom, Priest',
     eusebius_of_vercelli_bishop: 'Saint Eusebius of Vercelli, Bishop',
     exaltation_of_the_holy_cross: 'The Exaltation of the Holy Cross',
+    exuperius_of_toulouse_bishop: 'Saint Exuperius of Toulouse, Bishop',
     eysteinn_of_nidaros_bishop: 'Saint Eysteinn of Nidaros, Bishop',
     ezequiel_moreno_bishop: 'Saint Ezequiel Moreno, Bishop',
     fabian_i_pope: 'Saint Fabian, Pope and Martyr',
@@ -487,6 +493,7 @@ export const locale: Locale = {
     george_preca_priest: 'Saint George Preca, Priest',
     gerard_of_csanad_bishop: 'Saint Gerard of Csanád, Bishop and Martyr',
     germain_of_paris_bishop: 'Saint Germain of Paris, Bishop',
+    germaine_cousin_virgin: 'Saint Germaine Cousin, Virgin',
     germanus_of_auxerre_bishop: 'Saint Germanus of Auxerre, Bishop',
     germanus_of_normandy_bishop: 'Saint Germanus of Normandy, Bishop and Martyr',
     gertrude_of_nivelles_abbess: 'Saint Gertrude of Nivelles, Abbess',
@@ -518,6 +525,8 @@ export const locale: Locale = {
     henry_suso_priest: 'Blessed Henry Suso, Priest',
     hermann_joseph_of_steinfeld_priest: 'Saint Hermann Joseph, Priest',
     hermenegild_the_visigoths_martyr: 'Saint Hermenegild, Martyr',
+    hilarius_of_toulouse_bishop: 'Saint Hilary of Toulouse, Bishop',
+    hilarius_of_toulouse_bishop_and_sylvius_of_toulouse_bishops: 'Saints Hilary and Sylvius of Toulouse, Bishops',
     hilary_of_poitiers_bishop: 'Saint Hilary, Bishop and Doctor of the Church',
     hilda_of_whitby_abbess: 'Saint Hilda, Abbess',
     hildegard_of_bingen_abbess: 'Saint Hildegard of Bingen, Abbess and Doctor of the Church',
@@ -691,6 +700,7 @@ export const locale: Locale = {
     licinius_of_angers_bishop: 'Saint Licinius of Angers, Bishop', // mr_fr_2022_ed3_angers
     louis_bertrand_priest: 'Saint Louis Bertrand, Priest',
     louis_grignion_de_montfort_priest: 'Saint Louis Grignion de Montfort, Priest',
+    louis_of_toulouse_bishop: 'Saint Louis of Toulouse, Bishop',
     louis_ix_of_france: 'Saint Louis',
     louis_zephirin_moreau_bishop: 'Blessed Louis-Zéphirin Moreau, Bishop',
     louise_de_marillac_religious: 'Saint Louise de Marillac, Religious',
@@ -901,6 +911,7 @@ export const locale: Locale = {
     paul_of_the_cross_priest: 'Saint Paul of the Cross, Priest',
     paul_of_thebes_hermit: 'Blessed Paul of Thebes, Hermit',
     paul_vi_pope: 'Saint Paul VI, Pope',
+    paul_of_narbonne_bishop: 'Saint Paul of Narbonne, Bishop',
     paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin:
       'Saint Paulina of the Agonizing Heart of Jesus Visintainer, Virgin',
     paulinus_of_nola_bishop: 'Saint Paulinus of Nola, Bishop',
@@ -925,6 +936,7 @@ export const locale: Locale = {
     peter_julian_eymard_priest: 'Saint Peter Julian Eymard, Priest',
     peter_kibe_priest_and_companions_martyrs: 'Blessed Peter Kibe, Priest, and Companions, Martyrs',
     peter_liu_wenyuan_martyr: 'Saint Peter Liu Wenyuan, Martyr',
+    peter_nolasco_religious: 'Saint Peter Nolasco, Religious',
     peter_of_alcantara_priest: 'Saint Peter of Alcántara, Priest',
     peter_sanz_bishop: 'Saint Peter Sanz, Bishop and Martyr',
     peter_to_rot_martyr: 'Blessed Peter To Rot, Martyr',
@@ -960,6 +972,9 @@ export const locale: Locale = {
     raphael_guizar_y_valencia_bishop: 'Saint Raphael Guízar y Valencia, Bishop',
     raphael_of_saint_joseph_kalinowski_priest: 'Saint Raphael of Saint Joseph Kalinowski, Priest',
     raymond_of_penyafort_priest: 'Saint Raymond of Penyafort, Priest',
+    raymond_costeran_and_companions_martyrs: 'Blessed Raymond Costeran and Companions, Martyrs',
+    raymond_costeran_martyr: 'Blessed Raymond Costeran, Martyr',
+    raymond_gayrard_religious: 'Saint Raymond Gayrard, Religious',
     remigius_of_reims_bishop: 'Saint Remigius, Bishop',
     rene_goupil_religious: 'Saint René Goupil, Religious and Martyr', // mr_fr_2022_ed3_angers
     richard_gwyn_martyr: 'Saint Richard Gwyn, Martyr',
@@ -980,6 +995,7 @@ export const locale: Locale = {
     salomea_of_poland_religious: 'Blessed Salomea of Poland, Religious',
     sancha_of_portugal_and_mafalda_of_portugal_virgins: 'Blessed Sancha and Mafalda, Virgins',
     sara_salkahazi_virgin: 'Blessed Sára Salkaházi, Virgin and Martyr',
+    saturnin_of_toulouse_bishop: 'Saint Saturnin of Toulouse, Bishop and Martyr',
     scholastica_of_nursia_virgin: 'Saint Scholastica, Virgin',
     sebastian_de_aparicio_religious: 'Blessed Sebastian de Aparicio, Religious',
     sebastian_of_milan_martyr: 'Saint Sebastian, Martyr',
@@ -1005,10 +1021,13 @@ export const locale: Locale = {
     stanislaus_of_szczepanow_bishop_patron_of_poland: 'Saint Stanislaus, Bishop and Martyr, Patron of Poland',
     stephen_i_of_hungary: 'Saint Stephen of Hungary',
     stephen_the_first_martyr: 'Saint Stephen, the First Martyr',
+    stephen_the_first_martyr_and_principal_patron_of_the_archdiocese_of_toulouse:
+      'Saint Stephen, the First Martyr, Principal Patron of the Archdiocese of Toulouse',
     sunday_of_the_word_of_god: 'Third Sunday in Ordinary Time, or Sunday of the Word of God',
     sunniva_of_norway_virgin: 'Saint Sunniva, Virgin and Martyr',
     swithun_of_winchester_bishop: 'Saint Swithun, Bishop',
     sylvester_i_pope: 'Saint Sylvester I, Pope',
+    sylvius_of_toulouse_bishop: 'Saint Sylvius of Toulouse, Bishop',
     szilard_bogdanffy_bishop: 'Blessed Szilárd Bogdánffy, Bishop and Martyr',
     teilo_of_llandaff_bishop: 'Saint Teilo, Bishop',
     teresa_benedicta_of_the_cross_stein_virgin: 'Saint Teresa Benedicta of the Cross Stein, Virgin and Martyr',
@@ -1047,6 +1066,8 @@ export const locale: Locale = {
     turibius_of_mogrovejo_bishop: 'Saint Turibius of Mogrovejo, Bishop',
     ulrich_of_augsburg_bishop: 'Saint Ulrich of Augsburg, Bishop',
     urban_i_pope: 'Saint Urban I, Pope',
+    urban_ii_pope: 'Blessed Urban II, Pope',
+    urban_v_pope: 'Blessed Urban V, Pope',
     ursula_of_cologne_and_companions_virgins: 'Saint Ursula and Companions, Virgins and Martyrs',
     valentine_of_raetia_bishop: 'Saint Valentine of Raetia, Bishop',
     valerius_of_trier_bishop: 'Saint Valerius, Bishop',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -1,4 +1,4 @@
-import { Locale } from '../types/locale';
+import type { Locale } from '../types/locale';
 
 export const locale: Locale = {
   id: 'fr',
@@ -213,6 +213,7 @@ export const locale: Locale = {
       'Assomption de la bienheureuse Vierge Marie, patronne principale de la France',
     athanasius_of_alexandria_bishop: 'Saint Athanase, évêque, docteur et père de l’Église († 373)',
     aubert_of_avranches_bishop: 'Saint Aubert, évêque († 725)', // src: mr_fr_1982_ed2_coutances
+    aventin_of_larboust_martyr: 'Saint Aventin, martyr († VIIIème s.)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     audoen_of_rouen_bishop: 'Saint Ouen, évêque',
     audomar_of_therouanne_bishop: 'Saint Omer, évêque († 670)', // src: mr_fr_1982_ed2_coutances
     augustine_of_canterbury_bishop: 'Saint Augustin, évêque de Cantorbéry en Angleterre († 604)',
@@ -236,6 +237,7 @@ export const locale: Locale = {
     bernadette_soubirous_virgin: 'Sainte Bernadette Soubirous, vierge († 1879)',
     bernard_of_clairvaux_abbot: 'Saint Bernard de Clairvaux, abbé, docteur de l’Église († 1153)',
     bernardine_of_siena_priest: 'Saint Bernardin de Sienne, prêtre († 1444)',
+    bertrand_of_comminges_bishop: 'Saint Bertrand de Comminges, évêque († 1126)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     blaise_of_sebaste_bishop: 'Saint Blaise de Sébaste, évêque et martyr († 316)',
     blessed_martyrs_of_angers: 'Bienheureux Martyrs d’Angers († 1793-1794)', // mr_fr_2022_ed3_angers
     blessed_martyrs_of_paris: 'Bienheureux Martyrs de Paris († du 2 au 6 septembre 1792)',
@@ -304,7 +306,8 @@ export const locale: Locale = {
     dedication_of_the_cathedral_of_notre_dame_of_coutances_france: 'Dédicace de la cathédrale de Coutances', // src: mr_fr_1982_ed2_coutances
     dedication_of_the_cathedral_of_notre_dame_de_strasbourg_france: 'Dédicace de la cathédrale de Strasbourg',
     dedication_of_the_cathedral_of_saint_john_the_baptist_lyon_france: 'Dédicace de la cathédrale primatiale', // src: mr_fr_2014_ed2_lyon
-    dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france: 'Dédicace de la Cathédrale Saint Maurice', // mr_fr_2022_ed3_angers
+    dedication_of_the_cathedral_of_saint_maurice_of_agaunum_angers_france: 'Dédicace de la Cathédrale Saint-Maurice', // mr_fr_2022_ed3_angers
+    dedication_of_the_cathedral_of_saint_stephen_of_toulouse_france: 'Dédicace de la cathédrale Saint-Étienne', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     dedication_of_the_lateran_basilica: 'Dédicace de la Basilique du Latran',
     dedication_of_the_notre_dame_de_paris_cathedral_paris_france: 'Dédicace de la cathédrale de Paris',
     denis_of_paris_bishop_and_companions_martyrs:
@@ -325,6 +328,7 @@ export const locale: Locale = {
       'Bienheureuse Émilie Tavernier-Gamelin, religieuse, fondatrice des Sœurs de la Providence de Montréal († 1851)',
     ephrem_the_syrian_deacon: 'Saint Ephrem, diacre et docteur de l’Église, († 373)',
     epiphany_of_the_lord: 'Épiphanie du Seigneur',
+    erembert_of_toulouse_bishop: 'Saint Érembert, évêque († v. 672)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     epipodius_of_lyon_and_alexander_of_lyon_martyrs: 'Saints Épipode et Alexandre, martyrs († 178)', // src: mr_fr_2014_ed2_lyon
     eucharius_of_trier_bishop: 'Saint Euchaire, évêque († IVème s.)',
     eucherius_of_lyon_bishop: 'Saint Eucher, évêque († v. 449)', // src: mr_fr_2014_ed2_lyon
@@ -333,6 +337,7 @@ export const locale: Locale = {
     eugenia_of_alsace_and_attala_of_alsace_virgins: 'Sainte Eugénie et Sainte Attale, vierges († VIIIème s.)',
     eusebius_of_vercelli_bishop: 'Saint Eusèbe de Verceil, évêque († 371)',
     exaltation_of_the_holy_cross: 'La Croix Glorieuse',
+    exuperius_of_toulouse_bishop: 'Saint Exupère, évêque († v. 410)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     fabian_i_pope: 'Saint Fabien, pape et martyr († 250)',
     faustina_kowalska_virgin: 'Sainte Faustina Kowalska († 1938)',
     fidelis_of_sigmaringen_priest: 'Saint Fidèle de Sigmaringen, prêtre et martyr († 1622)',
@@ -361,6 +366,7 @@ export const locale: Locale = {
     george_of_lydda_martyr: 'Saint Georges, martyr († 303)',
     george_of_lydda_martyr_patron_of_england: 'Saint Georges, martyr et patron de l’Angleterre († 303)',
     germain_of_paris_bishop: 'Saint Germain, évêque de Paris († 576)',
+    germaine_cousin_virgin: 'Sainte Germaine Cousin, vierge († 1601)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     germanus_of_normandy_bishop: 'Saint Germain de la Mer, évêque et martyr († 480)', // src: mr_fr_1982_ed2_coutances
     gertrude_of_nivelles_abbess: 'Sainte Gertrude de Nivelles, abbesse († 659)',
     gertrude_the_great_virgin: 'Sainte Gertrude, vierge moniale († 1301)',
@@ -372,6 +378,9 @@ export const locale: Locale = {
     helier_of_jersey_martyr: 'Saint Hélier, martyr († v. 552)', // src: mr_fr_1982_ed2_coutances
     henry_ii_emperor: 'Saint Henri, empereur germanique († 1024)',
     henry_of_finland_bishop: 'Saint Henri, évêque et martyr († 1156)',
+    hilarius_of_toulouse_bishop: 'Saint Hilaire, évêque († v. 360)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
+    hilarius_of_toulouse_bishop_and_sylvius_of_toulouse_bishops:
+      'Saint Hilaire († v. 360) et Saint Silve († v. 400), évêques', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     hilary_of_poitiers_bishop: 'Saint Hilaire de Poitiers, évêque et docteur de l’Église († 367)',
     hildegard_of_bingen_abbess: 'Sainte Hildegarde de Bingen, abbesse et docteur de l’Église († 1179)',
     holy_family_of_jesus_mary_and_joseph: 'La Sainte Famille',
@@ -469,6 +478,7 @@ export const locale: Locale = {
     licinius_of_angers_bishop: 'Saint Lézin, évêque († 610)', // mr_fr_2022_ed3_angers
     louis_grignion_de_montfort_priest: 'Saint Louis-Marie Grignion de Montfort, prêtre († 1716)', // mr_fr_2021_ed3
     louis_ix_of_france: 'Saint Louis, roi de France († 1270)',
+    louis_of_toulouse_bishop: 'Saint Louis d’Anjou, évêque († 1297)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     louis_zephirin_moreau_bishop: 'Bienheureux Louis Zéphyrin Moreau, évêque († 1901)',
     louise_de_marillac_religious: 'Sainte Louise de Marillac, religieuse († 1660)',
     lucy_of_syracuse_virgin: 'Sainte Lucie, vierge et martyre en Sicile († v. 305)',
@@ -579,6 +589,7 @@ export const locale: Locale = {
     patrick_of_ireland_bishop: 'Saint Patrick, évêque († 461)',
     patrick_of_ireland_bishop_patron_of_ireland: 'Saint Patrick, évêque, patron de l’Irlande († 461)',
     paul_miki_and_companions_martyrs: 'Saints Paul Miki et ses compagnons, martyrs au Japon († 1597)',
+    paul_of_narbonne_bishop: 'Saint Paul de Narbonne, évêque († IIIème s.)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     paul_of_the_cross_priest: 'Saint Paul de la Croix, prêtre († 1776)',
     paul_vi_pope: 'Saint Paul VI, pape († 1978)',
     paulinus_of_nola_bishop: 'Saint Paulin, évêque († 431)',
@@ -594,6 +605,7 @@ export const locale: Locale = {
     peter_julian_eymard_priest:
       // note: fondateur des Pères du Saint-Sacrement
       'Saint Pierre-Julien Eymard, prêtre († 1868)', // mr_fr_2021_ed3
+    peter_nolasco_religious: 'Saint Pierre Nolasque, religieux († 1256)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     philip_and_james_apostles: 'Saint Philippe et Saint Jacques le Mineur, apôtres',
     philip_neri_priest: 'Saint Philippe Néri, prêtre († 1595)',
     pirmin_of_hornbach_abbot: 'Saint Pirmin, abbé († 753)',
@@ -611,6 +623,9 @@ export const locale: Locale = {
     presentation_of_the_lord: 'Présentation du Seigneur au Temple',
     queenship_of_the_blessed_virgin_mary: 'Vierge Marie, reine',
     raymond_of_penyafort_priest: 'Saint Raymond de Peñafort, prêtre († 1275)',
+    raymond_costeran_and_companions_martyrs: 'Bienheureux Raymond et ses compagnons, martyrs († 1242)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
+    raymond_costeran_martyr: 'Bienheureux Raymond, martyr († 1242)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
+    raymond_gayrard_religious: 'Saint Raymond Gayrard, religieux († 1118)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     remigius_of_reims_bishop: 'Saint Remi, évêque de Reims († 530)',
     rene_goupil_religious: 'Saint René Goupil, religieux et martyr († 1642)', // mr_fr_2022_ed3_angers
     richardis_of_swabia_empress: 'Sainte Richarde, impératrice († 894 ou 896)',
@@ -620,6 +635,7 @@ export const locale: Locale = {
     rosalie_jeanne_marie_rendu_virgin: 'Bienheureuse Rosalie Rendu, vierge († 1856)',
     rose_of_lima_virgin: 'Sainte Rose de Lima, vierge († 1617)',
     rumpharius_of_coutances_bishop: 'Saint Romphaire, évêque de Coutance († VIème s.)', // src: mr_fr_1982_ed2_coutances
+    saturnin_of_toulouse_bishop: 'Saint Saturnin, évêque et martyr († v. 257)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     scholastica_of_nursia_virgin: 'Sainte Scholastique, Moniale, sœur de Saint Benoît († 543)',
     sebastian_of_milan_martyr: 'Saint Sébastien, martyr († v. 284)',
     senerius_of_normandy_bishop: 'Saint Senier, évêque d’Avranches († v. 574)', // src: mr_fr_1982_ed2_coutances
@@ -633,8 +649,11 @@ export const locale: Locale = {
       'Saint Stanislas, évêque de Cracovie, martyr et patron de la Pologne († 1079)',
     stephen_i_of_hungary: 'Saint Étienne, roi de Hongrie († 1038)',
     stephen_the_first_martyr: 'Saint Étienne, diacre et premier martyr († 35)',
+    stephen_the_first_martyr_and_principal_patron_of_the_archdiocese_of_toulouse:
+      'Saint Étienne, martyr, patron principal du diocèse († 35)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     sunday_of_the_word_of_god: 'Troisième dimanche du Temps Ordinaire, ou Dimanche de la Parole de Dieu',
     sylvester_i_pope: 'Saint Sylvestre Ier, pape († 335)',
+    sylvius_of_toulouse_bishop: 'Saint Silve, évêque († v. 400)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     teresa_benedicta_of_the_cross_stein_virgin:
       'Sainte Thérèse-Bénédicte de la Croix (Edith Stein), Carmélite, martyr en Pologne († 1942)',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
@@ -647,7 +666,7 @@ export const locale: Locale = {
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin_copatroness_of_france:
       'Sainte Thérèse de l’Enfant-Jésus, vierge, docteur de l’Église, co-patronne de la France († 1897)',
     thomas_apostle: 'Saint Thomas, apôtre',
-    thomas_aquinas_priest: 'Saint Thomas d’Aquin, frère prêcheur, docteur de l’Église († 1274)',
+    thomas_aquinas_priest: 'Saint Thomas d’Aquin, prêtre et docteur de l’Église († 1274)', // src: mr_fr_2021_ed3, mr_fr_1974_ed1_region_apostolique_du_midi
     thomas_becket_bishop: 'Saint Thomas Becket, évêque et martyr († 1170)',
     thomas_jean_georges_rehm_priest: 'Bienheureux Jean-Georges Rehm, prêtre et martyr († 1794)',
     thomas_helye_priest: 'Bienheureux Thomas Hélye, prêtre († 1257)', // src: mr_fr_1982_ed2_coutances
@@ -659,6 +678,8 @@ export const locale: Locale = {
     turibius_of_mogrovejo_bishop: 'Saint Alphonse Turibe de Mogrovejo, évêque de Lima († 1606)',
     ulrich_of_augsburg_bishop: 'Saint Ulrich, évêque († 973)',
     urban_i_pope: 'Saint Urbain Ier, pape († IIIème s.)',
+    urban_ii_pope: 'Bienheureux Urbain II, pape († 1099)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
+    urban_v_pope: 'Bienheureux Urbain V, pape († 1370)', // src: mr_fr_1974_ed1_region_apostolique_du_midi
     valerius_of_trier_bishop: 'Saint Valère, évêque († IVème s.)',
     viator_of_lyon: 'Saint Viateur († v. 389)', // src: mr_fr_2014_ed2_lyon
     vincent_de_paul_priest:

--- a/rites/roman1969/src/types/martyrology.ts
+++ b/rites/roman1969/src/types/martyrology.ts
@@ -1,6 +1,6 @@
-import { CanonizationLevel, Sex } from '../constants/martyrology-metadata';
+import type { CanonizationLevel, Sex } from '../constants/martyrology-metadata';
 
-import { RomcalTitles } from './liturgical-day';
+import type { RomcalTitles } from './liturgical-day';
 
 export type MartyrologyDef = {
   /**
@@ -15,10 +15,22 @@ export type MartyrologyDef = {
   dateOfCanonization?: SaintDateDef;
 
   /**
+   * Specify whether an approximate indicator should be added, when the date is displayed.
+   * For example in English: 'c. 201'.
+   */
+  dateOfCanonizationIsApproximative?: boolean;
+
+  /**
    * Date of Beatification, as a Number (year), a String (in 'YYYY-MM' or 'YYYY-MM-DD' format),
    * or an object describing date range, multiple possible date, or a century.
    */
   dateOfBeatification?: SaintDateDef;
+
+  /**
+   * Specify whether an approximate indicator should be added, when the date is displayed.
+   * For example in English: 'c. 201'.
+   */
+  dateOfBeatificationIsApproximative?: boolean;
 
   /**
    * Specify if the canonization level should not be displayed.


### PR DESCRIPTION
**Sources:** _Proper of the [Archdiocese of Toulouse, France](https://en.wikipedia.org/wiki/Archdiocese_of_Toulouse)  (1st edition, 1974)_.

<details>
  <summary><strong>Liturgical calendar</strong> – in French (screenshots of the proper of the diocese)</summary>
<img src="https://github.com/user-attachments/assets/855839f4-5c91-4679-ae81-84552029a5f4" alt="Calendrier du diocèse de Toulouse 1/2" />
<img src="https://github.com/user-attachments/assets/6e1bb2a5-34af-49a0-92e5-38f485bd7a65" alt="Calendrier du diocèse de Toulouse 2/2" />

</details>

---

In `martyrology.ts`, I also took the opportunity to add 2 metadata:
- `dateOfCanonizationIsApproximative `
- `dateOfBeatificationIsApproximative `

And in `martyrology-metadata.ts`, a new `PatronTitle` entry:
- `PrincipalPatronOfTheDiocese`