### PR TITLE
fix(calendar): change precedence for dedication of Lateran Basilica

### DIFF
--- a/rites/roman1969/__tests__/__snapshots__/calendar-builder.test.ts.snap
+++ b/rites/roman1969/__tests__/__snapshots__/calendar-builder.test.ts.snap
@@ -31958,7 +31958,7 @@ exports[`Testing calendar snapshots General Roman Calendar in gregorian year 1`]
       "periods": [
         "LATE_ORDINARY_TIME",
       ],
-      "precedence": "GENERAL_FEAST_7",
+      "precedence": "GENERAL_LORD_FEAST_5",
       "rank": "FEAST",
       "seasons": [
         "ORDINARY_TIME",
@@ -68909,7 +68909,7 @@ exports[`Testing calendar snapshots General Roman Calendar in gregorian year 2`]
       "periods": [
         "LATE_ORDINARY_TIME",
       ],
-      "precedence": "GENERAL_FEAST_7",
+      "precedence": "GENERAL_LORD_FEAST_5",
       "rank": "FEAST",
       "seasons": [
         "ORDINARY_TIME",
@@ -106043,7 +106043,7 @@ exports[`Testing calendar snapshots General Roman Calendar in gregorian year 3`]
       "periods": [
         "LATE_ORDINARY_TIME",
       ],
-      "precedence": "GENERAL_FEAST_7",
+      "precedence": "GENERAL_LORD_FEAST_5",
       "rank": "FEAST",
       "seasons": [
         "ORDINARY_TIME",
@@ -146601,7 +146601,7 @@ exports[`Testing calendar snapshots General Roman Calendar in liturgical year 1`
       "periods": [
         "LATE_ORDINARY_TIME",
       ],
-      "precedence": "GENERAL_FEAST_7",
+      "precedence": "GENERAL_LORD_FEAST_5",
       "rank": "FEAST",
       "seasons": [
         "ORDINARY_TIME",
@@ -183552,7 +183552,7 @@ exports[`Testing calendar snapshots General Roman Calendar in liturgical year 2`
       "periods": [
         "LATE_ORDINARY_TIME",
       ],
-      "precedence": "GENERAL_FEAST_7",
+      "precedence": "GENERAL_LORD_FEAST_5",
       "rank": "FEAST",
       "seasons": [
         "ORDINARY_TIME",
@@ -220686,7 +220686,7 @@ exports[`Testing calendar snapshots General Roman Calendar in liturgical year 3`
       "periods": [
         "LATE_ORDINARY_TIME",
       ],
-      "precedence": "GENERAL_FEAST_7",
+      "precedence": "GENERAL_LORD_FEAST_5",
       "rank": "FEAST",
       "seasons": [
         "ORDINARY_TIME",

--- a/rites/roman1969/src/calendars/general-roman/index.ts
+++ b/rites/roman1969/src/calendars/general-roman/index.ts
@@ -1458,7 +1458,7 @@ export class GeneralRoman extends CalendarDef {
 
     // src: mr_la_2008_ed3
     dedication_of_the_lateran_basilica: {
-      precedence: Precedences.GeneralFeast_7,
+      precedence: Precedences.GeneralLordFeast_5,
       dateDef: { month: 11, date: 9 },
       commonsDef: Common.None,
     },

--- a/rites/roman1969/src/calendars/general-roman/index.ts
+++ b/rites/roman1969/src/calendars/general-roman/index.ts
@@ -1456,7 +1456,7 @@ export class GeneralRoman extends CalendarDef {
       commonsDef: Common.Bishops,
     },
 
-    // src: mr_la_2008_ed3
+    // src: Calendarium Romanum 1969 https://archive.org/details/CalendariumRomanum1969/page/n29/mode/2up
     dedication_of_the_lateran_basilica: {
       precedence: Precedences.GeneralLordFeast_5,
       dateDef: { month: 11, date: 9 },


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute a pull request! -->

<!-- Please fill out the following sections to help us understand your changes. -->

## What is the purpose of this pull request?

Change the rank of feast of the Lateran basilica to Our Lord's feast.

The feast of the Lateran basilica should be considered Our Lord's feast, as indicated in the [Calendarium Romanum (1969)](https://archive.org/details/CalendariumRomanum1969/page/n29/mode/2up) as well.

## Concept

 - Calendar Definition

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
