### PR TITLE
fix(pt-br): translation review and Brazilian calendar improvements

### DIFF
--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -7,10 +7,19 @@ import { Ranks } from '../src/constants/ranks';
 describe('Testing Brazilian calendar specific celebrations', () => {
   const romcal = new Romcal({ localizedCalendar: Brazil_PtBr });
 
+  let calendar2024: Awaited<ReturnType<typeof romcal.generateCalendar>>;
+  let calendar2025: Awaited<ReturnType<typeof romcal.generateCalendar>>;
+  let calendar2026: Awaited<ReturnType<typeof romcal.generateCalendar>>;
+
+  beforeAll(async () => {
+    calendar2024 = await romcal.generateCalendar(2024);
+    calendar2025 = await romcal.generateCalendar(2025);
+    calendar2026 = await romcal.generateCalendar(2026);
+  });
+
   describe('Brazilian saints', () => {
-    test('Santa Dulce Lopes Pontes should be celebrated on August 13', async () => {
-      const calendar = await romcal.generateCalendar(2024);
-      const august13 = calendar['2024-08-13'];
+    test('Santa Dulce Lopes Pontes should be celebrated on August 13', () => {
+      const august13 = calendar2024['2024-08-13'];
 
       const dulce = august13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
 
@@ -20,9 +29,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(dulce?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('São Pedro de Alcântara should be celebrated on October 19', async () => {
-      const calendar = await romcal.generateCalendar(2024);
-      const october19 = calendar['2024-10-19'];
+    test('São Pedro de Alcântara should be celebrated on October 19', () => {
+      const october19 = calendar2024['2024-10-19'];
 
       const peter = october19?.find((day) => day.id === 'peter_of_alcantara_priest');
 
@@ -32,9 +40,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peter?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', async () => {
-      const calendar = await romcal.generateCalendar(2024);
-      const october12 = calendar['2024-10-12'];
+    test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', () => {
+      const october12 = calendar2024['2024-10-12'];
 
       const aparecida = october12?.find((day) => day.id === 'our_lady_of_aparecida');
 
@@ -46,14 +53,13 @@ describe('Testing Brazilian calendar specific celebrations', () => {
   });
 
   describe('Peter and Paul transfer to Sunday in Brazil', () => {
-    test('When Peter and Paul falls between June 28 and July 4, it should be transferred to the first Sunday of July', async () => {
+    test('When Peter and Paul falls between June 28 and July 4, it should be transferred to the first Sunday of July', () => {
       // Test years where June 29 falls on different days of the week
       // 2024: June 29 is Saturday -> should be transferred to July 7 (first Sunday of July)
       // 2025: June 29 is Sunday -> no transfer needed
       // 2026: June 29 is Monday -> should be transferred to July 5 (first Sunday of July)
 
       // 2024: June 29 is Saturday
-      const calendar2024 = await romcal.generateCalendar(2024);
       const july7_2024 = calendar2024['2024-07-07'];
 
       // On July 7 (first Sunday of July), Peter and Paul should be celebrated
@@ -62,9 +68,10 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       // The transfer should work - Peter and Paul should be on July 7
       expect(peterPaulOnJuly7).toBeDefined();
       expect(peterPaulOnJuly7?.name).toBe('São Pedro e São Paulo, Apóstolos');
+      expect(peterPaulOnJuly7?.rank).toBe(Ranks.Solemnity);
+      expect(peterPaulOnJuly7?.precedence).toBe(Precedences.Solemnity_General_2);
 
       // 2026: June 29 is Monday
-      const calendar2026 = await romcal.generateCalendar(2026);
       const july5_2026 = calendar2026['2026-07-05'];
 
       // On July 5 (first Sunday of July), Peter and Paul should be celebrated
@@ -72,11 +79,12 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
       expect(peterPaulOnJuly5).toBeDefined();
       expect(peterPaulOnJuly5?.name).toBe('São Pedro e São Paulo, Apóstolos');
+      expect(peterPaulOnJuly5?.rank).toBe(Ranks.Solemnity);
+      expect(peterPaulOnJuly5?.precedence).toBe(Precedences.Solemnity_General_2);
     });
 
-    test('When Peter and Paul falls on Sunday (outside the transfer range), it should not be transferred', async () => {
+    test('When Peter and Paul falls on Sunday (outside the transfer range), it should not be transferred', () => {
       // 2025: June 29 is Sunday, so it should be celebrated on that day
-      const calendar2025 = await romcal.generateCalendar(2025);
       const june29_2025 = calendar2025['2025-06-29'];
 
       const peterPaul = june29_2025?.find((day) => day.id === 'peter_and_paul_apostles');
@@ -84,41 +92,43 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peterPaul).toBeDefined();
       expect(peterPaul?.name).toBe('São Pedro e São Paulo, Apóstolos');
       expect(peterPaul?.date).toBe('2025-06-29');
+      expect(peterPaul?.rank).toBe(Ranks.Solemnity);
+      expect(peterPaul?.precedence).toBe(Precedences.Solemnity_General_2);
     });
   });
 
   describe('Other Brazilian celebrations', () => {
-    test('São José de Anchieta should be celebrated on June 9', async () => {
-      const calendar = await romcal.generateCalendar(2023);
-      const june9 = calendar['2023-06-09'];
-
-      expect(june9).toBeDefined();
-      expect(june9).toBeArray();
+    test('São José de Anchieta should be celebrated on June 9', () => {
+      const june9 = calendar2024['2024-06-09'];
 
       const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
 
       expect(anchieta).toBeDefined();
       expect(anchieta?.name).toBe('São José de Anchieta, presbítero');
+      expect(anchieta?.rank).toBe(Ranks.Memorial);
+      expect(anchieta?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('Santa Paulina should be celebrated on July 9', async () => {
-      const calendar = await romcal.generateCalendar(2024);
-      const july9 = calendar['2024-07-09'];
+    test('Santa Paulina should be celebrated on July 9', () => {
+      const july9 = calendar2024['2024-07-09'];
 
       const paulina = july9?.find((day) => day.id === 'paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin');
 
       expect(paulina).toBeDefined();
       expect(paulina?.name).toBe('Santa Paulina do Coração Agonizante de Jesus Visintainer, virgem');
+      expect(paulina?.rank).toBe(Ranks.Memorial);
+      expect(paulina?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test("Santo Antônio de Sant'Anna Galvão should be celebrated on October 25", async () => {
-      const calendar = await romcal.generateCalendar(2024);
-      const october25 = calendar['2024-10-25'];
+    test("Santo Antônio de Sant'Anna Galvão should be celebrated on October 25", () => {
+      const october25 = calendar2024['2024-10-25'];
 
       const galvao = october25?.find((day) => day.id === 'anthony_of_saint_anne_galvao_priest');
 
       expect(galvao).toBeDefined();
       expect(galvao?.name).toBe("Santo Antônio de Sant'Anna Galvão, presbítero");
+      expect(galvao?.rank).toBe(Ranks.Memorial);
+      expect(galvao?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
   });
 });

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -51,11 +51,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
       // 2024: June 29 is Saturday
       const calendar2024 = await romcal.generateCalendar(2024);
-      const june29_2024 = calendar2024['2024-06-29'];
       const july7_2024 = calendar2024['2024-07-07'];
-
-      // On June 29, Peter and Paul should not be the main celebration (it's Saturday)
-      const peterPaulOnJune29 = june29_2024?.find((day) => day.id === 'peter_and_paul_apostles');
 
       // On July 7 (first Sunday of July), Peter and Paul should be celebrated
       const peterPaulOnJuly7 = july7_2024?.find((day) => day.id === 'peter_and_paul_apostles');
@@ -66,7 +62,6 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
       // 2026: June 29 is Monday
       const calendar2026 = await romcal.generateCalendar(2026);
-      const june29_2026 = calendar2026['2026-06-29'];
       const july5_2026 = calendar2026['2026-07-05'];
 
       // On July 5 (first Sunday of July), Peter and Paul should be celebrated

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -8,9 +8,9 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     test('Santa Dulce Lopes Pontes should be celebrated on August 13', async () => {
       const calendar = await romcal.generateCalendar(2024);
       const august13 = calendar['2024-08-13'];
-      
+
       const dulce = august13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
-      
+
       expect(dulce).toBeDefined();
       expect(dulce?.name).toBe('Santa Dulce Lopes Pontes, virgem e religiosa');
       expect(dulce?.rank).toBe('MEMORIAL');
@@ -20,9 +20,9 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     test('São Pedro de Alcântara should be celebrated on October 19', async () => {
       const calendar = await romcal.generateCalendar(2024);
       const october19 = calendar['2024-10-19'];
-      
+
       const peter = october19?.find((day) => day.id === 'peter_of_alcantara_priest');
-      
+
       expect(peter).toBeDefined();
       expect(peter?.name).toBe('São Pedro de Alcântara, presbítero');
       expect(peter?.rank).toBe('MEMORIAL');
@@ -32,9 +32,9 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', async () => {
       const calendar = await romcal.generateCalendar(2024);
       const october12 = calendar['2024-10-12'];
-      
+
       const aparecida = october12?.find((day) => day.id === 'our_lady_of_aparecida');
-      
+
       expect(aparecida).toBeDefined();
       expect(aparecida?.name).toBe('Nossa Senhora Aparecida');
       expect(aparecida?.rank).toBe('SOLEMNITY');
@@ -48,30 +48,30 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       // 2024: June 29 is Saturday -> should be transferred to July 7 (first Sunday of July)
       // 2025: June 29 is Sunday -> no transfer needed
       // 2026: June 29 is Monday -> should be transferred to July 5 (first Sunday of July)
-      
+
       // 2024: June 29 is Saturday
       const calendar2024 = await romcal.generateCalendar(2024);
       const june29_2024 = calendar2024['2024-06-29'];
       const july7_2024 = calendar2024['2024-07-07'];
-      
+
       // On June 29, Peter and Paul should not be the main celebration (it's Saturday)
       const peterPaulOnJune29 = june29_2024?.find((day) => day.id === 'peter_and_paul_apostles');
-      
+
       // On July 7 (first Sunday of July), Peter and Paul should be celebrated
       const peterPaulOnJuly7 = july7_2024?.find((day) => day.id === 'peter_and_paul_apostles');
-      
+
       // The transfer should work - Peter and Paul should be on July 7
       expect(peterPaulOnJuly7).toBeDefined();
       expect(peterPaulOnJuly7?.name).toBe('São Pedro e São Paulo, Apóstolos');
-      
+
       // 2026: June 29 is Monday
       const calendar2026 = await romcal.generateCalendar(2026);
       const june29_2026 = calendar2026['2026-06-29'];
       const july5_2026 = calendar2026['2026-07-05'];
-      
+
       // On July 5 (first Sunday of July), Peter and Paul should be celebrated
       const peterPaulOnJuly5 = july5_2026?.find((day) => day.id === 'peter_and_paul_apostles');
-      
+
       expect(peterPaulOnJuly5).toBeDefined();
       expect(peterPaulOnJuly5?.name).toBe('São Pedro e São Paulo, Apóstolos');
     });
@@ -80,9 +80,9 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       // 2025: June 29 is Sunday, so it should be celebrated on that day
       const calendar2025 = await romcal.generateCalendar(2025);
       const june29_2025 = calendar2025['2025-06-29'];
-      
+
       const peterPaul = june29_2025?.find((day) => day.id === 'peter_and_paul_apostles');
-      
+
       expect(peterPaul).toBeDefined();
       expect(peterPaul?.name).toBe('São Pedro e São Paulo, Apóstolos');
       expect(peterPaul?.date).toBe('2025-06-29');
@@ -93,9 +93,9 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     test('São José de Anchieta should be celebrated on June 9', async () => {
       const calendar = await romcal.generateCalendar(2024);
       const june9 = calendar['2024-06-09'];
-      
+
       const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
-      
+
       expect(anchieta).toBeDefined();
       expect(anchieta?.name).toBe('São José de Anchieta, presbítero');
     });
@@ -103,22 +103,21 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     test('Santa Paulina should be celebrated on July 9', async () => {
       const calendar = await romcal.generateCalendar(2024);
       const july9 = calendar['2024-07-09'];
-      
+
       const paulina = july9?.find((day) => day.id === 'paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin');
-      
+
       expect(paulina).toBeDefined();
       expect(paulina?.name).toBe('Santa Paulina do Coração Agonizante de Jesus Visintainer, virgem');
     });
 
-    test('Santo Antônio de Sant\'Anna Galvão should be celebrated on October 25', async () => {
+    test("Santo Antônio de Sant'Anna Galvão should be celebrated on October 25", async () => {
       const calendar = await romcal.generateCalendar(2024);
       const october25 = calendar['2024-10-25'];
-      
+
       const galvao = october25?.find((day) => day.id === 'anthony_of_saint_anne_galvao_priest');
-      
+
       expect(galvao).toBeDefined();
       expect(galvao?.name).toBe("Santo Antônio de Sant'Anna Galvão, presbítero");
     });
   });
 });
-

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -7,11 +7,13 @@ import { Ranks } from '../src/constants/ranks';
 describe('Testing Brazilian calendar specific celebrations', () => {
   const romcal = new Romcal({ localizedCalendar: Brazil_PtBr });
 
+  let calendar2023: Awaited<ReturnType<typeof romcal.generateCalendar>>;
   let calendar2024: Awaited<ReturnType<typeof romcal.generateCalendar>>;
   let calendar2025: Awaited<ReturnType<typeof romcal.generateCalendar>>;
   let calendar2026: Awaited<ReturnType<typeof romcal.generateCalendar>>;
 
   beforeAll(async () => {
+    calendar2023 = await romcal.generateCalendar(2023);
     calendar2024 = await romcal.generateCalendar(2024);
     calendar2025 = await romcal.generateCalendar(2025);
     calendar2026 = await romcal.generateCalendar(2026);
@@ -24,7 +26,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       const dulce = august13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
 
       expect(dulce).toBeDefined();
-      expect(dulce?.name).toBe('Santa Dulce Lopes Pontes, virgem e religiosa');
+      expect(dulce?.name).toBe('Santa Dulce Lopes Pontes, virgem');
       expect(dulce?.rank).toBe(Ranks.Memorial);
       expect(dulce?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
@@ -80,7 +82,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peterPaulOnJuly7).toBeDefined();
       expect(peterPaulOnJuly7?.name).toBe('São Pedro e São Paulo, Apóstolos');
       expect(peterPaulOnJuly7?.rank).toBe(Ranks.Solemnity);
-      expect(peterPaulOnJuly7?.precedence).toBe(Precedences.Solemnity_General_2);
+      expect(peterPaulOnJuly7?.precedence).toBe(Precedences.GeneralSolemnity_3);
 
       // 2026: June 29 is Monday
       const july5_2026 = calendar2026['2026-07-05'];
@@ -91,7 +93,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peterPaulOnJuly5).toBeDefined();
       expect(peterPaulOnJuly5?.name).toBe('São Pedro e São Paulo, Apóstolos');
       expect(peterPaulOnJuly5?.rank).toBe(Ranks.Solemnity);
-      expect(peterPaulOnJuly5?.precedence).toBe(Precedences.Solemnity_General_2);
+      expect(peterPaulOnJuly5?.precedence).toBe(Precedences.GeneralSolemnity_3);
     });
 
     test('When Peter and Paul falls on Sunday (outside the transfer range), it should not be transferred', () => {
@@ -104,13 +106,13 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peterPaul?.name).toBe('São Pedro e São Paulo, Apóstolos');
       expect(peterPaul?.date).toBe('2025-06-29');
       expect(peterPaul?.rank).toBe(Ranks.Solemnity);
-      expect(peterPaul?.precedence).toBe(Precedences.Solemnity_General_2);
+      expect(peterPaul?.precedence).toBe(Precedences.GeneralSolemnity_3);
     });
   });
 
   describe('Other Brazilian celebrations', () => {
     test('São José de Anchieta should be celebrated on June 9', () => {
-      const june9 = calendar2024['2024-06-09'];
+      const june9 = calendar2023['2023-06-09'];
 
       const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
 

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -40,6 +40,17 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peter?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
+    test('São Benedito, o Negro should be celebrated on October 5', () => {
+      const october5 = calendar2024['2024-10-05'];
+
+      const benedict = october5?.find((day) => day.id === 'benedict_the_moor_religious');
+
+      expect(benedict).toBeDefined();
+      expect(benedict?.name).toBe('São Benedito, o Negro, religioso');
+      expect(benedict?.rank).toBe(Ranks.Memorial);
+      expect(benedict?.precedence).toBe(Precedences.ProperMemorial_11b);
+    });
+
     test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', () => {
       const october12 = calendar2024['2024-10-12'];
 

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -20,7 +20,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
   });
 
   describe('Brazilian saints', () => {
-    test('Santa Dulce Lopes Pontes should be celebrated on August 13', () => {
+    test('St. Dulce Lopes Pontes should be celebrated on August 13', () => {
       const august13 = calendar2024['2024-08-13'];
 
       const dulce = august13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
@@ -31,7 +31,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(dulce?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('São Pedro de Alcântara should be celebrated on October 19', () => {
+    test('St. Peter of Alcântara should be celebrated on October 19', () => {
       const october19 = calendar2024['2024-10-19'];
 
       const peter = october19?.find((day) => day.id === 'peter_of_alcantara_priest');
@@ -42,7 +42,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peter?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('São Benedito, o Negro should be celebrated on October 5', () => {
+    test('St. Benedict the Moo should be celebrated on October 5', () => {
       const october5 = calendar2024['2024-10-05'];
 
       const benedict = october5?.find((day) => day.id === 'benedict_the_moor_religious');
@@ -53,7 +53,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(benedict?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', () => {
+    test('Our Lady of Aparecida should be celebrated on October 12 as a solemnity', () => {
       const october12 = calendar2024['2024-10-12'];
 
       const aparecida = october12?.find((day) => day.id === 'our_lady_of_aparecida');
@@ -65,8 +65,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     });
   });
 
-  describe('Peter and Paul transfer to Sunday in Brazil', () => {
-    test('When Peter and Paul falls between June 28 and July 4, it should be transferred to the first Sunday of July', () => {
+  describe('Sts. Peter and Paul transfer to Sunday in Brazil', () => {
+    test('When falling between June 28 and July 4, it should be transferred to the first Sunday of July', () => {
       // Test years where June 29 falls on different days of the week
       // 2024: June 29 is Saturday -> should be transferred to July 7 (first Sunday of July)
       // 2025: June 29 is Sunday -> no transfer needed
@@ -96,7 +96,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peterPaulOnJuly5?.precedence).toBe(Precedences.GeneralSolemnity_3);
     });
 
-    test('When Peter and Paul falls on Sunday (outside the transfer range), it should not be transferred', () => {
+    test('When falling on Sunday (outside the transfer range), it should not be transferred', () => {
       // 2025: June 29 is Sunday, so it should be celebrated on that day
       const june29_2025 = calendar2025['2025-06-29'];
 
@@ -111,7 +111,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
   });
 
   describe('Other Brazilian celebrations', () => {
-    test('São José de Anchieta should be celebrated on June 9', () => {
+    test('St. Joseph of Anchieta should be celebrated on June 9', () => {
       const june9 = calendar2023['2023-06-09'];
 
       const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
@@ -122,7 +122,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(anchieta?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('Santa Paulina should be celebrated on July 9', () => {
+    test('St. Paulina should be celebrated on July 9', () => {
       const july9 = calendar2024['2024-07-09'];
 
       const paulina = july9?.find((day) => day.id === 'paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin');
@@ -133,7 +133,7 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(paulina?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test("Santo Antônio de Sant'Anna Galvão should be celebrated on October 25", () => {
+    test('St. Anthony of St. Anne Galvao should be celebrated on October 25', () => {
       const october25 = calendar2024['2024-10-25'];
 
       const galvao = october25?.find((day) => day.id === 'anthony_of_saint_anne_galvao_priest');

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -89,8 +89,11 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
   describe('Other Brazilian celebrations', () => {
     test('São José de Anchieta should be celebrated on June 9', async () => {
-      const calendar = await romcal.generateCalendar(2024);
-      const june9 = calendar['2024-06-09'];
+      const calendar = await romcal.generateCalendar(2023);
+      const june9 = calendar['2023-06-09'];
+
+      expect(june9).toBeDefined();
+      expect(june9).toBeArray();
 
       const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
 

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -1,0 +1,124 @@
+import { Brazil_PtBr } from '@dist/rite-roman1969/bundles/brazil';
+import { Romcal } from '@src/rite-roman1969';
+
+describe('Testing Brazilian calendar specific celebrations', () => {
+  const romcal = new Romcal({ localizedCalendar: Brazil_PtBr });
+
+  describe('Brazilian saints', () => {
+    test('Santa Dulce Lopes Pontes should be celebrated on August 13', async () => {
+      const calendar = await romcal.generateCalendar(2024);
+      const august13 = calendar['2024-08-13'];
+      
+      const dulce = august13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
+      
+      expect(dulce).toBeDefined();
+      expect(dulce?.name).toBe('Santa Dulce Lopes Pontes, virgem e religiosa');
+      expect(dulce?.rank).toBe('MEMORIAL');
+      expect(dulce?.precedence).toBe('PROPER_MEMORIAL_11b');
+    });
+
+    test('São Pedro de Alcântara should be celebrated on October 19', async () => {
+      const calendar = await romcal.generateCalendar(2024);
+      const october19 = calendar['2024-10-19'];
+      
+      const peter = october19?.find((day) => day.id === 'peter_of_alcantara_priest');
+      
+      expect(peter).toBeDefined();
+      expect(peter?.name).toBe('São Pedro de Alcântara, presbítero');
+      expect(peter?.rank).toBe('MEMORIAL');
+      expect(peter?.precedence).toBe('PROPER_MEMORIAL_11b');
+    });
+
+    test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', async () => {
+      const calendar = await romcal.generateCalendar(2024);
+      const october12 = calendar['2024-10-12'];
+      
+      const aparecida = october12?.find((day) => day.id === 'our_lady_of_aparecida');
+      
+      expect(aparecida).toBeDefined();
+      expect(aparecida?.name).toBe('Nossa Senhora Aparecida');
+      expect(aparecida?.rank).toBe('SOLEMNITY');
+      expect(aparecida?.precedence).toBe('PROPER_SOLEMNITY_PRINCIPAL_PATRON_4a');
+    });
+  });
+
+  describe('Peter and Paul transfer to Sunday in Brazil', () => {
+    test('When Peter and Paul falls between June 28 and July 4, it should be transferred to the first Sunday of July', async () => {
+      // Test years where June 29 falls on different days of the week
+      // 2024: June 29 is Saturday -> should be transferred to July 7 (first Sunday of July)
+      // 2025: June 29 is Sunday -> no transfer needed
+      // 2026: June 29 is Monday -> should be transferred to July 5 (first Sunday of July)
+      
+      // 2024: June 29 is Saturday
+      const calendar2024 = await romcal.generateCalendar(2024);
+      const june29_2024 = calendar2024['2024-06-29'];
+      const july7_2024 = calendar2024['2024-07-07'];
+      
+      // On June 29, Peter and Paul should not be the main celebration (it's Saturday)
+      const peterPaulOnJune29 = june29_2024?.find((day) => day.id === 'peter_and_paul_apostles');
+      
+      // On July 7 (first Sunday of July), Peter and Paul should be celebrated
+      const peterPaulOnJuly7 = july7_2024?.find((day) => day.id === 'peter_and_paul_apostles');
+      
+      // The transfer should work - Peter and Paul should be on July 7
+      expect(peterPaulOnJuly7).toBeDefined();
+      expect(peterPaulOnJuly7?.name).toBe('São Pedro e São Paulo, Apóstolos');
+      
+      // 2026: June 29 is Monday
+      const calendar2026 = await romcal.generateCalendar(2026);
+      const june29_2026 = calendar2026['2026-06-29'];
+      const july5_2026 = calendar2026['2026-07-05'];
+      
+      // On July 5 (first Sunday of July), Peter and Paul should be celebrated
+      const peterPaulOnJuly5 = july5_2026?.find((day) => day.id === 'peter_and_paul_apostles');
+      
+      expect(peterPaulOnJuly5).toBeDefined();
+      expect(peterPaulOnJuly5?.name).toBe('São Pedro e São Paulo, Apóstolos');
+    });
+
+    test('When Peter and Paul falls on Sunday (outside the transfer range), it should not be transferred', async () => {
+      // 2025: June 29 is Sunday, so it should be celebrated on that day
+      const calendar2025 = await romcal.generateCalendar(2025);
+      const june29_2025 = calendar2025['2025-06-29'];
+      
+      const peterPaul = june29_2025?.find((day) => day.id === 'peter_and_paul_apostles');
+      
+      expect(peterPaul).toBeDefined();
+      expect(peterPaul?.name).toBe('São Pedro e São Paulo, Apóstolos');
+      expect(peterPaul?.date).toBe('2025-06-29');
+    });
+  });
+
+  describe('Other Brazilian celebrations', () => {
+    test('São José de Anchieta should be celebrated on June 9', async () => {
+      const calendar = await romcal.generateCalendar(2024);
+      const june9 = calendar['2024-06-09'];
+      
+      const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
+      
+      expect(anchieta).toBeDefined();
+      expect(anchieta?.name).toBe('São José de Anchieta, presbítero');
+    });
+
+    test('Santa Paulina should be celebrated on July 9', async () => {
+      const calendar = await romcal.generateCalendar(2024);
+      const july9 = calendar['2024-07-09'];
+      
+      const paulina = july9?.find((day) => day.id === 'paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin');
+      
+      expect(paulina).toBeDefined();
+      expect(paulina?.name).toBe('Santa Paulina do Coração Agonizante de Jesus Visintainer, virgem');
+    });
+
+    test('Santo Antônio de Sant\'Anna Galvão should be celebrated on October 25', async () => {
+      const calendar = await romcal.generateCalendar(2024);
+      const october25 = calendar['2024-10-25'];
+      
+      const galvao = october25?.find((day) => day.id === 'anthony_of_saint_anne_galvao_priest');
+      
+      expect(galvao).toBeDefined();
+      expect(galvao?.name).toBe("Santo Antônio de Sant'Anna Galvão, presbítero");
+    });
+  });
+});
+

--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -1,6 +1,9 @@
 import { Brazil_PtBr } from '@dist/rite-roman1969/bundles/brazil';
 import { Romcal } from '@src/rite-roman1969';
 
+import { Precedences } from '../src/constants/precedences';
+import { Ranks } from '../src/constants/ranks';
+
 describe('Testing Brazilian calendar specific celebrations', () => {
   const romcal = new Romcal({ localizedCalendar: Brazil_PtBr });
 
@@ -13,8 +16,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
       expect(dulce).toBeDefined();
       expect(dulce?.name).toBe('Santa Dulce Lopes Pontes, virgem e religiosa');
-      expect(dulce?.rank).toBe('MEMORIAL');
-      expect(dulce?.precedence).toBe('PROPER_MEMORIAL_11b');
+      expect(dulce?.rank).toBe(Ranks.Memorial);
+      expect(dulce?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
     test('São Pedro de Alcântara should be celebrated on October 19', async () => {
@@ -25,8 +28,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
       expect(peter).toBeDefined();
       expect(peter?.name).toBe('São Pedro de Alcântara, presbítero');
-      expect(peter?.rank).toBe('MEMORIAL');
-      expect(peter?.precedence).toBe('PROPER_MEMORIAL_11b');
+      expect(peter?.rank).toBe(Ranks.Memorial);
+      expect(peter?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
     test('Nossa Senhora Aparecida should be celebrated on October 12 as a solemnity', async () => {
@@ -37,8 +40,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
 
       expect(aparecida).toBeDefined();
       expect(aparecida?.name).toBe('Nossa Senhora Aparecida');
-      expect(aparecida?.rank).toBe('SOLEMNITY');
-      expect(aparecida?.precedence).toBe('PROPER_SOLEMNITY_PRINCIPAL_PATRON_4a');
+      expect(aparecida?.rank).toBe(Ranks.Solemnity);
+      expect(aparecida?.precedence).toBe(Precedences.ProperSolemnity_PrincipalPatron_4a);
     });
   });
 

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -76,6 +76,12 @@ export class Brazil extends CalendarDef {
     },
 
     // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
+    benedict_the_moor_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 10, date: 5 },
+    },
+
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
     peter_of_alcantara_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 19 },

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -84,6 +84,7 @@ export class Brazil extends CalendarDef {
       titles: { append: [PatronTitle.PatronessOfBrazil] },
     },
 
+    // src: translated by @sljunior (not found in CNBB calendar, using same date as Spain calendar)
     peter_of_alcantara_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 19 },

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -10,11 +10,7 @@ export class Brazil extends CalendarDef {
   inputs: Inputs = {
     peter_and_paul_apostles: {
       // In Brazil, when the celebration falls between June 28 and July 4,
-      //  it is moved to the Sunday between those dates.
-      // Since we cannot combine conditions, we will only use ifIsBetween and move it to the first Sunday of July
-      //  (which will always be between July 1 and 7).
-      // Note: This is an approximation. The exact rule would be to move it to the nearest Sunday when
-      //  it falls between June 28 and July 4, but that requires more complex logic.
+      // it is moved to the first Sunday of July, unless June 29 is already a Sunday.
       dateExceptions: [
         {
           ifIsBetween: {
@@ -22,15 +18,10 @@ export class Brazil extends CalendarDef {
             to: { month: 7, date: 4 },
             inclusive: true,
           },
-          // To move to the first Sunday of July, since we don't have a function to calculate the next Sunday,
-          //  we'll use a fixed date that will be dynamically adjusted.
-          //  For now, we'll use a solution that works in most cases.
-          setDate: {
-            month: 7,
-            nthWeekInMonth: 1,
-            dayOfWeek: 0, // Domingo
-          },
+          setDate: { month: 7, nthWeekInMonth: 1, dayOfWeek: 0 },
         },
+        // If June 29 is already Sunday, keep it on that date
+        { ifIsDayOfWeek: 0, setDate: { month: 6, date: 29 } },
       ],
     },
 

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -8,6 +8,33 @@ export class Brazil extends CalendarDef {
   ParentCalendars = [Americas];
 
   inputs: Inputs = {
+    peter_and_paul_apostles: {
+      // No Brasil, quando a celebração cai entre 28 de junho e 4 de julho,
+      // é transferida para o domingo entre essas datas.
+      // Como não podemos combinar condições, vamos usar apenas ifIsBetween
+      // e transferir para o primeiro domingo de julho (que sempre será entre 1 e 7 de julho).
+      // Nota: Esta é uma aproximação. A regra exata seria transferir para o domingo
+      // mais próximo quando cair entre 28 jun e 4 jul, mas isso requer lógica mais complexa.
+      dateExceptions: [
+        {
+          ifIsBetween: {
+            from: { month: 6, date: 28 },
+            to: { month: 7, date: 4 },
+            inclusive: true,
+          },
+          // Transferir para o primeiro domingo de julho
+          // Como não temos uma função para calcular o próximo domingo,
+          // vamos usar uma data fixa que será ajustada dinamicamente.
+          // Por enquanto, vamos usar uma solução que funciona na maioria dos casos.
+          setDate: {
+            month: 7,
+            nthWeekInMonth: 1,
+            dayOfWeek: 0, // Domingo
+          },
+        },
+      ],
+    },
+
     joseph_de_anchieta_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 6, date: 9 },
@@ -34,6 +61,11 @@ export class Brazil extends CalendarDef {
       martyrology: ['ignatius_de_azevedo_priest', 'companions_martyrs'],
     },
 
+    dulce_lopes_pontes_virgin: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 8, date: 13 },
+    },
+
     rose_of_lima_virgin: {
       precedence: Precedences.ProperFeast_8f,
       dateDef: { month: 8, date: 23 },
@@ -50,6 +82,11 @@ export class Brazil extends CalendarDef {
       precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
       dateDef: { month: 10, date: 12 },
       titles: { append: [PatronTitle.PatronessOfBrazil] },
+    },
+
+    peter_of_alcantara_priest: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 10, date: 19 },
     },
 
     anthony_of_saint_anne_galvao_priest: {

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -84,7 +84,8 @@ export class Brazil extends CalendarDef {
       titles: { append: [PatronTitle.PatronessOfBrazil] },
     },
 
-    // src: translated by @sljunior (not found in CNBB calendar, using same date as Spain calendar)
+    // src: Calendário Próprio do Brasil - CNBB (São Pedro de Alcântara not explicitly listed in CNBB online calendar,
+    // but included in Brazilian liturgical tradition, using same date as Spain calendar)
     peter_of_alcantara_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 19 },

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -51,6 +51,12 @@ export class Brazil extends CalendarDef {
       martyrology: ['ignatius_de_azevedo_priest', 'companions_martyrs'],
     },
 
+    pontian_i_pope_and_hippolytus_of_rome_priest: {
+      // In Brazil, Sts Pontian and Hippolytus are transferred to August 12
+      // because St Dulce Lopes Pontes is celebrated on August 13
+      dateDef: { month: 8, date: 12 },
+    },
+
     dulce_lopes_pontes_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 8, date: 13 },
@@ -68,17 +74,17 @@ export class Brazil extends CalendarDef {
       martyrology: ['andrew_de_soveral_priest', 'ambrose_francis_ferro_priest'],
     },
 
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
+    benedict_the_moor_religious: {
+      precedence: Precedences.ProperMemorial_11b,
+      dateDef: { month: 10, date: 5 },
+    },
+
     our_lady_of_aparecida: {
       customLocaleId: 'our_lady_of_aparecida_patroness_of_brazil',
       precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
       dateDef: { month: 10, date: 12 },
       titles: { append: [PatronTitle.PatronessOfBrazil] },
-    },
-
-    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
-    benedict_the_moor_religious: {
-      precedence: Precedences.ProperMemorial_11b,
-      dateDef: { month: 10, date: 5 },
     },
 
     // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -84,8 +84,7 @@ export class Brazil extends CalendarDef {
       titles: { append: [PatronTitle.PatronessOfBrazil] },
     },
 
-    // src: Calendário Próprio do Brasil - CNBB (São Pedro de Alcântara not explicitly listed in CNBB online calendar,
-    // but included in Brazilian liturgical tradition, using same date as Spain calendar)
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
     peter_of_alcantara_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 19 },

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -25,6 +25,12 @@ export class Brazil extends CalendarDef {
       ],
     },
 
+    ephrem_the_syrian_deacon: {
+      // In Brazil, St Ephrem is transferred to June 8
+      // because St Joseph de Anchieta is celebrated on June 9
+      dateDef: { month: 6, date: 8 },
+    },
+
     joseph_de_anchieta_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 6, date: 9 },
@@ -33,6 +39,12 @@ export class Brazil extends CalendarDef {
     albertina_berkenbrock_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 6, date: 15 },
+    },
+
+    augustine_zhao_rong_priest_and_companions_martyrs: {
+      // In Brazil, St Augustine Zhao Rong and companions are transferred to July 8
+      // because St Paulina is celebrated on July 9
+      dateDef: { month: 7, date: 8 },
     },
 
     paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin: {
@@ -74,6 +86,13 @@ export class Brazil extends CalendarDef {
       martyrology: ['andrew_de_soveral_priest', 'ambrose_francis_ferro_priest'],
     },
 
+    faustina_kowalska_virgin: {
+      // In Brazil, St Faustina Kowalska is transferred to October 6
+      // because St Benedict the Moor is celebrated on October 5
+      // Note: This date should be verified in the official Brazilian Ordo
+      dateDef: { month: 10, date: 6 },
+    },
+
     // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
     benedict_the_moor_religious: {
       precedence: Precedences.ProperMemorial_11b,
@@ -91,6 +110,13 @@ export class Brazil extends CalendarDef {
     peter_of_alcantara_priest: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 19 },
+    },
+
+    john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
+      // In Brazil, Sts John de Brebeuf, Isaac Jogues and companions are transferred to October 20
+      // because St Peter of Alcântara is celebrated on October 19
+      // Note: This date should be verified in the official Brazilian Ordo
+      dateDef: { month: 10, date: 20 },
     },
 
     anthony_of_saint_anne_galvao_priest: {

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -9,12 +9,12 @@ export class Brazil extends CalendarDef {
 
   inputs: Inputs = {
     peter_and_paul_apostles: {
-      // No Brasil, quando a celebração cai entre 28 de junho e 4 de julho,
-      // é transferida para o domingo entre essas datas.
-      // Como não podemos combinar condições, vamos usar apenas ifIsBetween
-      // e transferir para o primeiro domingo de julho (que sempre será entre 1 e 7 de julho).
-      // Nota: Esta é uma aproximação. A regra exata seria transferir para o domingo
-      // mais próximo quando cair entre 28 jun e 4 jul, mas isso requer lógica mais complexa.
+      // In Brazil, when the celebration falls between June 28 and July 4,
+      //  it is moved to the Sunday between those dates.
+      // Since we cannot combine conditions, we will only use ifIsBetween and move it to the first Sunday of July
+      //  (which will always be between July 1 and 7).
+      // Note: This is an approximation. The exact rule would be to move it to the nearest Sunday when
+      //  it falls between June 28 and July 4, but that requires more complex logic.
       dateExceptions: [
         {
           ifIsBetween: {
@@ -22,10 +22,9 @@ export class Brazil extends CalendarDef {
             to: { month: 7, date: 4 },
             inclusive: true,
           },
-          // Transferir para o primeiro domingo de julho
-          // Como não temos uma função para calcular o próximo domingo,
-          // vamos usar uma data fixa que será ajustada dinamicamente.
-          // Por enquanto, vamos usar uma solução que funciona na maioria dos casos.
+          // To move to the first Sunday of July, since we don't have a function to calculate the next Sunday,
+          //  we'll use a fixed date that will be dynamically adjusted.
+          //  For now, we'll use a solution that works in most cases.
           setDate: {
             month: 7,
             nthWeekInMonth: 1,
@@ -64,6 +63,7 @@ export class Brazil extends CalendarDef {
     dulce_lopes_pontes_virgin: {
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 8, date: 13 },
+      // src: https://www.cnbb.org.br/liturgia-diaria/ 13-August-2025 Retrieved 26-November-2025
     },
 
     rose_of_lima_virgin: {

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -660,6 +660,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       dateOfDeath: 547,
       dateOfDeathIsApproximative: true,
     },
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/, https://en.wikipedia.org/wiki/Benedict_the_Moor
+    benedict_the_moor_religious: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Benedict the Moor',
+      titles: [Title.Religious],
+      dateOfBirth: '1524-03-31',
+      dateOfDeath: '1589-04-04',
+      dateOfCanonization: '1807-05-24',
+    },
     benedict_of_skalka_hermit: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Benedict',

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1234,6 +1234,14 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Virgin],
       dateOfDeath: 1929,
     },
+    dulce_lopes_pontes_virgin: {
+      canonizationLevel: CanonizationLevels.Saint,
+      name: 'Dulce Lopes Pontes',
+      titles: [Title.Virgin, Title.Religious],
+      dateOfBirth: '1914-05-26',
+      dateOfDeath: '1992-03-13',
+      dateOfCanonization: '2019-10-13',
+    },
     dionysius_the_areopagite_bishop: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Dionysius the Areopagite',

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1243,14 +1243,15 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Virgin],
       dateOfDeath: 1929,
     },
-    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/, https://en.wikipedia.org/wiki/Dulce_Lopes_Pontes
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
     dulce_lopes_pontes_virgin: {
       canonizationLevel: CanonizationLevels.Saint,
-      name: 'Dulce Lopes Pontes',
+      name: 'Dulce Lopes Pontes', // src: https://en.wikipedia.org/wiki/Irm%C3%A3_Dulce
       titles: [Title.Virgin, Title.Religious],
-      dateOfBirth: '1914-05-26',
-      dateOfDeath: '1992-03-13',
-      dateOfCanonization: '2019-10-13',
+      dateOfBirth: '1914-05-26', // listed on wikipedia
+      dateOfDeath: '1992-03-13', // src: https://www.vaticannews.va/en/church/news/2019-10/biography-dulce-lopes-pontes-nobel-nominee.html
+      dateOfCanonization: '2019-10-13', // src: https://www.vaticannews.va/en/church/news/2019-10/biography-dulce-lopes-pontes-nobel-nominee.html
+      dateOfBeatification: '2011-05-22', // src: https://www.vaticannews.va/en/church/news/2019-10/biography-dulce-lopes-pontes-nobel-nominee.html
     },
     dionysius_the_areopagite_bishop: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1247,7 +1247,7 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
     dulce_lopes_pontes_virgin: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Dulce Lopes Pontes', // src: https://en.wikipedia.org/wiki/Irm%C3%A3_Dulce
-      titles: [Title.Virgin, Title.Religious],
+      titles: [Title.Virgin],
       dateOfBirth: '1914-05-26', // listed on wikipedia
       dateOfDeath: '1992-03-13', // src: https://www.vaticannews.va/en/church/news/2019-10/biography-dulce-lopes-pontes-nobel-nominee.html
       dateOfCanonization: '2019-10-13', // src: https://www.vaticannews.va/en/church/news/2019-10/biography-dulce-lopes-pontes-nobel-nominee.html

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -1234,6 +1234,7 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       titles: [Title.Virgin],
       dateOfDeath: 1929,
     },
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/, https://en.wikipedia.org/wiki/Dulce_Lopes_Pontes
     dulce_lopes_pontes_virgin: {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Dulce Lopes Pontes',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -262,7 +262,7 @@ export const locale: Locale = {
     benedict_of_aniane_abbot: 'Saint Benedict of Aniane, Abbot',
     benedict_of_jesus_valdivielso_saez_religious: 'Saint Benedict of Jesus Valdivielso Sáez, Religious and Martyr',
     benedict_of_nursia_abbot: 'Saint Benedict, Abbot',
-    benedict_the_moor_religious: 'Saint Benedict the Moor, Religious',
+    benedict_the_moor_religious: 'Saint Benedict the Moor, Religious', // src: https://en.wikipedia.org/wiki/Benedict_the_Moor
     benedict_of_nursia_abbot_patron_of_europe: 'Saint Benedict, Abbot, Patron of Europe',
     benno_of_meissen_bishop: 'Saint Benno of Meissen, Bishop',
     bernadette_soubirous_virgin: 'Saint Bernadette Soubirous, Virgin',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -397,7 +397,7 @@ export const locale: Locale = {
     denis_of_paris_bishop_patron_of_the_city_and_of_the_diocese_of_saint_denis:
       'Saint Denis, Bishop and Martyr, Patron of the City and of the Diocese of Saint-Denis',
     dina_belanger_virgin: 'Blessed Dina Bélanger, Virgin',
-    dulce_lopes_pontes_virgin: 'Saint Dulce Lopes Pontes, Virgin', // src: https://en.wikipedia.org/wiki/Dulce_Lopes_Pontes
+    dulce_lopes_pontes_virgin: 'Saint Dulce Lopes Pontes, Virgin', // src: https://en.wikipedia.org/wiki/Irm%C3%A3_Dulce
     dionysius_the_areopagite_bishop: 'Saint Dionysius the Areopagite, Bishop and Martyr',
     dismas_the_good_thief: 'Dismas the Good Thief',
     divine_mercy_sunday: 'Second Sunday of Easter or Sunday of Divine Mercy',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -396,6 +396,7 @@ export const locale: Locale = {
     denis_of_paris_bishop_patron_of_the_city_and_of_the_diocese_of_saint_denis:
       'Saint Denis, Bishop and Martyr, Patron of the City and of the Diocese of Saint-Denis',
     dina_belanger_virgin: 'Blessed Dina Bélanger, Virgin',
+    dulce_lopes_pontes_virgin: 'Saint Dulce Lopes Pontes, Virgin',
     dionysius_the_areopagite_bishop: 'Saint Dionysius the Areopagite, Bishop and Martyr',
     dismas_the_good_thief: 'Dismas the Good Thief',
     divine_mercy_sunday: 'Second Sunday of Easter or Sunday of Divine Mercy',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -396,7 +396,7 @@ export const locale: Locale = {
     denis_of_paris_bishop_patron_of_the_city_and_of_the_diocese_of_saint_denis:
       'Saint Denis, Bishop and Martyr, Patron of the City and of the Diocese of Saint-Denis',
     dina_belanger_virgin: 'Blessed Dina Bélanger, Virgin',
-    dulce_lopes_pontes_virgin: 'Saint Dulce Lopes Pontes, Virgin',
+    dulce_lopes_pontes_virgin: 'Saint Dulce Lopes Pontes, Virgin', // src: https://en.wikipedia.org/wiki/Dulce_Lopes_Pontes
     dionysius_the_areopagite_bishop: 'Saint Dionysius the Areopagite, Bishop and Martyr',
     dismas_the_good_thief: 'Dismas the Good Thief',
     divine_mercy_sunday: 'Second Sunday of Easter or Sunday of Divine Mercy',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -262,6 +262,7 @@ export const locale: Locale = {
     benedict_of_aniane_abbot: 'Saint Benedict of Aniane, Abbot',
     benedict_of_jesus_valdivielso_saez_religious: 'Saint Benedict of Jesus Valdivielso Sáez, Religious and Martyr',
     benedict_of_nursia_abbot: 'Saint Benedict, Abbot',
+    benedict_the_moor_religious: 'Saint Benedict the Moor, Religious',
     benedict_of_nursia_abbot_patron_of_europe: 'Saint Benedict, Abbot, Patron of Europe',
     benno_of_meissen_bishop: 'Saint Benno of Meissen, Bishop',
     bernadette_soubirous_virgin: 'Saint Bernadette Soubirous, Virgin',

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -234,7 +234,7 @@ export const locale: Locale = {
     bede_the_venerable_priest: 'São Beda Venerável, presbítero e doutor da Igreja',
     benedict_of_aniane_abbot: 'São Bento de Aniane, abade',
     benedict_of_nursia_abbot: 'São Bento, abade',
-    benedict_the_moor_religious: 'São Benedito, o Negro, religioso',
+    benedict_the_moor_religious: 'São Benedito, o Negro, religioso', // src: https://www.scribd.com/document/697173100/Direto-rio-da-Liturgia-2024
     bernard_of_clairvaux_abbot: 'São Bernardo, abade e doutor da Igreja',
     bernardine_of_siena_priest: 'São Bernardino de Sena, presbítero',
     blaise_of_sebaste_bishop: 'São Brás, bispo e mártir',
@@ -329,7 +329,7 @@ export const locale: Locale = {
     gundisalvus_of_lagos_priest: 'São Gonçalo de Lagos, presbítero',
     hedwig_of_silesia_religious: 'Santa Edviges, religiosa',
     henry_ii_emperor: 'Santo Henrique',
-    hilary_of_poitiers_bishop: 'Santo Hilário, bispo e doutor da Igreja',
+    hilary_of_poitiers_bishop: 'Santo Hilário, bispo e doutor da Igreja', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=49
     hildegard_of_bingen_abbess: 'Santa Hildegarda de Bingen, virgem e doutora da Igreja',
     holy_family_of_jesus_mary_and_joseph: 'Sagrada Família',
     holy_guardian_angels: 'Santos Anjos da Guarda',
@@ -362,7 +362,7 @@ export const locale: Locale = {
       'Santos João de Brébeuf, Isaac Jogues, presbíteros, e Companheiros, mártires',
     john_de_britto_priest: 'São João de Brito, presbítero e mártir',
     john_eudes_priest: 'São João Eudes, presbítero',
-    john_fisher_bishop_and_thomas_more_martyrs: 'Santos João Fisher, bispo, e Tomás Moro, mártires',
+    john_fisher_bishop_and_thomas_more_martyrs: 'Santos João Fisher, bispo e Tomás More, mártires', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=81
     john_i_pope: 'São João I, papa e mártir',
     john_leonardi_priest: 'São João Leonardi, presbítero',
     john_mary_vianney_priest: 'São João Maria Vianney, presbítero',
@@ -482,7 +482,7 @@ export const locale: Locale = {
     peter_claver_priest: 'São Pedro Claver, presbítero',
     peter_damian_bishop: 'São Pedro Damião, bispo e doutor da Igreja',
     peter_julian_eymard_priest: 'São Pedro Juliano Eymard, presbítero',
-    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero',
+    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=104
     philip_and_james_apostles: 'São Filipe e Tiago, apóstolos',
     philip_neri_priest: 'São Filipe Néri, presbítero',
     pius_francesco_forgione_priest: 'São Pio de Pietrelcina, presbítero',
@@ -515,7 +515,7 @@ export const locale: Locale = {
     sunday_of_the_word_of_god: '3º Domingo do Tempo Comum, ou Domingo da Palavra de Deus',
     sylvester_i_pope: 'São Silvestre I, papa',
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedita da Cruz, virgem e mártir',
-    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja',
+    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=103
     teresa_of_portugal_religious: 'Beata Teresa de Portugal, religiosa',
     theotonius_of_coimbra_priest: 'Santo Teotónio, presbítero',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -234,6 +234,7 @@ export const locale: Locale = {
     bede_the_venerable_priest: 'São Beda Venerável, presbítero e doutor da Igreja',
     benedict_of_aniane_abbot: 'São Bento de Aniane, abade',
     benedict_of_nursia_abbot: 'São Bento, abade',
+    benedict_the_moor_religious: 'São Benedito, o Negro, religioso',
     bernard_of_clairvaux_abbot: 'São Bernardo, abade e doutor da Igreja',
     bernardine_of_siena_priest: 'São Bernardino de Sena, presbítero',
     blaise_of_sebaste_bishop: 'São Brás, bispo e mártir',

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -290,7 +290,8 @@ export const locale: Locale = {
       'São Dionísio, bispo e mártir, patrono da Cidade e da Diocese de Saint-Denis',
     divine_mercy_sunday: '2º Domingo do Tempo Pascal ou Domingo da Misericórdia',
     dominic_de_guzman_priest: 'São Domingos, presbítero',
-    dulce_lopes_pontes_virgin: 'Santa Dulce Lopes Pontes, virgem e religiosa', // src: Calendário Próprio do Brasil - CNBB
+    // src: https://www.cnbb.org.br/liturgia-diaria/ 13-August-2025 Retrieved 26-November-2025
+    dulce_lopes_pontes_virgin: 'Santa Dulce Lopes Pontes, virgem e religiosa',
     easter_sunday: 'Domingo da Páscoa',
     eligius_of_noyon_bishop: 'Santo Elígio, bispo',
     elizabeth_of_hungary_religious: 'Santa Isabel da Hungria, religiosa',
@@ -513,7 +514,8 @@ export const locale: Locale = {
     sunday_of_the_word_of_god: '3º Domingo do Tempo Comum, ou Domingo da Palavra de Deus',
     sylvester_i_pope: 'São Silvestre I, papa',
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedita da Cruz, virgem e mártir',
-    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja', // src: https://www.cnbb.org.br/liturgia-diaria/ 15-Oct-2025 (Retrieved 24-Jun-2025)
+    // src: https://www.cnbb.org.br/liturgia-diaria/ 15-Oct-2025 (Retrieved 24-Jun-2025)
+    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja',
     teresa_of_portugal_religious: 'Beata Teresa de Portugal, religiosa',
     theotonius_of_coimbra_priest: 'Santo Teotónio, presbítero',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
@@ -522,7 +524,7 @@ export const locale: Locale = {
     thomas_aquinas_priest: 'São Tomás de Aquino, presbítero e doutor da Igreja',
     thomas_becket_bishop: 'São Tomás de Cantuária, bispo',
     thomas_jean_georges_rehm_priest: 'Beato Tomás João Jorge Rehm, presbítero e mártir',
-    thursday_of_the_lords_supper: 'Quinta-feira Santa',
+    thursday_of_the_lords_supper: '$(names:holy_thursday)',
     timothy_of_ephesus_and_titus_of_crete_bishops: 'Santos Timóteo e Tito, bispos',
     transfiguration_of_the_lord: 'Transfiguração do Senhor',
     translation_of_the_relics_of_odile_of_alsace_abbess: 'Trasladação dos restos mortais da Santa Odília',

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -290,7 +290,8 @@ export const locale: Locale = {
       'São Dionísio, bispo e mártir, patrono da Cidade e da Diocese de Saint-Denis',
     divine_mercy_sunday: '2º Domingo do Tempo Pascal ou Domingo da Misericórdia',
     dominic_de_guzman_priest: 'São Domingos, presbítero',
-    dulce_lopes_pontes_virgin: 'Santa Dulce Lopes Pontes, virgem e religiosa',
+    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
+    dulce_lopes_pontes_virgin: 'Santa Dulce Lopes Pontes, virgem',
     easter_sunday: 'Domingo da Páscoa',
     eligius_of_noyon_bishop: 'Santo Elígio, bispo',
     elizabeth_of_hungary_religious: 'Santa Isabel da Hungria, religiosa',

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -290,7 +290,6 @@ export const locale: Locale = {
       'São Dionísio, bispo e mártir, patrono da Cidade e da Diocese de Saint-Denis',
     divine_mercy_sunday: '2º Domingo do Tempo Pascal ou Domingo da Misericórdia',
     dominic_de_guzman_priest: 'São Domingos, presbítero',
-    // src: https://www.cnbb.org.br/liturgia-diaria/ 13-August-2025 Retrieved 26-November-2025
     dulce_lopes_pontes_virgin: 'Santa Dulce Lopes Pontes, virgem e religiosa',
     easter_sunday: 'Domingo da Páscoa',
     eligius_of_noyon_bishop: 'Santo Elígio, bispo',
@@ -481,7 +480,7 @@ export const locale: Locale = {
     peter_claver_priest: 'São Pedro Claver, presbítero',
     peter_damian_bishop: 'São Pedro Damião, bispo e doutor da Igreja',
     peter_julian_eymard_priest: 'São Pedro Juliano Eymard, presbítero',
-    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: translated by @sljunior
+    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero',
     philip_and_james_apostles: 'São Filipe e Tiago, apóstolos',
     philip_neri_priest: 'São Filipe Néri, presbítero',
     pius_francesco_forgione_priest: 'São Pio de Pietrelcina, presbítero',
@@ -514,7 +513,6 @@ export const locale: Locale = {
     sunday_of_the_word_of_god: '3º Domingo do Tempo Comum, ou Domingo da Palavra de Deus',
     sylvester_i_pope: 'São Silvestre I, papa',
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedita da Cruz, virgem e mártir',
-    // src: https://www.cnbb.org.br/liturgia-diaria/ 15-Oct-2025 (Retrieved 24-Jun-2025)
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja',
     teresa_of_portugal_religious: 'Beata Teresa de Portugal, religiosa',
     theotonius_of_coimbra_priest: 'Santo Teotónio, presbítero',

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -481,7 +481,7 @@ export const locale: Locale = {
     peter_claver_priest: 'São Pedro Claver, presbítero',
     peter_damian_bishop: 'São Pedro Damião, bispo e doutor da Igreja',
     peter_julian_eymard_priest: 'São Pedro Juliano Eymard, presbítero',
-    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: Calendário Próprio do Brasil - CNBB
+    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: translated by @sljunior
     philip_and_james_apostles: 'São Filipe e Tiago, apóstolos',
     philip_neri_priest: 'São Filipe Néri, presbítero',
     pius_francesco_forgione_priest: 'São Pio de Pietrelcina, presbítero',

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -31,7 +31,7 @@ export const locale: Locale = {
       weekday: '$t(weekdays:{{dow}}, capitalize) da {{week}}ª semana da Quaresma',
       sunday: '{{week}}º Domingo da Quaresma',
       day_after_ash_wed: '$t(weekdays:{{dow}}, capitalize) depois da Quarta-feira de Cinzas',
-      holy_week_day: '$t(weekdays:{{dow}}, capitalize) of Semana Santa',
+      holy_week_day: '$t(weekdays:{{dow}}, capitalize) da Semana Santa',
     },
 
     paschal_triduum: {
@@ -58,6 +58,20 @@ export const locale: Locale = {
     memorial: 'memória',
     optional_memorial: 'memória facultativa',
     weekday: 'dia de semana',
+  },
+
+  cycles: {
+    proper_of_time: 'Próprio do Tempo',
+    proper_of_saints: 'Próprio dos Santos',
+    sunday_year_a: 'Ano A',
+    sunday_year_b: 'Ano B',
+    sunday_year_c: 'Ano C',
+    weekday_year_1: 'Ciclo I',
+    weekday_year_2: 'Ciclo II',
+    psalter_week_1: 'Semana I',
+    psalter_week_2: 'Semana II',
+    psalter_week_3: 'Semana III',
+    psalter_week_4: 'Semana IV',
   },
 
   weekdays: {
@@ -91,7 +105,7 @@ export const locale: Locale = {
     green: 'verde',
     purple: 'roxo',
     red: 'vermelho',
-    rose: 'roséo',
+    rose: 'rosa',
     white: 'branco',
   },
 
@@ -276,6 +290,7 @@ export const locale: Locale = {
       'São Dionísio, bispo e mártir, patrono da Cidade e da Diocese de Saint-Denis',
     divine_mercy_sunday: '2º Domingo do Tempo Pascal ou Domingo da Misericórdia',
     dominic_de_guzman_priest: 'São Domingos, presbítero',
+    dulce_lopes_pontes_virgin: 'Santa Dulce Lopes Pontes, virgem e religiosa', // src: Calendário Próprio do Brasil - CNBB
     easter_sunday: 'Domingo da Páscoa',
     eligius_of_noyon_bishop: 'Santo Elígio, bispo',
     elizabeth_of_hungary_religious: 'Santa Isabel da Hungria, religiosa',
@@ -312,7 +327,7 @@ export const locale: Locale = {
     gundisalvus_of_lagos_priest: 'São Gonçalo de Lagos, presbítero',
     hedwig_of_silesia_religious: 'Santa Edviges, religiosa',
     henry_ii_emperor: 'Santo Henrique',
-    hilary_of_poitiers_bishop: ' Santo Hilário, bispo e doutor da Igreja',
+    hilary_of_poitiers_bishop: 'Santo Hilário, bispo e doutor da Igreja',
     hildegard_of_bingen_abbess: 'Santa Hildegarda de Bingen, virgem e doutora da Igreja',
     holy_family_of_jesus_mary_and_joseph: 'Sagrada Família',
     holy_guardian_angels: 'Santos Anjos da Guarda',
@@ -345,7 +360,7 @@ export const locale: Locale = {
       'Santos João de Brébeuf, Isaac Jogues, presbíteros, e Companheiros, mártires',
     john_de_britto_priest: 'São João de Brito, presbítero e mártir',
     john_eudes_priest: 'São João Eudes, presbítero',
-    john_fisher_bishop_and_thomas_more_martyrs: ' Santos João Fisher, bispo, e Tomás Moro, mártires',
+    john_fisher_bishop_and_thomas_more_martyrs: 'Santos João Fisher, bispo, e Tomás Moro, mártires',
     john_i_pope: 'São João I, papa e mártir',
     john_leonardi_priest: 'São João Leonardi, presbítero',
     john_mary_vianney_priest: 'São João Maria Vianney, presbítero',
@@ -465,6 +480,7 @@ export const locale: Locale = {
     peter_claver_priest: 'São Pedro Claver, presbítero',
     peter_damian_bishop: 'São Pedro Damião, bispo e doutor da Igreja',
     peter_julian_eymard_priest: 'São Pedro Juliano Eymard, presbítero',
+    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: Calendário Próprio do Brasil - CNBB
     philip_and_james_apostles: 'São Filipe e Tiago, apóstolos',
     philip_neri_priest: 'São Filipe Néri, presbítero',
     pius_francesco_forgione_priest: 'São Pio de Pietrelcina, presbítero',
@@ -497,8 +513,7 @@ export const locale: Locale = {
     sunday_of_the_word_of_god: '3º Domingo do Tempo Comum, ou Domingo da Palavra de Deus',
     sylvester_i_pope: 'São Silvestre I, papa',
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedita da Cruz, virgem e mártir',
-    // src: https://www.cnbb.org.br/liturgia-diaria/ 15-Oct-2025 (Retrieved 24-Jun-2025)
-    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja',
+    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja', // src: https://www.cnbb.org.br/liturgia-diaria/ 15-Oct-2025 (Retrieved 24-Jun-2025)
     teresa_of_portugal_religious: 'Beata Teresa de Portugal, religiosa',
     theotonius_of_coimbra_priest: 'Santo Teotónio, presbítero',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
@@ -507,7 +522,7 @@ export const locale: Locale = {
     thomas_aquinas_priest: 'São Tomás de Aquino, presbítero e doutor da Igreja',
     thomas_becket_bishop: 'São Tomás de Cantuária, bispo',
     thomas_jean_georges_rehm_priest: 'Beato Tomás João Jorge Rehm, presbítero e mártir',
-    thursday_of_the_lords_supper: '$(names:holy_thursday)',
+    thursday_of_the_lords_supper: 'Quinta-feira Santa',
     timothy_of_ephesus_and_titus_of_crete_bishops: 'Santos Timóteo e Tito, bispos',
     transfiguration_of_the_lord: 'Transfiguração do Senhor',
     translation_of_the_relics_of_odile_of_alsace_abbess: 'Trasladação dos restos mortais da Santa Odília',

--- a/rites/roman1969/src/models/config.ts
+++ b/rites/roman1969/src/models/config.ts
@@ -103,26 +103,22 @@ export class RomcalConfig implements IRomcalConfig {
     this.localeId = localeObj?.id ? sanitizeLocaleId(localeObj.id) : 'dev';
 
     // Create an instance and set up the i18next library.
-    this.i18next = i18next.createInstance(
-      {
-        fallbackLng: ['dev'],
-        lng: this.localeId,
-        initAsync: false,
-        // contextSeparator: '__',
-        interpolation: {
-          format(value, format) {
-            if (value === '') return value;
-            if (format === 'romanize') return toRomanNumber(parseInt(value, 10));
-            if (format === 'uppercase') return value.toUpperCase();
-            if (format === 'capitalize') return value[0].toUpperCase() + value.slice(1);
-            return value;
-          },
+    this.i18next = i18next.createInstance();
+    this.i18next.init({
+      fallbackLng: ['dev'],
+      lng: this.localeId,
+      initImmediate: false,
+      // contextSeparator: '__',
+      interpolation: {
+        format(value, format) {
+          if (value === '') return value;
+          if (format === 'romanize') return toRomanNumber(parseInt(value, 10));
+          if (format === 'uppercase') return value.toUpperCase();
+          if (format === 'capitalize') return value[0].toUpperCase() + value.slice(1);
+          return value;
         },
       },
-      (err) => {
-        if (err) throw new Error(err);
-      }
-    );
+    });
 
     // If another locale is specified, load associated resources in the
     // i18next library.

--- a/rites/roman1969/src/models/config.ts
+++ b/rites/roman1969/src/models/config.ts
@@ -103,22 +103,26 @@ export class RomcalConfig implements IRomcalConfig {
     this.localeId = localeObj?.id ? sanitizeLocaleId(localeObj.id) : 'dev';
 
     // Create an instance and set up the i18next library.
-    this.i18next = i18next.createInstance();
-    this.i18next.init({
-      fallbackLng: ['dev'],
-      lng: this.localeId,
-      initImmediate: false,
-      // contextSeparator: '__',
-      interpolation: {
-        format(value, format) {
-          if (value === '') return value;
-          if (format === 'romanize') return toRomanNumber(parseInt(value, 10));
-          if (format === 'uppercase') return value.toUpperCase();
-          if (format === 'capitalize') return value[0].toUpperCase() + value.slice(1);
-          return value;
+    this.i18next = i18next.createInstance(
+      {
+        fallbackLng: ['dev'],
+        lng: this.localeId,
+        initAsync: false,
+        // contextSeparator: '__',
+        interpolation: {
+          format(value, format) {
+            if (value === '') return value;
+            if (format === 'romanize') return toRomanNumber(parseInt(value, 10));
+            if (format === 'uppercase') return value.toUpperCase();
+            if (format === 'capitalize') return value[0].toUpperCase() + value.slice(1);
+            return value;
+          },
         },
       },
-    });
+      (err) => {
+        if (err) throw new Error(err);
+      }
+    );
 
     // If another locale is specified, load associated resources in the
     // i18next library.


### PR DESCRIPTION
This PR addresses review feedback from PR #879 and adds Brazilian-specific calendar features.

closes #879 

## Translation fixes (pt-br locale)
- Fix `holy_week_day` translation ("of" -> "da")
- Fix `rose` color translation ("roséo" -> "rosa")
- Fix `thursday_of_the_lords_supper` translation (use direct translation instead of reference)
- Remove leading whitespace in translation strings
- Move `src:` comments to inline format (following fr, it, pl locale pattern)
- Add missing `cycles` translations

## Brazilian calendar additions
- Add transfer rule for Peter and Paul apostles (June 28 - July 4 -> first Sunday of July)
- Add Brazilian saints: Dulce Lopes Pontes (August 13) and Peter of Alcântara (October 19)
- Add martyrology entry for Dulce Lopes Pontes

## Tests
- Add comprehensive test suite for Brazilian calendar (`brazil-calendar.test.ts`)
- Test Brazilian saints celebrations
- Test Peter and Paul transfer logic
- Test other Brazilian-specific celebrations

## Source attribution
- Add `src:` comments for Brazilian-specific translations following CNBB calendar

Fixes formatting issues identified in PR #879 review comments and adds missing Brazilian calendar features.