### PR TITLE
feat(spain): add peter_poveda_and_innocent

### DIFF
--- a/rites/roman1969/src/calendars/countries/spain/index.ts
+++ b/rites/roman1969/src/calendars/countries/spain/index.ts
@@ -126,6 +126,12 @@ export class Spain extends CalendarDef {
       dateDef: { month: 10, date: 19 },
     },
 
+    // src: https://www.conferenciaepiscopal.es/wp-content/uploads/2024/11/CLP-2024-2025.pdf#page=334
+    peter_poveda_and_innocent_of_mary_immaculate_canoura_priests_and_companions_martyrs: {
+      precedence: Precedences.GeneralMemorial_10,
+      dateDef: { month: 11, date: 6 },
+    },
+
     leander_of_seville_bishop: {
       precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 11, date: 13 },

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -939,6 +939,7 @@ export const locale: Locale = {
     peter_nolasco_religious: 'Saint Peter Nolasco, Religious',
     peter_of_alcantara_priest: 'Saint Peter of Alcántara, Priest',
     peter_poveda_and_innocent_of_mary_immaculate_canoura_priests_and_companions_martyrs:
+      // src: https://en.wikipedia.org/wiki/Pedro_Poveda_Castroverde, https://en.wikipedia.org/wiki/Inocencio_of_Mary_Immaculate, 
       'Saints Peter Poveda Castroverde and Innocent of Mary Immaculate Canoura Arnau, Priests, and Companions Martyrs',
     peter_sanz_bishop: 'Saint Peter Sanz, Bishop and Martyr',
     peter_to_rot_martyr: 'Blessed Peter To Rot, Martyr',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -939,7 +939,7 @@ export const locale: Locale = {
     peter_nolasco_religious: 'Saint Peter Nolasco, Religious',
     peter_of_alcantara_priest: 'Saint Peter of Alcántara, Priest',
     peter_poveda_and_innocent_of_mary_immaculate_canoura_priests_and_companions_martyrs:
-      // src: https://en.wikipedia.org/wiki/Pedro_Poveda_Castroverde, https://en.wikipedia.org/wiki/Inocencio_of_Mary_Immaculate, 
+      // src: https://en.wikipedia.org/wiki/Pedro_Poveda_Castroverde, https://en.wikipedia.org/wiki/Inocencio_of_Mary_Immaculate,
       'Saints Peter Poveda Castroverde and Innocent of Mary Immaculate Canoura Arnau, Priests, and Companions Martyrs',
     peter_sanz_bishop: 'Saint Peter Sanz, Bishop and Martyr',
     peter_to_rot_martyr: 'Blessed Peter To Rot, Martyr',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -938,6 +938,8 @@ export const locale: Locale = {
     peter_liu_wenyuan_martyr: 'Saint Peter Liu Wenyuan, Martyr',
     peter_nolasco_religious: 'Saint Peter Nolasco, Religious',
     peter_of_alcantara_priest: 'Saint Peter of Alcántara, Priest',
+    peter_poveda_and_innocent_of_mary_immaculate_canoura_priests_and_companions_martyrs:
+      'Saints Pedro Poveda Castroverde and Innocent of Immaculate Canoura Arnau, Priests, and Companions Martyrs',
     peter_sanz_bishop: 'Saint Peter Sanz, Bishop and Martyr',
     peter_to_rot_martyr: 'Blessed Peter To Rot, Martyr',
     peter_wu_guosheng_martyr: 'Saint Peter Wu Guosheng, Martyr',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -939,7 +939,7 @@ export const locale: Locale = {
     peter_nolasco_religious: 'Saint Peter Nolasco, Religious',
     peter_of_alcantara_priest: 'Saint Peter of Alcántara, Priest',
     peter_poveda_and_innocent_of_mary_immaculate_canoura_priests_and_companions_martyrs:
-      'Saints Pedro Poveda Castroverde and Innocent of Immaculate Canoura Arnau, Priests, and Companions Martyrs',
+      'Saints Peter Poveda Castroverde and Innocent of Mary Immaculate Canoura Arnau, Priests, and Companions Martyrs',
     peter_sanz_bishop: 'Saint Peter Sanz, Bishop and Martyr',
     peter_to_rot_martyr: 'Blessed Peter To Rot, Martyr',
     peter_wu_guosheng_martyr: 'Saint Peter Wu Guosheng, Martyr',

--- a/rites/roman1969/src/locales/es.ts
+++ b/rites/roman1969/src/locales/es.ts
@@ -551,6 +551,8 @@ export const locale: Locale = {
     peter_de_zuniga_and_louis_flores_priests: 'Beatos Pedro Zuniga y Luis Flores, presbíteros y mártires',
     peter_julian_eymard_priest: 'San Pedro Julián Eymard, presbítero',
     peter_of_alcantara_priest: 'San Pedro de Alcántara, presbítero',
+    peter_poveda_and_innocent_of_mary_immaculate_canoura_priests_and_companions_martyrs:
+      'Santos Pedro Poveda Castroverde e Inocencio de la Inmaculada Canoura Arnau, presbíteros, y compañeros, mártires', // src: https://www.conferenciaepiscopal.es/wp-content/uploads/2024/11/CLP-2024-2025.pdf#page=334
     philip_and_james_apostles: 'Santos Felipe y Santiago, apóstoles',
     philip_neri_priest: 'San Felipe Neri, presbítero',
     philip_of_jesus_de_las_casas_martyr: 'San Felipe de Jesús de las Casas, mártir',


### PR DESCRIPTION
## What is the purpose of this pull request?

Add missing memory in spain: "SANTOS PEDRO POVEDA CASTROVERDE e INOCENCIO DE LA INMACULADA CANOURA ARNAU, presbíteros, y compañeros, mártires, memoria obligatoria" from the episcopal conference in spain: https://www.conferenciaepiscopal.es/wp-content/uploads/2024/11/CLP-2024-2025.pdf#page=334

I've added the missing date and the spanish translate.

I'm not sure if I should add this to the martyrs object:
```
martyrology: ['peter_poveda_priest', 'inocencius_of_inmaculate_canoura_priest'],
```

## Concept

        - Localization
        - Calendar Definition

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
