### PR TITLE
fix(l10n): missing locales

### DIFF
--- a/docs/calendar-definitions.md
+++ b/docs/calendar-definitions.md
@@ -56,6 +56,8 @@ In the `england` calendar, we will only define a new entry with its `key` and th
 
 It's generally a good practice to extend an existing liturgical day, with its specifications for a particular calendar, instead of redefining multiple time the same liturgical day in different calendars.
 
+For any extension or redefinition, there must be a corresponding src reference in the calendar to provide context for the definition. See [localization documentation](./localization.md) for more details on how these references should be structured.
+
 ### Overriding a liturgical day by its key
 
 In most countries, All Saints and All Souls are always celebrated on the 1st and 2nd of November respectively. However, in England and Wales, if All Saints (1 November) falls on a Saturday, it is transferred to the Sunday and All Souls is transferred to Monday 3rd November.

--- a/docs/calendar-definitions.md
+++ b/docs/calendar-definitions.md
@@ -56,7 +56,7 @@ In the `england` calendar, we will only define a new entry with its `key` and th
 
 It's generally a good practice to extend an existing liturgical day, with its specifications for a particular calendar, instead of redefining multiple time the same liturgical day in different calendars.
 
-For any extension or redefinition, there must be a corresponding src reference in the calendar to provide context for the definition. See [localization documentation](./localization.md) for more details on how these references should be structured.
+For any extension or redefinition, there must be a corresponding source reference in the calendar to provide context for the definition. See [localization documentation](./localization.md) for more details on how these references should be structured.
 
 ### Overriding a liturgical day by its key
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -56,7 +56,7 @@ Each entry in the locale file corresponds to a specific part of the liturgical c
 - `names`: Localized names for specific liturgical days, such as feasts of saints and titles of Our Lord and Our Blessed Mother.
   - Each entry for any name that is added to a specific locale other than `en` must also exist in the `en` locale file, as this is the main source of truth.
   - If a name is not found in the specified locale, romcal will look for it in the fallback locales, ending with `en`.
-  - There are also tests to ensure that all names in other locales exist in the `en` locale file. (pending #992)
+  - There are also tests to ensure that all names in other locales exist in the `en` locale file.
   - Each entry should have a corresponding src comment with a link to the source of the translation, if applicable.
     - If a reference to a missal is used instead, this is the format we've decided to use:
       - `// src: $sourceName`

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -57,7 +57,7 @@ Each entry in the locale file corresponds to a specific part of the liturgical c
   - Each entry for any name that is added to a specific locale other than `en` must also exist in the `en` locale file, as this is the main source of truth.
   - If a name is not found in the specified locale, romcal will look for it in the fallback locales, ending with `en`.
   - There are also tests to ensure that all names in other locales exist in the `en` locale file.
-  - Each entry should have a corresponding src comment with a link to the source of the translation, if applicable.
+  - Each entry should have a corresponding source comment with a link to the source of the translation, if applicable.
     - If a reference to a missal is used instead, this is the format we've decided to use:
       - `// src: $sourceName`
         - when the key value can be found exactly in the referenced document
@@ -71,4 +71,4 @@ Each entry in the locale file corresponds to a specific part of the liturgical c
         - `angers` = optional suffix when variations exist (examples below)
           - English Missals are published e.g. in the UK, the US, Australia
           - French Missals are published per diocese in France, but maybe in Canada too
-      - so this would be the full reference: `// src: mr_fr_2022_ed3_angers`
+      - the parts above are joined with an underscore (`_`): `// src: mr_fr_2022_ed3_angers`

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,12 +1,10 @@
-**:warning: The documentation above is written for romcal v2, and has not been updated yet to romcal v3.**
-
 # Localization
 
 ## Localizing liturgical day names
 
 Liturgical day names in romcal can be localized to any language that is already supported by [DayJS i18n](https://day.js.org/docs/en/i18n/i18n).
 
-Locales are stored as `.ts` files in the `src/locales` directory.
+Locales are stored as `.ts` files in the `rites/roman1969/src/locales` directory.
 
 If the given locale contains a region (the second group of letters after a hyphen, e.g. for `fr-ca`, the `ca` represents the region), a base language will be set as a locale fallback (`fr` in our example).
 
@@ -22,22 +20,53 @@ The structure of the locale file is typically like so:
 
 ```json5
 {
-  advent: {},
-  christmastide: {},
-  epiphany: {},
-  ordinary_time: {},
-  lent: {},
-  holy_week: {},
-  eastertide: {},
-  liturgical_colors: {},
+  id: 'fr-ca',
+  seasons: {
+    advent: {},
+    christmas_time: {},
+    ordinary_time: {},
+    lent: {},
+    pachal_triduum: {},
+    easter_time: {},
+  },
+  periods: {},
   ranks: {},
-  celebrations: {},
-  sanctorale: {},
+  weekdays: {},
+  months: {},
+  colors: {},
+  names: {},
 }
 ```
 
-The first 7 objects define locale keys used by `src/lib/Seasons.ts` when generating liturgical dates.
+Each entry in the locale file corresponds to a specific part of the liturgical calendar that can be localized.
 
-The `celebrations` and `sanctorale` objects will hold localization for `src/lib/Celebrations.ts`, `src/calendars/general.ts` and `src/calendars/<country>.ts` respectively where the celebration `key` is used as an identifier for localization purposes.
-
-See the end of these files to see the function that localizes the dates according to their keys.
+- `seasons`: Localized names for liturgical seasons.
+  - Uses the format:
+    - `season_name`:
+      - `season`: Localized name of the season.
+      - `weekday`: Localized day format for a given weekday.
+      - `sunday`: Localized day format for a given Sunday.
+      - `privileged_weekday`: Localized day format for a privileged weekday in the season.
+      - Other fields may be present depending on needs of the particular season.
+- `periods`: Localized names for liturgical periods.
+- `ranks`: Localized names for liturgical ranks.
+- `weekdays`: Localized names for the days of the week.
+- `months`: Localized names for the months of the year.
+- `colors`: Localized names for liturgical colors.
+- `names`: Localized names for specific liturgical days, such as feasts of saints and titles of Our Lord and Our Blessed Mother.
+  - Each entry for any name that is added to a specific locale other than `en` must also exist in the `en` locale file, as this is the main source of truth.
+  - If a name is not found in the specified locale, romcal will look for it in the fallback locales, ending with `en`.
+  - There are also tests to ensure that all names in other locales exist in the `en` locale file. (pending #992)
+  - Each entry should have a corresponding src comment with a link to the source of the translation, if applicable.
+    - If a reference to a missal is used instead, this is the format we've decided to use:
+      - `// src: $sourceName`
+        - when the key value can be found exactly in the referenced document
+      - `// based on: $sourceName`
+        - when the key value is adapted from the referenced document
+      - For a given missal or document, the following short form is used: (values are examples)
+        - `mr` = Missale Romanum;
+        - `fr` = is the locale of the Missal;
+        - `2022` = publication year;
+        - `ed3` = editio typica tertia;
+        - `angers` = optional suffix when variations exist (e.g. English Missals are published e.g. in the UK, the US, Australia; French Missals are published per diocese in France, but maybe in Canada too).
+      - so this would be the full reference: `// src: mr_fr_2022_ed3_angers`

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -68,5 +68,7 @@ Each entry in the locale file corresponds to a specific part of the liturgical c
         - `fr` = is the locale of the Missal;
         - `2022` = publication year;
         - `ed3` = editio typica tertia;
-        - `angers` = optional suffix when variations exist (e.g. English Missals are published e.g. in the UK, the US, Australia; French Missals are published per diocese in France, but maybe in Canada too).
+        - `angers` = optional suffix when variations exist (examples below)
+          - English Missals are published e.g. in the UK, the US, Australia
+          - French Missals are published per diocese in France, but maybe in Canada too
       - so this would be the full reference: `// src: mr_fr_2022_ed3_angers`

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -63,7 +63,7 @@ Each entry in the locale file corresponds to a specific part of the liturgical c
         - when the key value can be found exactly in the referenced document
       - `// based on: $sourceName`
         - when the key value is adapted from the referenced document
-      - For a given missal or document, the following short form is used: (values are examples)
+      - For missals, the following short form is used: (values are examples)
         - `mr` = Missale Romanum;
         - `fr` = is the locale of the Missal;
         - `2022` = publication year;

--- a/rites/roman1969/__tests__/locales.test.ts
+++ b/rites/roman1969/__tests__/locales.test.ts
@@ -58,3 +58,24 @@ describe('Testing whether celebration names from `.names` object with seasonal w
     });
   });
 });
+
+describe('English Locale', () => {
+  const English = Romcal.LOCALES.En;
+  const NonEnglish = Object.values(Romcal.LOCALES).filter((locale) => locale.id !== 'en');
+  test('Has all keys from all other locales', () => {
+    const missing: Array<{ locale: string; key: string }> = [];
+    NonEnglish.forEach((locale) => {
+      Object.keys(locale.names!).forEach((key) => {
+        if (!English.names!.hasOwnProperty(key)) {
+          missing.push({ locale: locale.id, key });
+        }
+      });
+    });
+    if (missing.length > 0) {
+      console.error(
+        `The English locale is missing the following keys:\n${missing.map((m) => `- [${m.locale}]: ${m.key}`).join('\n')}`
+      );
+    }
+    expect(missing.length).toEqual(0);
+  });
+});

--- a/rites/roman1969/src/catalog/martyrology.ts
+++ b/rites/roman1969/src/catalog/martyrology.ts
@@ -314,7 +314,7 @@ export const Martyrology: { catalog: MartyrologyCatalog } = {
       canonizationLevel: CanonizationLevels.Saint,
       name: 'Andrew Bauer',
       titles: [Title.Martyr],
-      dateOfDeath: '1900-7-9',
+      dateOfDeath: '1900-07-09',
     },
     andrew_bobola_priest: {
       canonizationLevel: CanonizationLevels.Saint,

--- a/rites/roman1969/src/constants/locales.ts
+++ b/rites/roman1969/src/constants/locales.ts
@@ -1,5 +1,6 @@
 import { locales } from '../locales';
 import { toPackageName } from '../utils/string';
 
+export const LOCALES = locales;
 export const LOCALE_VAR_NAMES: string[] = Object.keys(locales);
 export const LOCALE_IDS: string[] = LOCALE_VAR_NAMES.map((c) => toPackageName(c));

--- a/rites/roman1969/src/index.ts
+++ b/rites/roman1969/src/index.ts
@@ -18,7 +18,7 @@ import {
   WeekdayCycles,
 } from './constants/cycles';
 import { GENERAL_ROMAN_NAME, PROPER_OF_TIME_NAME } from './constants/general-calendar-names';
-import { LOCALE_IDS, LOCALE_VAR_NAMES } from './constants/locales';
+import { LOCALE_IDS, LOCALE_VAR_NAMES, LOCALES } from './constants/locales';
 import {
   CANONIZATION_LEVEL,
   CanonizationLevel,
@@ -388,6 +388,8 @@ class Romcal {
   static LOCALE_VAR_NAMES = LOCALE_VAR_NAMES;
 
   static LOCALE_IDS = LOCALE_IDS;
+
+  static LOCALES = LOCALES;
 }
 
 export {

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -200,6 +200,7 @@ export const locale: Locale = {
     andrew_apostle: 'Saint Andrew, Apostle',
     andrew_apostle_patron_of_russia: 'Saint Andrew, Apostle, Patron of Russia',
     andrew_apostle_patron_of_scotland: 'Saint Andrew, Apostle, Patron of Scotland',
+    andrew_bauer_martyr: 'Saint Andrew Bauer, Martyr', // src: https://en.wikipedia.org/wiki/Martyr_Saints_of_China
     andrew_bobola_priest: 'Saint Andrew Bobola, Priest and Martyr',
     andrew_de_soveral_and_ambrose_francis_ferro_priests:
       'Saints Andrew de Soveral and Ambrose Francis Ferro, Priests and Martyrs',
@@ -806,8 +807,8 @@ export const locale: Locale = {
     michael_kozal_bishop: 'Blessed Michael Kozal, Bishop and Martyr',
     miguel_agustin_pro_priest: 'Blessed Miguel Agustín Pro, Priest and Martyr',
     miguel_febres_cordero_religious: 'Saint Miguel Febres Cordero, Religious',
-    modestus_andlauer_and_andrew_bauer_martyrs: 'Saints Modestus Andlauer and Andrew Bauer, Martyrs',
-    modestus_andlauer_martyr: 'Saint Modestus Andlauer, Martyr',
+    modestus_andlauer_and_andrew_bauer_martyrs: 'Saints Modeste Andlauer and Andrew Bauer, Martyrs',
+    modestus_andlauer_martyr: 'Saint Modeste Andlauer, Martyr', // src: https://en.wikipedia.org/wiki/Martyr_Saints_of_China
     monica_of_hippo: 'Saint Monica',
     moninne_of_killeavy_virgin: 'Saint Moninne, Virgin',
     morand_of_cluny_monk: 'Saint Morand, Monk',
@@ -855,6 +856,7 @@ export const locale: Locale = {
      * src: https://gcatholic.org/calendar/2024/CR-en.htm + @TobiTenno direct translation of the Spanish title
      */
     our_lady_of_angels_patroness_of_costa_rica: 'Our Lady of Angels, Patroness of Costa Rica',
+    our_lady_of_aparecida: 'Our Lady of Aparecida', // src: https://en.wikipedia.org/wiki/Our_Lady_of_Aparecida
     our_lady_of_aparecida_patroness_of_brazil: 'Our Lady of Aparecida, Patroness of Brazil',
     our_lady_of_bethlehem: 'Our Lady of Bethlehem',
     our_lady_of_china: 'Our Lady of China',
@@ -873,6 +875,7 @@ export const locale: Locale = {
     our_lady_of_lebanon: 'Our Lady of Lebanon',
     our_lady_of_loreto: 'Our Lady of Loreto',
     our_lady_of_lourdes: 'Our Lady of Lourdes',
+    our_lady_of_lujan: 'Our Lady of Luján', // src: https://en.wikipedia.org/wiki/Our_Lady_of_Luj%C3%A1n
     our_lady_of_lujan_patroness_of_argentina: 'Our Lady of Luján, Patroness of Argentina',
     our_lady_of_madhu: 'Our Lady of Madhu',
     our_lady_of_marija_bistrica: 'Our Lady of Marija Bistrica',


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute a pull request! -->

<!-- Please fill out the following sections to help us understand your changes. -->

## What is the purpose of this pull request?

- add strings missing from en.ts
- tests for names existing in en.ts checking all other locales
- export LOCALES (already present in the bundle, just wasn't exported)
- closes #455  

<!-- What should the change be that this pull request is addressing? -->

## Concept

- Localization
<!-- What part of the project does this feature relate to?
ex:     - Infrastructure
        - Localization
        - Calendar Definition
        - Discussion
        - Documentation
-->

## Example code

<!-- Please include a code sample for your usage. -->

No new usage, just verification by way of tests
```ts
const English = Romcal.LOCALES.En;
const NonEnglish = Object.values(Romcal.LOCALES).filter((locale) => locale.id !== 'en');
const missing: Array<{ locale: string; key: string }> = [];
NonEnglish.forEach((locale) => {
  Object.keys(locale.names!).forEach((key) => {
    if (!English.names!.hasOwnProperty(key)) {
      missing.push({ locale: locale.id, key });
    }
  });
});
```

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
