### PR TITLE
fix(brazil): update Brazilian calendar definitions and add tests

### DIFF
--- a/rites/roman1969/__tests__/brazil-calendar.test.ts
+++ b/rites/roman1969/__tests__/brazil-calendar.test.ts
@@ -11,19 +11,108 @@ describe('Testing Brazilian calendar specific celebrations', () => {
   let calendar2024: Awaited<ReturnType<typeof romcal.generateCalendar>>;
   let calendar2025: Awaited<ReturnType<typeof romcal.generateCalendar>>;
   let calendar2026: Awaited<ReturnType<typeof romcal.generateCalendar>>;
+  let calendar2027: Awaited<ReturnType<typeof romcal.generateCalendar>>;
 
   beforeAll(async () => {
     calendar2023 = await romcal.generateCalendar(2023);
     calendar2024 = await romcal.generateCalendar(2024);
     calendar2025 = await romcal.generateCalendar(2025);
     calendar2026 = await romcal.generateCalendar(2026);
+    calendar2027 = await romcal.generateCalendar(2027);
   });
 
-  describe('Brazilian saints', () => {
-    test('St. Dulce Lopes Pontes should be celebrated on August 13', () => {
-      const august13 = calendar2024['2024-08-13'];
+  describe('Brazilian celebrations', () => {
+    // June 8 - St. Ephrem (transferred from June 9)
+    test('St. Ephrem the Syrian should be celebrated on June 8', () => {
+      // Using 2026 because June 8, 2023 is Corpus Christi and June 8, 2024 is Immaculate Heart
+      const june8 = calendar2026['2026-06-08'];
 
-      const dulce = august13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
+      const ephrem = june8?.find((day) => day.id === 'ephrem_the_syrian_deacon');
+
+      expect(ephrem).toBeDefined();
+      expect(ephrem?.name).toBe('Santo Efrém, diácono e doutor da Igreja');
+      expect(ephrem?.rank).toBe(Ranks.OptionalMemorial);
+      expect(ephrem?.precedence).toBe(Precedences.OptionalMemorial_12);
+    });
+
+    // June 9 - St. Joseph de Anchieta
+    test('St. Joseph de Anchieta should be celebrated on June 9', () => {
+      // Using 2023 because June 9, 2024 is a Sunday
+      const june9 = calendar2023['2023-06-09'];
+
+      const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
+
+      expect(anchieta).toBeDefined();
+      expect(anchieta?.name).toBe('São José de Anchieta, presbítero');
+      expect(anchieta?.rank).toBe(Ranks.Memorial);
+      expect(anchieta?.precedence).toBe(Precedences.ProperMemorial_11b);
+    });
+
+    // July 8 - St. Augustine Zhao Rong (transferred from July 9)
+    test('St. Augustine Zhao Rong and companions should be celebrated on July 8', () => {
+      const july8 = calendar2024['2024-07-08'];
+
+      const augustine = july8?.find((day) => day.id === 'augustine_zhao_rong_priest_and_companions_martyrs');
+
+      expect(augustine).toBeDefined();
+      expect(augustine?.name).toBe('Santos Agostinho Zhao Rong, presbítero, e Companheiros, mártires');
+      expect(augustine?.rank).toBe(Ranks.OptionalMemorial);
+      expect(augustine?.precedence).toBe(Precedences.OptionalMemorial_12);
+    });
+
+    // July 9 - St. Paulina
+    test('St. Paulina should be celebrated on July 9', () => {
+      const july9 = calendar2024['2024-07-09'];
+
+      const paulina = july9?.find((day) => day.id === 'paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin');
+
+      expect(paulina).toBeDefined();
+      expect(paulina?.name).toBe('Santa Paulina do Coração Agonizante de Jesus, virgem');
+      expect(paulina?.rank).toBe(Ranks.Memorial);
+      expect(paulina?.precedence).toBe(Precedences.ProperMemorial_11b);
+    });
+
+    // July 16 - Our Lady of Mount Carmel
+    test('Our Lady of Mount Carmel should be celebrated on July 16 as a feast', () => {
+      const july16 = calendar2024['2024-07-16'];
+
+      const carmel = july16?.find((day) => day.id === 'our_lady_of_mount_carmel');
+
+      expect(carmel).toBeDefined();
+      expect(carmel?.name).toBe('Nossa Senhora do Monte Carmelo');
+      expect(carmel?.rank).toBe(Ranks.Feast);
+      expect(carmel?.precedence).toBe(Precedences.ProperFeast_8f);
+    });
+
+    // July 17 - Bl. Ignatius de Azevedo and companions
+    test('Bl. Ignatius de Azevedo and companions should be celebrated on July 17', () => {
+      const july17 = calendar2024['2024-07-17'];
+
+      const ignatius = july17?.find((day) => day.id === 'ignatius_de_azevedo_priest_and_companions_martyrs');
+
+      expect(ignatius).toBeDefined();
+      expect(ignatius?.name).toBe('Bem-aventurado Inácio de Azevedo, presbítero, e companheiros, mártires');
+      expect(ignatius?.rank).toBe(Ranks.Memorial);
+      expect(ignatius?.precedence).toBe(Precedences.ProperMemorial_11b);
+    });
+
+    // August 12 - Sts. Pontian and Hippolytus (transferred from August 13)
+    test('Sts. Pontian and Hippolytus should be celebrated on August 12', () => {
+      const aug12 = calendar2024['2024-08-12'];
+
+      const pontian = aug12?.find((day) => day.id === 'pontian_i_pope_and_hippolytus_of_rome_priest');
+
+      expect(pontian).toBeDefined();
+      expect(pontian?.name).toBe('Santos Ponciano, papa, e Hipólito, presbítero, mártires');
+      expect(pontian?.rank).toBe(Ranks.OptionalMemorial);
+      expect(pontian?.precedence).toBe(Precedences.OptionalMemorial_12);
+    });
+
+    // August 13 - St. Dulce Lopes Pontes
+    test('St. Dulce Lopes Pontes should be celebrated on August 13', () => {
+      const aug13 = calendar2024['2024-08-13'];
+
+      const dulce = aug13?.find((day) => day.id === 'dulce_lopes_pontes_virgin');
 
       expect(dulce).toBeDefined();
       expect(dulce?.name).toBe('Santa Dulce Lopes Pontes, virgem');
@@ -31,21 +120,35 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(dulce?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('St. Peter of Alcântara should be celebrated on October 19', () => {
-      const october19 = calendar2024['2024-10-19'];
+    // August 23 - St. Rose of Lima
+    test('St. Rose of Lima should be celebrated on August 23 as a feast', () => {
+      const aug23 = calendar2024['2024-08-23'];
 
-      const peter = october19?.find((day) => day.id === 'peter_of_alcantara_priest');
+      const rose = aug23?.find((day) => day.id === 'rose_of_lima_virgin');
 
-      expect(peter).toBeDefined();
-      expect(peter?.name).toBe('São Pedro de Alcântara, presbítero');
-      expect(peter?.rank).toBe(Ranks.Memorial);
-      expect(peter?.precedence).toBe(Precedences.ProperMemorial_11b);
+      expect(rose).toBeDefined();
+      expect(rose?.name).toBe('Santa Rosa de Lima, virgem');
+      expect(rose?.rank).toBe(Ranks.Feast);
+      expect(rose?.precedence).toBe(Precedences.ProperFeast_8f);
     });
 
-    test('St. Benedict the Moo should be celebrated on October 5', () => {
-      const october5 = calendar2024['2024-10-05'];
+    // October 3 - Sts. Andrew de Soveral and Ambrose Francis Ferro
+    test('Sts. Andrew de Soveral and Ambrose Francis Ferro should be celebrated on October 3', () => {
+      const oct3 = calendar2024['2024-10-03'];
 
-      const benedict = october5?.find((day) => day.id === 'benedict_the_moor_religious');
+      const andrew = oct3?.find((day) => day.id === 'andrew_de_soveral_and_ambrose_francis_ferro_priests');
+
+      expect(andrew).toBeDefined();
+      expect(andrew?.name).toBe('Santos André de Soveral e Ambrósio Francisco Ferro, presbíteros e mártires');
+      expect(andrew?.rank).toBe(Ranks.Memorial);
+      expect(andrew?.precedence).toBe(Precedences.ProperMemorial_11b);
+    });
+
+    // October 5 - St. Benedict the Moor
+    test('St. Benedict the Moor should be celebrated on October 5', () => {
+      const oct5 = calendar2024['2024-10-05'];
+
+      const benedict = oct5?.find((day) => day.id === 'benedict_the_moor_religious');
 
       expect(benedict).toBeDefined();
       expect(benedict?.name).toBe('São Benedito, o Negro, religioso');
@@ -53,41 +156,83 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(benedict?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
 
-    test('Our Lady of Aparecida should be celebrated on October 12 as a solemnity', () => {
-      const october12 = calendar2024['2024-10-12'];
+    // October 6 - St. Faustina Kowalska (transferred from October 5)
+    test('St. Faustina Kowalska should be celebrated on October 6', () => {
+      // Using 2023 because October 6, 2024 is a Sunday
+      const oct6 = calendar2023['2023-10-06'];
 
-      const aparecida = october12?.find((day) => day.id === 'our_lady_of_aparecida');
+      const faustina = oct6?.find((day) => day.id === 'faustina_kowalska_virgin');
+
+      expect(faustina).toBeDefined();
+      expect(faustina?.name).toBe('Santa Faustina Kowalska, virgem');
+      expect(faustina?.rank).toBe(Ranks.OptionalMemorial);
+      expect(faustina?.precedence).toBe(Precedences.OptionalMemorial_12);
+    });
+
+    // October 12 - Our Lady of Aparecida
+    test('Our Lady of Aparecida should be celebrated on October 12 as a solemnity', () => {
+      const oct12 = calendar2024['2024-10-12'];
+
+      const aparecida = oct12?.find((day) => day.id === 'our_lady_of_aparecida');
 
       expect(aparecida).toBeDefined();
-      expect(aparecida?.name).toBe('Nossa Senhora Aparecida');
+      expect(aparecida?.name).toBe('Nossa Senhora da Conceição Aparecida, Padroeira do Brasil');
       expect(aparecida?.rank).toBe(Ranks.Solemnity);
       expect(aparecida?.precedence).toBe(Precedences.ProperSolemnity_PrincipalPatron_4a);
+    });
+
+    // October 19 - St. Peter of Alcántara
+    test('St. Peter of Alcántara should be celebrated on October 19', () => {
+      const oct19 = calendar2024['2024-10-19'];
+
+      const peter = oct19?.find((day) => day.id === 'peter_of_alcantara_priest');
+
+      expect(peter).toBeDefined();
+      expect(peter?.name).toBe('São Pedro de Alcântara, presbítero');
+      expect(peter?.rank).toBe(Ranks.OptionalMemorial);
+      expect(peter?.precedence).toBe(Precedences.OptionalMemorial_12);
+    });
+
+    // October 25 - St. Anthony of St. Anne Galvão
+    test('St. Anthony of St. Anne Galvão should be celebrated on October 25', () => {
+      const oct25 = calendar2024['2024-10-25'];
+
+      const galvao = oct25?.find((day) => day.id === 'anthony_of_saint_anne_galvao_priest');
+
+      expect(galvao).toBeDefined();
+      expect(galvao?.name).toBe('Santo Antônio de Sant’Ana Galvão, presbítero');
+      expect(galvao?.rank).toBe(Ranks.Memorial);
+      expect(galvao?.precedence).toBe(Precedences.ProperMemorial_11b);
+    });
+
+    // November 19 - Sts. Roque González, Afonso Rodríguez and João de Castillo
+    test('Sts. Roque González, Afonso Rodríguez and João de Castillo should be celebrated on November 19', () => {
+      const nov19 = calendar2024['2024-11-19'];
+
+      const roque = nov19?.find((day) => day.id === 'roch_gonzalez_alphonsus_rodriguez_and_john_del_castillo_priests');
+
+      expect(roque).toBeDefined();
+      expect(roque?.name).toBe('Santos Roque González, Afonso Rodríguez e João de Castillo, presbíteros e mártires');
+      expect(roque?.rank).toBe(Ranks.Memorial);
+      expect(roque?.precedence).toBe(Precedences.ProperMemorial_11b);
     });
   });
 
   describe('Sts. Peter and Paul transfer to Sunday in Brazil', () => {
     test('When falling between June 28 and July 4, it should be transferred to the first Sunday of July', () => {
-      // Test years where June 29 falls on different days of the week
       // 2024: June 29 is Saturday -> should be transferred to July 7 (first Sunday of July)
-      // 2025: June 29 is Sunday -> no transfer needed
-      // 2026: June 29 is Monday -> should be transferred to July 5 (first Sunday of July)
-
-      // 2024: June 29 is Saturday
       const july7_2024 = calendar2024['2024-07-07'];
 
-      // On July 7 (first Sunday of July), Peter and Paul should be celebrated
       const peterPaulOnJuly7 = july7_2024?.find((day) => day.id === 'peter_and_paul_apostles');
 
-      // The transfer should work - Peter and Paul should be on July 7
       expect(peterPaulOnJuly7).toBeDefined();
       expect(peterPaulOnJuly7?.name).toBe('São Pedro e São Paulo, Apóstolos');
       expect(peterPaulOnJuly7?.rank).toBe(Ranks.Solemnity);
       expect(peterPaulOnJuly7?.precedence).toBe(Precedences.GeneralSolemnity_3);
 
-      // 2026: June 29 is Monday
+      // 2026: June 29 is Monday -> should be transferred to July 5 (first Sunday of July)
       const july5_2026 = calendar2026['2026-07-05'];
 
-      // On July 5 (first Sunday of July), Peter and Paul should be celebrated
       const peterPaulOnJuly5 = july5_2026?.find((day) => day.id === 'peter_and_paul_apostles');
 
       expect(peterPaulOnJuly5).toBeDefined();
@@ -96,8 +241,8 @@ describe('Testing Brazilian calendar specific celebrations', () => {
       expect(peterPaulOnJuly5?.precedence).toBe(Precedences.GeneralSolemnity_3);
     });
 
-    test('When falling on Sunday (outside the transfer range), it should not be transferred', () => {
-      // 2025: June 29 is Sunday, so it should be celebrated on that day
+    test('When June 29 is already a Sunday, it should not be transferred', () => {
+      // 2025: June 29 is Sunday
       const june29_2025 = calendar2025['2025-06-29'];
 
       const peterPaul = june29_2025?.find((day) => day.id === 'peter_and_paul_apostles');
@@ -110,38 +255,53 @@ describe('Testing Brazilian calendar specific celebrations', () => {
     });
   });
 
-  describe('Other Brazilian celebrations', () => {
-    test('St. Joseph of Anchieta should be celebrated on June 9', () => {
-      const june9 = calendar2023['2023-06-09'];
+  describe('Assumption of Our Lady transfer to Sunday in Brazil', () => {
+    test('When August 15 is not a Sunday, it should be transferred to the 3rd Sunday of August', () => {
+      // 2024: Aug 15 is Thursday -> should be transferred to Aug 18 (3rd Sunday of August)
+      const aug18_2024 = calendar2024['2024-08-18'];
 
-      const anchieta = june9?.find((day) => day.id === 'joseph_de_anchieta_priest');
+      const assumption = aug18_2024?.find((day) => day.id === 'assumption_of_the_blessed_virgin_mary');
 
-      expect(anchieta).toBeDefined();
-      expect(anchieta?.name).toBe('São José de Anchieta, presbítero');
-      expect(anchieta?.rank).toBe(Ranks.Memorial);
-      expect(anchieta?.precedence).toBe(Precedences.ProperMemorial_11b);
+      expect(assumption).toBeDefined();
+      expect(assumption?.name).toBe('Assunção da Bem-aventurada Virgem Maria');
+      expect(assumption?.rank).toBe(Ranks.Solemnity);
     });
 
-    test('St. Paulina should be celebrated on July 9', () => {
-      const july9 = calendar2024['2024-07-09'];
+    test('When August 15 is already a Sunday, it should not be transferred', () => {
+      // 2027: Aug 15 is Sunday
+      const aug15_2027 = calendar2027['2027-08-15'];
 
-      const paulina = july9?.find((day) => day.id === 'paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin');
+      const assumption = aug15_2027?.find((day) => day.id === 'assumption_of_the_blessed_virgin_mary');
 
-      expect(paulina).toBeDefined();
-      expect(paulina?.name).toBe('Santa Paulina do Coração Agonizante de Jesus Visintainer, virgem');
-      expect(paulina?.rank).toBe(Ranks.Memorial);
-      expect(paulina?.precedence).toBe(Precedences.ProperMemorial_11b);
+      expect(assumption).toBeDefined();
+      expect(assumption?.name).toBe('Assunção da Bem-aventurada Virgem Maria');
+      expect(assumption?.date).toBe('2027-08-15');
+      expect(assumption?.rank).toBe(Ranks.Solemnity);
+    });
+  });
+
+  describe('All Saints transfer to Sunday in Brazil', () => {
+    test('When November 1 is not a Sunday, it should be transferred to the 1st Sunday of November', () => {
+      // 2024: Nov 1 is Friday -> should be transferred to Nov 3 (1st Sunday of November)
+      const nov3_2024 = calendar2024['2024-11-03'];
+
+      const allSaints = nov3_2024?.find((day) => day.id === 'all_saints');
+
+      expect(allSaints).toBeDefined();
+      expect(allSaints?.name).toBe('Todos os Santos');
+      expect(allSaints?.rank).toBe(Ranks.Solemnity);
     });
 
-    test('St. Anthony of St. Anne Galvao should be celebrated on October 25', () => {
-      const october25 = calendar2024['2024-10-25'];
+    test('When November 1 is already a Sunday, it should not be transferred', () => {
+      // 2026: Nov 1 is Sunday
+      const nov1_2026 = calendar2026['2026-11-01'];
 
-      const galvao = october25?.find((day) => day.id === 'anthony_of_saint_anne_galvao_priest');
+      const allSaints = nov1_2026?.find((day) => day.id === 'all_saints');
 
-      expect(galvao).toBeDefined();
-      expect(galvao?.name).toBe("Santo Antônio de Sant'Anna Galvão, presbítero");
-      expect(galvao?.rank).toBe(Ranks.Memorial);
-      expect(galvao?.precedence).toBe(Precedences.ProperMemorial_11b);
+      expect(allSaints).toBeDefined();
+      expect(allSaints?.name).toBe('Todos os Santos');
+      expect(allSaints?.date).toBe('2026-11-01');
+      expect(allSaints?.rank).toBe(Ranks.Solemnity);
     });
   });
 });

--- a/rites/roman1969/src/calendars/countries/brazil/index.ts
+++ b/rites/roman1969/src/calendars/countries/brazil/index.ts
@@ -11,6 +11,7 @@ export class Brazil extends CalendarDef {
     peter_and_paul_apostles: {
       // In Brazil, when the celebration falls between June 28 and July 4,
       // it is moved to the first Sunday of July, unless June 29 is already a Sunday.
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=20
       dateExceptions: [
         {
           ifIsBetween: {
@@ -28,36 +29,37 @@ export class Brazil extends CalendarDef {
     ephrem_the_syrian_deacon: {
       // In Brazil, St Ephrem is transferred to June 8
       // because St Joseph de Anchieta is celebrated on June 9
+      // src: `https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=79`
       dateDef: { month: 6, date: 8 },
     },
 
     joseph_de_anchieta_priest: {
+      // src: https://diocesedeipameri.com.br/wp-content/uploads/2022/01/Direto%CC%81rio-da-Liturgia.pdf#page=43
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 6, date: 9 },
-    },
-
-    albertina_berkenbrock_virgin: {
-      precedence: Precedences.ProperMemorial_11b,
-      dateDef: { month: 6, date: 15 },
     },
 
     augustine_zhao_rong_priest_and_companions_martyrs: {
       // In Brazil, St Augustine Zhao Rong and companions are transferred to July 8
       // because St Paulina is celebrated on July 9
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=85
       dateDef: { month: 7, date: 8 },
     },
 
     paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=85
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 7, date: 9 },
     },
 
     our_lady_of_mount_carmel: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=86
       precedence: Precedences.ProperFeast_8f,
       dateDef: { month: 7, date: 16 },
     },
 
     ignatius_de_azevedo_priest_and_companions_martyrs: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=87
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 7, date: 17 },
       martyrology: ['ignatius_de_azevedo_priest', 'companions_martyrs'],
@@ -66,6 +68,7 @@ export class Brazil extends CalendarDef {
     pontian_i_pope_and_hippolytus_of_rome_priest: {
       // In Brazil, Sts Pontian and Hippolytus are transferred to August 12
       // because St Dulce Lopes Pontes is celebrated on August 13
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=92
       dateDef: { month: 8, date: 12 },
     },
 
@@ -75,56 +78,90 @@ export class Brazil extends CalendarDef {
       // src: https://www.cnbb.org.br/liturgia-diaria/ 13-August-2025 Retrieved 26-November-2025
     },
 
+    assumption_of_the_blessed_virgin_mary: {
+      // In Brazil, the Assumption is moved to the Sunday within August 14-20,
+      // unless August 15 is already a Sunday.
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=20
+      dateExceptions: [
+        {
+          ifIsBetween: {
+            from: { month: 8, date: 14 },
+            to: { month: 8, date: 20 },
+            inclusive: true,
+          },
+          setDate: { month: 8, nthWeekInMonth: 3, dayOfWeek: 0 },
+        },
+        // If August 15 is already Sunday, keep it on that date
+        { ifIsDayOfWeek: 0, setDate: { month: 8, date: 15 } },
+      ],
+    },
+
     rose_of_lima_virgin: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=94
       precedence: Precedences.ProperFeast_8f,
       dateDef: { month: 8, date: 23 },
     },
 
     andrew_de_soveral_and_ambrose_francis_ferro_priests: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=101
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 3 },
       martyrology: ['andrew_de_soveral_priest', 'ambrose_francis_ferro_priest'],
     },
 
-    faustina_kowalska_virgin: {
-      // In Brazil, St Faustina Kowalska is transferred to October 6
-      // because St Benedict the Moor is celebrated on October 5
-      // Note: This date should be verified in the official Brazilian Ordo
-      dateDef: { month: 10, date: 6 },
-    },
-
-    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
     benedict_the_moor_religious: {
+      // src: https://diocesedeipameri.com.br/wp-content/uploads/2022/01/Diretório-da-Liturgia.pdf#page=65
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 5 },
     },
 
+    faustina_kowalska_virgin: {
+      // In Brazil, St Faustina Kowalska is transferred to October 6
+      // because St Benedict the Moor is celebrated on October 5
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=102
+      dateDef: { month: 10, date: 6 },
+    },
+
     our_lady_of_aparecida: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=102
       customLocaleId: 'our_lady_of_aparecida_patroness_of_brazil',
       precedence: Precedences.ProperSolemnity_PrincipalPatron_4a,
       dateDef: { month: 10, date: 12 },
       titles: { append: [PatronTitle.PatronessOfBrazil] },
     },
 
-    // src: https://www.cnbb.org.br/missal-romano-calendario-proprio-dos-santos-brasil/
     peter_of_alcantara_priest: {
-      precedence: Precedences.ProperMemorial_11b,
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=104
+      precedence: Precedences.OptionalMemorial_12,
       dateDef: { month: 10, date: 19 },
     },
 
-    john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs: {
-      // In Brazil, Sts John de Brebeuf, Isaac Jogues and companions are transferred to October 20
-      // because St Peter of Alcântara is celebrated on October 19
-      // Note: This date should be verified in the official Brazilian Ordo
-      dateDef: { month: 10, date: 20 },
-    },
-
     anthony_of_saint_anne_galvao_priest: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=105
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 10, date: 25 },
     },
 
+    all_saints: {
+      // In Brazil, All Saints is moved to the Sunday within October 31 - November 6,
+      // unless November 1 is already a Sunday.
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=20
+      dateExceptions: [
+        {
+          ifIsBetween: {
+            from: { month: 10, date: 31 },
+            to: { month: 11, date: 6 },
+            inclusive: true,
+          },
+          setDate: { month: 11, nthWeekInMonth: 1, dayOfWeek: 0 },
+        },
+        // If November 1 is already Sunday, keep it on that date
+        { ifIsDayOfWeek: 0, setDate: { month: 11, date: 1 } },
+      ],
+    },
+
     roch_gonzalez_alphonsus_rodriguez_and_john_del_castillo_priests: {
+      // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=110
       precedence: Precedences.ProperMemorial_11b,
       dateDef: { month: 11, date: 19 },
       martyrology: ['roch_gonzalez_priest', 'alphonsus_rodriguez_priest', 'john_del_castillo_priest'],

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -197,7 +197,7 @@ export const locale: Locale = {
     ambrose_of_milan_bishop: 'Santo Ambrósio de Milão, bispo e doutor da Igreja',
     andrew_apostle: 'Santo André, apóstolo',
     andrew_de_soveral_and_ambrose_francis_ferro_priests:
-      'Santo André de Soveral e Santo Ambrósio Francisco Ferro, presbíteros e mártires',
+      'Santos André de Soveral e Ambrósio Francisco Ferro, presbíteros e mártires', // based on: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=101
     andrew_dung_lac_priest_and_companions_martyrs: 'Santo André Dũng-Lạc e Companheiros, mártires',
     andrew_kim_tae_gon_priest_paul_chong_ha_sang_and_companions_martyrs:
       'Santos André Kim Taegon, presbítero, Paulo Chang Hasang e Companheiros, mártires',
@@ -208,7 +208,7 @@ export const locale: Locale = {
     anthony_mary_claret_bishop: 'Santo Antônio Maria Claret, bispo',
     anthony_of_egypt_abbot: 'Santo Antão, abade',
     anthony_of_padua_priest: 'Santo Antônio, presbítero e doutor da Igreja',
-    anthony_of_saint_anne_galvao_priest: "Santo Antônio de Sant'Anna Galvão, presbítero",
+    anthony_of_saint_anne_galvao_priest: 'Santo Antônio de Sant’Ana Galvão, presbítero', // based on: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=105
     anthony_zaccaria_priest: 'Santo Antônio Maria Zacarias, presbítero',
     apollinaris_of_ravenna_bishop: 'Santo Apolinário, bispo e mártir',
     arbogast_of_strasbourg_bishop: 'São Arbogasto, bispo',
@@ -216,7 +216,7 @@ export const locale: Locale = {
       'São Arbogasto, bispo e patrono da Arquidiocese de Estrasburgo',
     ascension_of_the_lord: 'Ascensão do Senhor',
     ash_wednesday: 'Quarta-feira de Cinzas',
-    assumption_of_the_blessed_virgin_mary: 'Assunção da Bem Aventurada Virgem Maria',
+    assumption_of_the_blessed_virgin_mary: 'Assunção da Bem-aventurada Virgem Maria', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=93
     athanasius_of_alexandria_bishop: 'Santo Atanásio, bispo e doutor da Igreja',
     audoen_of_rouen_bishop: 'São Audoeno, bispo',
     augustine_of_canterbury_bishop: 'Santo Agostinho de Cantuária, bispo',
@@ -297,7 +297,7 @@ export const locale: Locale = {
     eligius_of_noyon_bishop: 'Santo Elígio, bispo',
     elizabeth_of_hungary_religious: 'Santa Isabel da Hungria, religiosa',
     elizabeth_of_portugal: 'Santa Isabel de Portugal',
-    ephrem_the_syrian_deacon: 'Santo Efrém, o Sírio, diácono',
+    ephrem_the_syrian_deacon: 'Santo Efrém, diácono e doutor da Igreja', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=79
     epiphany_of_the_lord: 'Epifania do Senhor',
     eucharius_of_trier_bishop: 'Santo Eucario, bispo',
     eugenia_of_alsace_and_attala_of_alsace_virgins: 'Santas Eugenia e Attala, virgens',
@@ -329,14 +329,15 @@ export const locale: Locale = {
     gundisalvus_of_lagos_priest: 'São Gonçalo de Lagos, presbítero',
     hedwig_of_silesia_religious: 'Santa Edviges, religiosa',
     henry_ii_emperor: 'Santo Henrique',
-    hilary_of_poitiers_bishop: 'Santo Hilário, bispo e doutor da Igreja', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=49
+    hilary_of_poitiers_bishop: 'Santo Hilário, bispo e doutor da Igreja', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=49
     hildegard_of_bingen_abbess: 'Santa Hildegarda de Bingen, virgem e doutora da Igreja',
     holy_family_of_jesus_mary_and_joseph: 'Sagrada Família',
     holy_guardian_angels: 'Santos Anjos da Guarda',
     holy_innocents_martyrs: 'Santos Inocentes, mártires',
     holy_saturday: 'Sábado Santo',
     holy_thursday: 'Quinta-feira Santa',
-    ignatius_de_azevedo_priest_and_companions_martyrs: 'Beatos Inácio de Azevedo, presbítero, e companheiros, mártires',
+    ignatius_de_azevedo_priest_and_companions_martyrs:
+      'Bem-aventurado Inácio de Azevedo, presbítero, e companheiros, mártires', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=87
     ignatius_of_antioch_bishop: 'Santo Inácio de Antioquia, bispo e mártir',
     ignatius_of_loyola_priest: 'Santo Inácio de Loiola, presbítero',
     immaculate_conception_of_the_blessed_virgin_mary: 'Imaculada Conceição',
@@ -359,10 +360,10 @@ export const locale: Locale = {
     john_chrysostom_bishop: 'São João Crisóstomo, bispo e doutor da Igreja',
     john_damascene_priest: 'São João Damasceno, presbítero e doutor da Igreja',
     john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs:
-      'Santos João de Brébeuf, Isaac Jogues, presbíteros, e Companheiros, mártires',
+      'Santos João de Brébeuf e Isaac Jogues, presbíteros e companheiros, mártires', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=104
     john_de_britto_priest: 'São João de Brito, presbítero e mártir',
     john_eudes_priest: 'São João Eudes, presbítero',
-    john_fisher_bishop_and_thomas_more_martyrs: 'Santos João Fisher, bispo e Tomás More, mártires', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=81
+    john_fisher_bishop_and_thomas_more_martyrs: 'Santos João Fisher, bispo e Tomás More, mártires', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=81
     john_i_pope: 'São João I, papa e mártir',
     john_leonardi_priest: 'São João Leonardi, presbítero',
     john_mary_vianney_priest: 'São João Maria Vianney, presbítero',
@@ -443,8 +444,8 @@ export const locale: Locale = {
     our_lady_help_of_christians: 'Nossa Senhora, Auxílio dos Cristãos',
     our_lady_mediatrix_of_all_grace: 'Nossa Senhora, Medianeira de todas as Graças',
     our_lady_mother_of_divine_providence_patroness_of_puerto_rico: 'Nossa Senhora, Mãe da Divina Providência',
-    our_lady_of_aparecida: 'Nossa Senhora da Conceição Aparecida',
-    our_lady_of_aparecida_patroness_of_brazil: 'Nossa Senhora Aparecida',
+    our_lady_of_aparecida: 'Nossa Senhora da Conceição Aparecida', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=102
+    our_lady_of_aparecida_patroness_of_brazil: 'Nossa Senhora da Conceição Aparecida, Padroeira do Brasil', // src: https://diocesedeipameri.com.br/wp-content/uploads/2022/01/Direto%CC%81rio-da-Liturgia.pdf#page=66
     our_lady_of_china: 'Nossa Senhora da China',
     our_lady_of_fatima: 'Nossa Senhora de Fatima',
     our_lady_of_good_counsel: 'Nossa Senhora do Bom Conselho',
@@ -453,7 +454,7 @@ export const locale: Locale = {
     our_lady_of_loreto: 'Nossa Senhora de Loreto',
     our_lady_of_lourdes: 'Nossa Senhora de Lourdes',
     our_lady_of_lujan_patroness_of_argentina: 'Nossa Senhora de Luján, padroeira da Argentina',
-    our_lady_of_mount_carmel: 'Nossa Senhora do Monte Carmelo',
+    our_lady_of_mount_carmel: 'Nossa Senhora do Monte Carmelo', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=86
     our_lady_of_perpetual_help: 'Nossa Senhora do Perpétuo Socorro',
     our_lady_of_sorrows: 'Nossa Senhora das Dores',
     our_lady_of_the_gate_of_dawn: 'Nossa Senhora da Porta da Aurora',
@@ -470,8 +471,7 @@ export const locale: Locale = {
     paul_miki_and_companions_martyrs: 'Santos Paulo Miki e Companheiros, mártires',
     paul_of_the_cross_priest: 'São Paulo da Cruz, presbítero',
     paul_vi_pope: 'São Paulo VI, papa',
-    paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin:
-      'Santa Paulina do Coração Agonizante de Jesus Visintainer, virgem',
+    paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin: 'Santa Paulina do Coração Agonizante de Jesus, virgem', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=85
     paulinus_of_nola_bishop: 'São Paulino de Nola, bispo',
     pentecost_sunday: 'Pentecostes',
     perpetua_of_carthage_and_felicity_of_carthage_martyrs: 'Santas Perpétua e Felicidade, mártires',
@@ -482,14 +482,14 @@ export const locale: Locale = {
     peter_claver_priest: 'São Pedro Claver, presbítero',
     peter_damian_bishop: 'São Pedro Damião, bispo e doutor da Igreja',
     peter_julian_eymard_priest: 'São Pedro Juliano Eymard, presbítero',
-    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=104
+    peter_of_alcantara_priest: 'São Pedro de Alcântara, presbítero', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=104
     philip_and_james_apostles: 'São Filipe e Tiago, apóstolos',
     philip_neri_priest: 'São Filipe Néri, presbítero',
     pius_francesco_forgione_priest: 'São Pio de Pietrelcina, presbítero',
     pius_v_pope: 'São Pio V, papa',
     pius_x_pope: 'São Pio X, papa',
     polycarp_of_smyrna_bishop: 'São Policarpo, bispo e mártir',
-    pontian_i_pope_and_hippolytus_of_rome_priest: 'Santos Pôncio I, papa, e Hipólito de Roma, presbítero',
+    pontian_i_pope_and_hippolytus_of_rome_priest: 'Santos Ponciano, papa, e Hipólito, presbítero, mártires', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=92
     presentation_of_the_blessed_virgin_mary: 'Apresentação da Virgem Maria',
     presentation_of_the_lord: 'Apresentação do Senhor',
     queenship_of_the_blessed_virgin_mary: 'Bem-aventurada virgem Maria, Rainha do Céu',
@@ -498,10 +498,10 @@ export const locale: Locale = {
     rita_of_cascia_religious: 'Santa Rita de Cássia, religiosa',
     robert_bellarmine_bishop: 'São Roberto Belarmino, bispo e doutor da Igreja',
     roch_gonzalez_alphonsus_rodriguez_and_john_del_castillo_priests:
-      'São Roque González Alfonso Rodríguez e São João del Castillo, presbíteros e mártires',
+      'Santos Roque González, Afonso Rodríguez e João de Castillo, presbíteros e mártires', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=110
     romuald_of_ravenna_abbot: 'São Romualdo, abade',
     rosalie_jeanne_marie_rendu_virgin: 'Beata Rosália Rendu, virgem',
-    rose_of_lima_virgin: 'Santa Rosa de Lima, virgem',
+    rose_of_lima_virgin: 'Santa Rosa de Lima, virgem', // based on: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=94
     sancha_of_portugal_and_mafalda_of_portugal_virgins: 'Beatas Sancha e Mafalda, virgens, e Teresa, religiosa',
     scholastica_of_nursia_virgin: 'Santa Escolástica, virgem',
     sebastian_of_milan_martyr: 'São Sebastião, mártir',
@@ -515,7 +515,7 @@ export const locale: Locale = {
     sunday_of_the_word_of_god: '3º Domingo do Tempo Comum, ou Domingo da Palavra de Deus',
     sylvester_i_pope: 'São Silvestre I, papa',
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedita da Cruz, virgem e mártir',
-    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja', // src: arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=103
+    teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=103
     teresa_of_portugal_religious: 'Beata Teresa de Portugal, religiosa',
     theotonius_of_coimbra_priest: 'Santo Teotónio, presbítero',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:

--- a/rites/roman1969/src/locales/pt-br.ts
+++ b/rites/roman1969/src/locales/pt-br.ts
@@ -515,6 +515,7 @@ export const locale: Locale = {
     sunday_of_the_word_of_god: '3º Domingo do Tempo Comum, ou Domingo da Palavra de Deus',
     sylvester_i_pope: 'São Silvestre I, papa',
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedita da Cruz, virgem e mártir',
+    teresa_of_calcutta_virgin: 'Santa Teresa de Calcutá, virgem', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#portoghese
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesus, virgem e doutora da Igreja', // src: https://arquidiocesemilitar.org.br/wp-content/uploads/2025/01/DIRETORIO-LITURGICO-OMB-2025-1_compressed.pdf#page=103
     teresa_of_portugal_religious: 'Beata Teresa de Portugal, religiosa',
     theotonius_of_coimbra_priest: 'Santo Teotónio, presbítero',


### PR DESCRIPTION
## Summary

Calendar changes:

- Fix `peter_of_alcantara_priest` rank to `OptionalMemorial_12`
- Move `faustina_kowalska_virgin` after `benedict_the_moor_religious`
- Remove `john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs`
  (celebrated alongside `peter_of_alcantara_priest` and `paul_of_the_cross_priest`
  as optional memorials)
- Remove `albertina_berkenbrock_virgin` (not found in Brazilian Ordos
  or cnbb.org.br)
- Add date exceptions for `assumption_of_the_blessed_virgin_mary`
  (transfer to 3rd Sunday of August)
- Add date exceptions for `all_saints` (transfer to 1st Sunday of November)
- Add source references to all celebrations

Locale changes (`pt-br.ts`):

- `andrew_de_soveral_and_ambrose_francis_ferro_priests`
- `anthony_of_saint_anne_galvao_priest`
- `assumption_of_the_blessed_virgin_mary`
- `ephrem_the_syrian_deacon`
- `ignatius_de_azevedo_priest_and_companions_martyrs`
- `john_de_brebeuf_isaac_jogues_priests_and_companions_martyrs`
- `our_lady_of_aparecida_patroness_of_brazil`
- `our_lady_of_mount_carmel`
- `paulina_of_the_agonizing_heart_of_jesus_visintainer_virgin`
- `pontian_i_pope_and_hippolytus_of_rome_priest`
- `roch_gonzalez_alphonsus_rodriguez_and_john_del_castillo_priests`

Test changes:

- Add tests for all Brazilian celebrations in chronological order
- Fix `peter_of_alcantara_priest` test to expect `OptionalMemorial`
- Fix typo in `benedict_the_moor_religious` test name