### PR TITLE
refactor(util): improve data checks and update teresa_of_calcutta_virgin translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "romcal",
   "version": "3.0.0-dev.118",
   "lockfileVersion": 3,
-  "requires": true,
   "packages": {
     "": {
       "name": "romcal",
@@ -88,7 +87,6 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1050,6 +1048,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
@@ -1062,6 +1061,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1073,6 +1073,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3138,6 +3139,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -3179,6 +3181,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3235,6 +3238,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3391,7 +3395,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3436,7 +3439,6 @@
       "integrity": "sha512-X63hI1bxl5ohelzr0LY5coufyl0LJNthld+abwxpCoo6Gq+hSqhKwci7MUWkXo67mzgUK6YFByhmaHmUcuBJmA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.48.1",
@@ -3477,7 +3479,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -3695,7 +3696,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -3709,7 +3711,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -3723,7 +3726,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -3737,7 +3741,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -3751,7 +3756,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -3765,7 +3771,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -3779,7 +3786,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -3793,7 +3801,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -3807,7 +3816,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -3821,7 +3831,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -3835,7 +3846,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -3849,7 +3861,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -3863,7 +3876,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -3877,7 +3891,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -3891,7 +3906,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -3903,6 +3919,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -3922,7 +3939,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -3936,7 +3954,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -3950,7 +3969,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "8.14.1",
@@ -3958,7 +3978,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4453,7 +4472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5479,7 +5497,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5555,7 +5572,6 @@
       "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5617,7 +5633,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7959,7 +7974,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -11800,7 +11814,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13402,7 +13415,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13554,7 +13566,8 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -13598,9 +13611,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.3.0.tgz",
-      "integrity": "sha512-d9CwU93nN0IA1QL+GSNDdwLAu1Ew5ZjTwupvedwg3WdfoH6pIDvYQ2hV0Uc2nKBLPq7NB5apCx57MLS5qlmO5g==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.3.1.tgz",
+      "integrity": "sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -13705,7 +13718,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14519,5 +14531,6 @@
         "unified": "^11.0.5"
       }
     }
-  }
+  },
+  "requires": true
 }

--- a/rites/roman1969/__tests__/calendar-data.test.ts
+++ b/rites/roman1969/__tests__/calendar-data.test.ts
@@ -1,0 +1,311 @@
+import { calendarDefinitions } from '../src/calendars';
+import { GeneralRoman } from '../src/calendars/general-roman';
+import { Martyrology } from '../src/catalog/martyrology';
+import { locales } from '../src/locales';
+import { RomcalConfig } from '../src/models/config';
+import { CalendarDefInstance, Inputs } from '../src/types/calendar-def';
+import { DateDef } from '../src/types/liturgical-day';
+
+import { findMissingInArray } from './util/findMissingInArray';
+
+const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+/**
+ * Map of dateFn names to their fixed date equivalents (month, date).
+ * These functions always return the same date regardless of year.
+ */
+const FIXED_DATE_FN_MAP: Record<string, { month: number; date: number }> = {
+  peterAndPaulApostles: { month: 6, date: 29 },
+  assumption: { month: 8, date: 15 },
+  allSaints: { month: 11, date: 1 },
+  christmas: { month: 12, date: 25 },
+  maryMotherOfGod: { month: 1, date: 1 },
+  epiphany: { month: 1, date: 6 },
+  immaculateConceptionOfMary: { month: 12, date: 8 },
+};
+
+/**
+ * Extract all celebration locale keys (names keys) used across all calendar definitions.
+ * This includes:
+ * - The celebration ID itself if it's in the names object
+ * - The customLocaleId if defined
+ */
+const extractAllCelebrationLocaleKeys = (): Set<string> => {
+  const allKeys = new Set<string>();
+  const devLocale = { id: 'dev' };
+
+  for (const CalendarDefClass of Object.values(calendarDefinitions)) {
+    const isGRC = CalendarDefClass.name === GeneralRoman.name;
+    const config = isGRC
+      ? new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale)
+      : new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale, CalendarDefClass);
+
+    config.calendarsDef.forEach((cal) => cal.buildAllDefinitions());
+
+    for (const def of Object.values(config.liturgicalDayDef)) {
+      // The i18nDef typically starts with 'names:' for celebration names
+      if (def.i18nDef && def.i18nDef[0]?.startsWith('names:')) {
+        const nameKey = def.i18nDef[0].replace('names:', '');
+        allKeys.add(nameKey);
+      }
+
+      // Check for customLocaleId in inputs
+      for (const input of def.input) {
+        if (input.customLocaleId) {
+          allKeys.add(input.customLocaleId);
+        }
+      }
+    }
+  }
+
+  return allKeys;
+};
+
+/**
+ * Get the inputs from a calendar class.
+ */
+const getCalendarInputs = (CalendarClass: CalendarDefInstance): Inputs => {
+  const instance = new (CalendarClass as unknown as new (cfg: unknown) => { inputs?: Inputs })({
+    calendarsDef: [],
+    liturgicalDayDef: {},
+  });
+  return instance.inputs || {};
+};
+
+/**
+ * Get the parent calendars from a calendar class.
+ */
+const getParentCalendars = (CalendarClass: CalendarDefInstance): CalendarDefInstance[] => {
+  const proto = (
+    CalendarClass as unknown as {
+      prototype?: { constructor?: { prototype?: { ParentCalendars?: CalendarDefInstance[] } } };
+    }
+  ).prototype;
+  return proto?.constructor?.prototype?.ParentCalendars || [];
+};
+
+/**
+ * Build the full inheritance chain for a calendar (from most specific to GeneralRoman).
+ * Returns an array of calendar classes, starting with the current calendar.
+ */
+const buildInheritanceChain = (CalendarClass: CalendarDefInstance): CalendarDefInstance[] => {
+  const chain: CalendarDefInstance[] = [CalendarClass];
+
+  if (CalendarClass === GeneralRoman) {
+    return chain;
+  }
+
+  const parents = getParentCalendars(CalendarClass);
+
+  if (parents.length === 0) {
+    // No explicit parents means implicit inheritance from GeneralRoman
+    chain.push(GeneralRoman);
+  } else {
+    // Traverse parent chain
+    for (const parent of parents) {
+      chain.push(...buildInheritanceChain(parent));
+    }
+    // Ensure GeneralRoman is at the end if not already included
+    if (!chain.includes(GeneralRoman)) {
+      chain.push(GeneralRoman);
+    }
+  }
+
+  return chain;
+};
+
+/**
+ * Find the dateDef for a celebration ID by traversing the inheritance chain.
+ * Continues searching up the chain even if an entry exists without dateDef.
+ */
+const findDateDefInChain = (celebrationId: string, chain: CalendarDefInstance[]): DateDef | undefined => {
+  for (const CalendarClass of chain) {
+    const inputs = getCalendarInputs(CalendarClass);
+    const input = inputs[celebrationId];
+
+    if (input) {
+      // Handle both single input and array of inputs
+      const inputObj = Array.isArray(input) ? input[0] : input;
+      if (inputObj.dateDef) {
+        return inputObj.dateDef as DateDef;
+      }
+      // Continue searching - entry exists but has no dateDef (only dateExceptions, etc.)
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Format a DateDef into a human-readable string.
+ */
+const formatDateDef = (dateDef: DateDef | undefined): string => {
+  if (!dateDef) return 'unknown';
+
+  // Fixed date: month and date specified
+  if ('month' in dateDef && 'date' in dateDef) {
+    return `${MONTH_NAMES[dateDef.month - 1]} ${dateDef.date}`;
+  }
+
+  // Fixed date with nthWeekInMonth
+  if ('month' in dateDef && 'nthWeekInMonth' in dateDef) {
+    const ordinal = ['1st', '2nd', '3rd', '4th', '5th'][dateDef.nthWeekInMonth! - 1] || `${dateDef.nthWeekInMonth}th`;
+    return `${ordinal} week of ${MONTH_NAMES[dateDef.month - 1]}`;
+  }
+
+  // Fixed date with lastDayOfWeekInMonth
+  if ('month' in dateDef && 'lastDayOfWeekInMonth' in dateDef) {
+    return `last week of ${MONTH_NAMES[dateDef.month - 1]}`;
+  }
+
+  // Movable feast (dateFn-based)
+  if ('dateFn' in dateDef) {
+    // Check if this dateFn maps to a fixed date
+    const fixedDate = FIXED_DATE_FN_MAP[dateDef.dateFn];
+    if (fixedDate) {
+      return `${MONTH_NAMES[fixedDate.month - 1]} ${fixedDate.date}`;
+    }
+
+    let result = dateDef.dateFn;
+    if ('addDay' in dateDef && dateDef.addDay) {
+      result += ` +${dateDef.addDay} days`;
+    }
+    if ('subtractDay' in dateDef && dateDef.subtractDay) {
+      result += ` -${dateDef.subtractDay} days`;
+    }
+    return result;
+  }
+
+  return 'unknown';
+};
+
+/**
+ * Get a sortable date value from a DateDef.
+ * Fixed dates return month * 100 + date (e.g., Jan 15 = 115, Dec 25 = 1225)
+ * Movable dates (dateFn-based) return a large number so they sort after fixed dates.
+ */
+const getDateSortValue = (dateDef: DateDef | undefined): number => {
+  if (!dateDef) return 99999;
+
+  // Fixed date: month and date specified
+  if ('month' in dateDef && 'date' in dateDef) {
+    return dateDef.month * 100 + dateDef.date;
+  }
+
+  // Fixed date with nthWeekInMonth (e.g., first Monday of September)
+  // Use day 1 of that week range as the sort value
+  if ('month' in dateDef && 'nthWeekInMonth' in dateDef) {
+    // nthWeekInMonth=1 means days 1-7, so use day 1 + (nthWeek-1)*7
+    const approximateDay = 1 + ((dateDef.nthWeekInMonth ?? 1) - 1) * 7;
+    return dateDef.month * 100 + approximateDay;
+  }
+
+  // Fixed date with lastDayOfWeekInMonth
+  if ('month' in dateDef && 'lastDayOfWeekInMonth' in dateDef) {
+    // Approximate: last week of month, so around day 22-28
+    return dateDef.month * 100 + 22;
+  }
+
+  // Movable feast (dateFn-based)
+  if ('dateFn' in dateDef) {
+    // Check if this dateFn maps to a fixed date
+    const fixedDate = FIXED_DATE_FN_MAP[dateDef.dateFn];
+    if (fixedDate) {
+      return fixedDate.month * 100 + fixedDate.date;
+    }
+
+    // True movable feasts (Easter-dependent) sort after all fixed dates
+    const addDay = 'addDay' in dateDef ? (dateDef.addDay ?? 0) : 0;
+    const subtractDay = 'subtractDay' in dateDef ? (dateDef.subtractDay ?? 0) : 0;
+    return 90000 + addDay - subtractDay;
+  }
+
+  return 99999;
+};
+
+type SortingIssue = {
+  key: string;
+  keyDate: string;
+  prevKey: string;
+  prevKeyDate: string;
+};
+
+/**
+ * Check if a calendar's inputs are sorted chronologically.
+ * Uses inheritance chain to resolve dates.
+ */
+const checkCalendarSorting = (CalendarClass: CalendarDefInstance): SortingIssue[] => {
+  const inputs = getCalendarInputs(CalendarClass);
+  const inputKeys = Object.keys(inputs);
+
+  if (inputKeys.length === 0) {
+    return [];
+  }
+
+  const chain = buildInheritanceChain(CalendarClass);
+  const issues: SortingIssue[] = [];
+
+  let prevSortValue = -Infinity;
+  let prevKey = '';
+  let prevDateDef: DateDef | undefined;
+
+  for (const key of inputKeys) {
+    const dateDef = findDateDefInChain(key, chain);
+    const sortValue = getDateSortValue(dateDef);
+
+    // Allow same date (multiple celebrations on same day)
+    if (sortValue < prevSortValue) {
+      issues.push({
+        key,
+        keyDate: formatDateDef(dateDef),
+        prevKey,
+        prevKeyDate: formatDateDef(prevDateDef),
+      });
+    }
+
+    prevSortValue = sortValue;
+    prevKey = key;
+    prevDateDef = dateDef;
+  }
+
+  return issues;
+};
+
+describe('Calendar Data Validation', () => {
+  describe('All celebration keys used in calendars must exist in en.ts names', () => {
+    const allCelebrationKeys = extractAllCelebrationLocaleKeys();
+    const enNamesKeys = Object.keys(locales.En.names ?? {});
+    const missingKeys = findMissingInArray(allCelebrationKeys, enNamesKeys);
+
+    it('should have all celebration names in en.ts', () => {
+      expect(missingKeys).toEqual([]);
+    });
+  });
+
+  describe('Calendar celebrations should be sorted chronologically', () => {
+    for (const [calendarName, CalendarDefClass] of Object.entries(calendarDefinitions)) {
+      const inputs = getCalendarInputs(CalendarDefClass);
+
+      // Skip calendars with no inputs
+      if (Object.keys(inputs).length === 0) {
+        continue;
+      }
+
+      it(`${calendarName} celebrations should be sorted chronologically`, () => {
+        expect(checkCalendarSorting(CalendarDefClass)).toEqual([]);
+      });
+    }
+  });
+});

--- a/rites/roman1969/__tests__/locale-data.test.ts
+++ b/rites/roman1969/__tests__/locale-data.test.ts
@@ -1,0 +1,392 @@
+import { merge } from 'ts-deepmerge';
+
+import { calendarDefinitions } from '../src/calendars';
+import { GeneralRoman } from '../src/calendars/general-roman';
+import { Martyrology } from '../src/catalog/martyrology';
+import { SEASONS } from '../src/constants/seasons';
+import { locales } from '../src/locales';
+import { RomcalConfig } from '../src/models/config';
+import { ProperOfTime } from '../src/proper-of-time/proper-of-time';
+import { Locale } from '../src/types/locale';
+import { toPackageName } from '../src/utils/string';
+
+import { getNestedPropertyNames } from './util/getNestedPropertyNames';
+import { isObjectPropsSortedAlphabetically } from './util/isObjectPropsSortedAlphabetically';
+
+/**
+ * Extract all season keys used by Proper of Time dynamically.
+ * Returns keys like 'advent.sunday', 'lent.weekday', etc.
+ */
+const extractProperOfTimeSeasonKeys = (): string[] => {
+  const seasonKeys = new Set<string>();
+  const devLocale = { id: 'dev' };
+
+  const config = new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale);
+  const properOfTime = new ProperOfTime(config);
+  properOfTime.buildAllDefinitions();
+
+  for (const def of Object.values(config.liturgicalDayDef)) {
+    if (def.i18nDef && def.i18nDef[0]?.startsWith('seasons:')) {
+      // Extract path after 'seasons:', e.g., 'advent.sunday'
+      const path = def.i18nDef[0].replace('seasons:', '');
+      seasonKeys.add(path);
+    }
+  }
+
+  // Also add season names (*.season)
+  SEASONS.forEach((s) => seasonKeys.add(`${s.toLowerCase()}.season`));
+
+  return Array.from(seasonKeys).sort();
+};
+
+/**
+ * Extract ordinal base numbers from en.ts (the reference locale).
+ * Returns ['1', '2', ...] without gender suffixes.
+ */
+const extractOrdinalKeys = (): string[] => {
+  const enOrdinals = locales.En.ordinals;
+  if (!enOrdinals) return [];
+
+  // Get unique base numbers (strip _masculine, _feminine suffixes)
+  const baseNumbers = new Set<string>();
+  for (const key of Object.keys(enOrdinals)) {
+    const baseNum = key.split('_')[0];
+    baseNumbers.add(baseNum);
+  }
+
+  return Array.from(baseNumbers).sort((a, b) => Number(a) - Number(b));
+};
+
+/**
+ * Extract keys from en.ts for a specific namespace.
+ */
+const extractKeysFromEnLocale = (namespace: keyof Locale): string[] => {
+  const obj = locales.En[namespace];
+  if (!obj || typeof obj !== 'object') return [];
+  return Object.keys(obj);
+};
+
+/**
+ * Meta locale keys that must exist in ALL locales.
+ * Derived dynamically from en.ts (reference locale) and Proper of Time.
+ */
+const REQUIRED_META_KEYS = {
+  colors: extractKeysFromEnLocale('colors'),
+  ranks: extractKeysFromEnLocale('ranks'),
+  cycles: extractKeysFromEnLocale('cycles'),
+  weekdays: extractKeysFromEnLocale('weekdays'),
+  months: extractKeysFromEnLocale('months'),
+  ordinals: extractOrdinalKeys(),
+  seasons: extractProperOfTimeSeasonKeys(),
+  periods: extractKeysFromEnLocale('periods'),
+};
+
+/**
+ * Map of locale IDs to their associated calendar names.
+ * A locale must have all keys required by these calendars.
+ */
+const localeToCalendarsMap: Record<string, string[]> = {
+  En: ['GeneralRoman', 'England', 'Scotland', 'Wales', 'Ireland', 'UnitedStates', 'Canada', 'Australia', 'NewZealand'],
+  EnGb: ['England', 'Scotland', 'Wales'],
+  EnIe: ['Ireland'],
+  PtBr: ['Brazil'],
+  Fr: [
+    'France',
+    'France_Angers',
+    'France_Coutances',
+    'France_Lyon',
+    'France_Paris',
+    'France_SaintDenis',
+    'France_Strasbourg',
+    'France_Toulouse',
+  ],
+  De: ['Germany', 'Austria', 'Switzerland'],
+  Es: [
+    'Spain',
+    'Mexico',
+    'Argentina',
+    'Chile',
+    'Bolivia',
+    'CostaRica',
+    'Guatemala',
+    'Panama',
+    'Paraguay',
+    'Peru',
+    'Uruguay',
+    'Venezuela',
+    'PuertoRico',
+  ],
+  It: ['Italy'],
+  Pl: ['Poland'],
+  Cs: ['CzechRepublic'],
+  Sk: ['Slovakia'],
+  La: ['GeneralRoman'],
+  Ta: ['India'],
+};
+
+/**
+ * Meta i18n keys required by all locales (derived from REQUIRED_META_KEYS).
+ * Used for building calendar locale key sets.
+ */
+const metaI18nKeys: string[] = [
+  ...REQUIRED_META_KEYS.colors.map((c) => `colors:${c}`),
+  ...REQUIRED_META_KEYS.ranks.map((r) => `ranks:${r}`),
+  ...REQUIRED_META_KEYS.cycles.map((c) => `cycles:${c}`),
+  ...REQUIRED_META_KEYS.weekdays.map((w) => `weekdays:${w}`),
+  ...REQUIRED_META_KEYS.months.map((m) => `months:${m}`),
+  ...REQUIRED_META_KEYS.seasons.map((s) => `seasons:${s}`),
+  ...REQUIRED_META_KEYS.periods.map((p) => `periods:${p}`),
+];
+
+/**
+ * Extract all locale keys (i18n keys) used across specified calendar definitions.
+ * Also includes customLocaleId values when celebrations define them.
+ */
+const extractLocaleKeysForCalendars = (calendarNames: string[]): Set<string> => {
+  const allLocaleKeys = new Set<string>(metaI18nKeys);
+  const devLocale = { id: 'dev' };
+
+  for (const calendarName of calendarNames) {
+    const CalendarDefClass = calendarDefinitions[calendarName];
+    if (!CalendarDefClass) continue;
+
+    const isGRC = CalendarDefClass.name === GeneralRoman.name;
+    const config = isGRC
+      ? new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale)
+      : new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale, CalendarDefClass);
+
+    config.calendarsDef.forEach((cal) => cal.buildAllDefinitions());
+
+    for (const def of Object.values(config.liturgicalDayDef)) {
+      // Add the i18nDef key
+      if (def.i18nDef && def.i18nDef[0]) {
+        allLocaleKeys.add(def.i18nDef[0]);
+      }
+
+      // Also check for customLocaleId in input definitions
+      for (const input of def.input) {
+        if (input.customLocaleId) {
+          allLocaleKeys.add(`names:${input.customLocaleId}`);
+        }
+      }
+    }
+  }
+
+  return allLocaleKeys;
+};
+
+/**
+ * Extract locale keys used across ALL calendar definitions (without martyrology keys).
+ * Used for checking required keys in en.ts.
+ */
+const extractAllLocaleKeysFromCalendars = (): Set<string> => {
+  const allCalendarNames = Object.keys(calendarDefinitions);
+  return extractLocaleKeysForCalendars(allCalendarNames);
+};
+
+/**
+ * Get namespace from a namespaced key (e.g., 'names:all_saints' -> 'names')
+ */
+const getNamespace = (key: string): string => key.split(':')[0];
+
+/**
+ * Remove namespace from a key (e.g., 'names:all_saints' -> 'all_saints')
+ */
+const removeNamespace = (key: string): string => key.split(':')[1] ?? key;
+
+/**
+ * Group keys by namespace.
+ */
+const groupKeysByNamespace = (keys: string[]): Record<string, Set<string>> => {
+  return keys.reduce<Record<string, Set<string>>>((acc, key) => {
+    const namespace = getNamespace(key);
+    if (!acc[namespace]) acc[namespace] = new Set();
+    acc[namespace].add(removeNamespace(key));
+    return acc;
+  }, {});
+};
+
+/**
+ * Find missing localized items by comparing computed keys against a locale object.
+ */
+const findMissingInLocale = (
+  computedKeys: string[],
+  locale: Locale,
+  options?: { reverse?: boolean; localeKeyNamesOnly?: boolean }
+): Record<string, string[]> => {
+  const groupedKeys = groupKeysByNamespace(computedKeys);
+  const result: Record<string, string[]> = {};
+
+  for (const [namespace, obj] of Object.entries(locale)) {
+    if (namespace === 'id') continue;
+    if (options?.localeKeyNamesOnly && namespace !== 'names') continue;
+    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) continue;
+
+    const localeProps = getNestedPropertyNames(obj as Record<string, unknown>);
+    const computedProps = groupedKeys[namespace] ?? new Set();
+
+    const missingItems = options?.reverse
+      ? localeProps.filter((item) => !computedProps.has(item))
+      : Array.from(computedProps).filter((item) => !localeProps.includes(item));
+
+    if (missingItems.length > 0) {
+      result[namespace] = missingItems;
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Merge a region locale with its base locale if applicable.
+ */
+const mergeLocaleWithBase = (localeKey: string): Locale => {
+  if (localeKey.length === 4 && locales[localeKey.slice(0, 2)]) {
+    return merge(locales[localeKey.slice(0, 2)], locales[localeKey]) as Locale;
+  }
+  return locales[localeKey];
+};
+
+/**
+ * Format locale key for display (e.g., 'En' -> 'English locale (en.ts)')
+ */
+const formatLocaleKey = (localeKey: string): string => {
+  return `${toPackageName(localeKey)}.ts`;
+};
+
+/**
+ * Check if a locale has a nested key.
+ * e.g., hasNestedKey(locale, 'seasons', 'advent.season') checks locale.seasons.advent.season
+ */
+const hasNestedKey = (locale: Locale, namespace: keyof Locale, path: string): boolean => {
+  const obj = locale[namespace];
+  if (!obj || typeof obj !== 'object') return false;
+
+  const parts = path.split('.');
+  let current: unknown = obj;
+
+  for (const part of parts) {
+    if (current === null || typeof current !== 'object') return false;
+    current = (current as Record<string, unknown>)[part];
+  }
+
+  return current !== undefined;
+};
+
+/**
+ * Check if a locale has an ordinal for a given number.
+ * Ordinals can be: '1', '1_masculine', '1_feminine', etc.
+ */
+const hasOrdinalForNumber = (locale: Locale, num: string): boolean => {
+  const ordinals = locale.ordinals;
+  if (!ordinals || typeof ordinals !== 'object') return false;
+
+  // Check for exact match or gendered forms
+  const keys = Object.keys(ordinals);
+  return keys.some((key) => key === num || key.startsWith(`${num}_`));
+};
+
+/**
+ * Find missing meta keys in a locale for a specific namespace.
+ */
+const findMissingMetaKeys = (locale: Locale, namespace: keyof typeof REQUIRED_META_KEYS): string[] => {
+  const requiredKeys = REQUIRED_META_KEYS[namespace];
+  const missing: string[] = [];
+
+  for (const key of requiredKeys) {
+    // Special handling for ordinals - they can have gendered forms
+    if (namespace === 'ordinals') {
+      if (!hasOrdinalForNumber(locale, key)) {
+        missing.push(key);
+      }
+    } else if (!hasNestedKey(locale, namespace as keyof Locale, key)) {
+      missing.push(key);
+    }
+  }
+
+  return missing;
+};
+
+describe('Locale Data Validation', () => {
+  describe('English locale (en.ts) must have all required keys', () => {
+    const allLocaleKeys = extractAllLocaleKeysFromCalendars();
+    const enLocale = locales.En;
+    const missingKeys = findMissingInLocale(Array.from(allLocaleKeys), enLocale);
+
+    it('should have all required name keys', () => {
+      expect(missingKeys.names ?? []).toEqual([]);
+    });
+
+    it('should have all required color keys', () => {
+      expect(missingKeys.colors ?? []).toEqual([]);
+    });
+
+    it('should have all required rank keys', () => {
+      expect(missingKeys.ranks ?? []).toEqual([]);
+    });
+
+    it('should have all required season keys', () => {
+      expect(missingKeys.seasons ?? []).toEqual([]);
+    });
+  });
+
+  describe('Each locale names must be sorted alphabetically', () => {
+    for (const [localeKey, locale] of Object.entries(locales)) {
+      it(`${formatLocaleKey(localeKey)} names should be sorted alphabetically`, () => {
+        if (!locale.names) {
+          expect(true).toBe(true);
+          return;
+        }
+        expect(isObjectPropsSortedAlphabetically(locale.names)).toBe(true);
+      });
+    }
+  });
+
+  describe('Each locale must have all keys for GRC and associated country calendars', () => {
+    const grcKeys = extractLocaleKeysForCalendars(['GeneralRoman']);
+
+    for (const [localeKey, calendarNames] of Object.entries(localeToCalendarsMap)) {
+      const locale = locales[localeKey];
+      if (!locale) continue;
+
+      it(`${formatLocaleKey(localeKey)} should have all GRC keys`, () => {
+        const mergedLocale = mergeLocaleWithBase(localeKey);
+        const missingKeys = findMissingInLocale(Array.from(grcKeys), mergedLocale);
+        expect(missingKeys.names ?? []).toEqual([]);
+      });
+
+      it(`${formatLocaleKey(localeKey)} should have all keys for associated calendars (${calendarNames.join(', ')})`, () => {
+        const calendarKeys = extractLocaleKeysForCalendars(calendarNames);
+        const mergedLocale = mergeLocaleWithBase(localeKey);
+        const missingKeys = findMissingInLocale(Array.from(calendarKeys), mergedLocale);
+        expect(missingKeys.names ?? []).toEqual([]);
+      });
+    }
+  });
+
+  describe('All locales must have required meta keys', () => {
+    const metaNamespaces: (keyof typeof REQUIRED_META_KEYS)[] = [
+      'colors',
+      'ranks',
+      'cycles',
+      'weekdays',
+      'months',
+      'ordinals',
+      'seasons',
+      'periods',
+    ];
+
+    for (const localeKey of Object.keys(locales)) {
+      describe(`${formatLocaleKey(localeKey)}`, () => {
+        const mergedLocale = mergeLocaleWithBase(localeKey);
+
+        for (const namespace of metaNamespaces) {
+          it(`should have all required ${namespace} keys`, () => {
+            const missingKeys = findMissingMetaKeys(mergedLocale, namespace);
+            expect(missingKeys).toEqual([]);
+          });
+        }
+      });
+    }
+  });
+});

--- a/rites/roman1969/__tests__/martyrology-data.test.ts
+++ b/rites/roman1969/__tests__/martyrology-data.test.ts
@@ -1,0 +1,79 @@
+import { calendarDefinitions } from '../src/calendars';
+import { GeneralRoman } from '../src/calendars/general-roman';
+import { Martyrology } from '../src/catalog/martyrology';
+import { locales } from '../src/locales';
+import { RomcalConfig } from '../src/models/config';
+
+import { findMissingInArray } from './util/findMissingInArray';
+import { isObjectPropsSortedAlphabetically } from './util/isObjectPropsSortedAlphabetically';
+
+/**
+ * Extract all martyrology keys used across all calendar definitions.
+ * This includes:
+ * - Keys from the `martyrology` array property (string or object with `id`)
+ * - The celebration key itself if it exists in the martyrology catalog
+ */
+const extractAllMartyrologyKeys = (): Set<string> => {
+  const allMartyrologyKeys = new Set<string>();
+  const catalogKeys = new Set(Object.keys(Martyrology.catalog));
+  const devLocale = { id: 'dev' };
+
+  for (const CalendarDefClass of Object.values(calendarDefinitions)) {
+    // Create a config to build the calendar definitions
+    const isGRC = CalendarDefClass.name === GeneralRoman.name;
+    const config = isGRC
+      ? new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale)
+      : new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale, CalendarDefClass);
+
+    // Build definitions
+    config.calendarsDef.forEach((cal) => cal.buildAllDefinitions());
+
+    // Extract martyrology keys from all definitions
+    for (const def of Object.values(config.liturgicalDayDef)) {
+      // Get martyrology keys from the input definitions
+      for (const input of def.input) {
+        if (input.martyrology) {
+          for (const m of input.martyrology) {
+            const key = typeof m === 'string' ? m : m.id;
+            allMartyrologyKeys.add(key);
+          }
+        }
+      }
+
+      // If the celebration key itself exists in the catalog, it's also considered "used"
+      if (catalogKeys.has(def.id)) {
+        allMartyrologyKeys.add(def.id);
+      }
+    }
+  }
+
+  return allMartyrologyKeys;
+};
+
+describe('Martyrology Data Validation', () => {
+  describe('All martyrology keys used in calendars must exist in Martyrology.catalog', () => {
+    const allUsedKeys = extractAllMartyrologyKeys();
+    const catalogKeys = Object.keys(Martyrology.catalog);
+    const missingKeys = findMissingInArray(allUsedKeys, catalogKeys);
+
+    it('should have no missing martyrology entries', () => {
+      expect(missingKeys).toEqual([]);
+    });
+  });
+
+  describe('All martyrology entries referenced in LiturgicalDays must have translations', () => {
+    const allUsedKeys = extractAllMartyrologyKeys();
+    const enNamesKeys = Object.keys(locales.En.names ?? {});
+    const missingTranslations = findMissingInArray(allUsedKeys, enNamesKeys);
+
+    it('should have translations in en.ts for all used martyrology keys', () => {
+      expect(missingTranslations).toEqual([]);
+    });
+  });
+
+  describe('Martyrology.catalog keys must be sorted alphabetically', () => {
+    it('should have alphabetically sorted keys', () => {
+      expect(isObjectPropsSortedAlphabetically(Martyrology.catalog)).toBe(true);
+    });
+  });
+});

--- a/rites/roman1969/__tests__/proper-of-time.test.ts
+++ b/rites/roman1969/__tests__/proper-of-time.test.ts
@@ -1,0 +1,163 @@
+import { Martyrology } from '../src/catalog/martyrology';
+import { locales } from '../src/locales';
+import { RomcalConfig } from '../src/models/config';
+import { ProperOfTime } from '../src/proper-of-time/proper-of-time';
+import { Locale } from '../src/types/locale';
+
+/**
+ * Extract all i18n keys used by the Proper of Time.
+ * These come from the i18nDef property of each liturgical day definition.
+ */
+const extractProperOfTimeI18nKeys = (): Set<string> => {
+  const allKeys = new Set<string>();
+  const devLocale = { id: 'dev' };
+
+  // Create a minimal config to build proper of time definitions
+  const config = new RomcalConfig({ scope: 'liturgical' }, Martyrology.catalog, devLocale);
+
+  // Build the proper of time definitions
+  const properOfTime = new ProperOfTime(config);
+  properOfTime.buildAllDefinitions();
+
+  // Extract i18nDef from all definitions
+  for (const def of Object.values(config.liturgicalDayDef)) {
+    if (def.i18nDef && def.i18nDef[0]) {
+      // The key is the first element, e.g., 'seasons:advent.sunday'
+      allKeys.add(def.i18nDef[0]);
+    }
+  }
+
+  return allKeys;
+};
+
+/**
+ * Parse a namespaced key and get the lookup path.
+ * e.g., 'seasons:advent.sunday' -> { namespace: 'seasons', path: ['advent', 'sunday'] }
+ */
+const parseI18nKey = (key: string): { namespace: string; path: string[] } | null => {
+  const [namespace, rest] = key.split(':');
+  if (!namespace || !rest) return null;
+  return {
+    namespace,
+    path: rest.split('.'),
+  };
+};
+
+/**
+ * Check if a locale has a key at the given path.
+ */
+const hasLocaleKey = (locale: Locale, namespace: string, path: string[]): boolean => {
+  const namespaceObj = locale[namespace as keyof Locale];
+  if (!namespaceObj || typeof namespaceObj !== 'object') return false;
+
+  let current: unknown = namespaceObj;
+  for (const segment of path) {
+    if (current === null || typeof current !== 'object') return false;
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current !== undefined;
+};
+
+/**
+ * Find missing i18n keys in a locale.
+ */
+const findMissingI18nKeys = (keys: Set<string>, locale: Locale): string[] => {
+  const missing: string[] = [];
+
+  for (const key of keys) {
+    const parsed = parseI18nKey(key);
+    if (!parsed) continue;
+
+    if (!hasLocaleKey(locale, parsed.namespace, parsed.path)) {
+      missing.push(key);
+    }
+  }
+
+  return missing.sort();
+};
+
+describe('Proper of Time Data Validation', () => {
+  const allKeys = extractProperOfTimeI18nKeys();
+
+  describe('All i18n keys used by Proper of Time must exist in en.ts', () => {
+    const enLocale = locales.En;
+    const missingKeys = findMissingI18nKeys(allKeys, enLocale);
+
+    it('should have all required season keys', () => {
+      const seasonKeys = missingKeys.filter((k) => k.startsWith('seasons:'));
+      expect(seasonKeys).toEqual([]);
+    });
+
+    it('should have all required names keys', () => {
+      const namesKeys = missingKeys.filter((k) => k.startsWith('names:'));
+      expect(namesKeys).toEqual([]);
+    });
+
+    it('should have no missing i18n keys overall', () => {
+      expect(missingKeys).toEqual([]);
+    });
+  });
+
+  // Note: Season keys for all locales are checked in locale-data.test.ts
+  // under "All locales must have required meta keys" -> seasons
+
+  describe('Expected season keys are present in en.ts', () => {
+    const expectedSeasonKeys = [
+      'seasons:advent.sunday',
+      'seasons:advent.weekday',
+      'seasons:advent.privileged_weekday',
+      'seasons:christmas_time.octave',
+      'seasons:christmas_time.second_sunday_after_christmas',
+      'seasons:christmas_time.before_epiphany',
+      'seasons:christmas_time.after_epiphany',
+      'seasons:lent.day_after_ash_wed',
+      'seasons:lent.sunday',
+      'seasons:lent.weekday',
+      'seasons:lent.holy_week_day',
+      'seasons:easter_time.octave',
+      'seasons:easter_time.sunday',
+      'seasons:easter_time.weekday',
+      'seasons:ordinary_time.sunday',
+      'seasons:ordinary_time.weekday',
+    ];
+
+    for (const key of expectedSeasonKeys) {
+      it(`should have key: ${key}`, () => {
+        const parsed = parseI18nKey(key);
+        expect(parsed).not.toBeNull();
+        expect(hasLocaleKey(locales.En, parsed!.namespace, parsed!.path)).toBe(true);
+      });
+    }
+  });
+
+  describe('Expected names keys from Proper of Time are present in en.ts', () => {
+    const expectedNamesKeys = [
+      'nativity_of_the_lord',
+      'holy_family_of_jesus_mary_and_joseph',
+      'mary_mother_of_god',
+      'epiphany_of_the_lord',
+      'baptism_of_the_lord',
+      'ash_wednesday',
+      'palm_sunday_of_the_passion_of_the_lord',
+      'thursday_of_the_lords_supper',
+      'friday_of_the_passion_of_the_lord',
+      'holy_saturday',
+      'easter_sunday',
+      'divine_mercy_sunday',
+      'ascension_of_the_lord',
+      'pentecost_sunday',
+      'most_holy_trinity',
+      'most_holy_body_and_blood_of_christ',
+      'most_sacred_heart_of_jesus',
+      'sunday_of_the_word_of_god',
+      'our_lord_jesus_christ_king_of_the_universe',
+    ];
+
+    for (const key of expectedNamesKeys) {
+      it(`should have names:${key}`, () => {
+        expect(locales.En.names?.[key]).toBeDefined();
+      });
+    }
+  });
+});

--- a/rites/roman1969/__tests__/util/findMissingInArray.test.ts
+++ b/rites/roman1969/__tests__/util/findMissingInArray.test.ts
@@ -1,0 +1,39 @@
+import { findMissingInArray } from './findMissingInArray';
+
+describe('findMissingInArray', () => {
+  it('should find items in first array not in second', () => {
+    const arr1 = ['a', 'b', 'c', 'd'];
+    const arr2 = ['a', 'c'];
+    expect(findMissingInArray(arr1, arr2)).toEqual(['b', 'd']);
+  });
+
+  it('should work with Sets', () => {
+    const set1 = new Set(['a', 'b', 'c']);
+    const set2 = new Set(['a']);
+    expect(findMissingInArray(set1, set2)).toEqual(['b', 'c']);
+  });
+
+  it('should return empty array when all items exist', () => {
+    const arr1 = ['a', 'b'];
+    const arr2 = ['a', 'b', 'c'];
+    expect(findMissingInArray(arr1, arr2)).toEqual([]);
+  });
+
+  it('should return all items when second array is empty', () => {
+    const arr1 = ['a', 'b'];
+    const arr2: string[] = [];
+    expect(findMissingInArray(arr1, arr2)).toEqual(['a', 'b']);
+  });
+
+  it('should return empty array when first array is empty', () => {
+    const arr1: string[] = [];
+    const arr2 = ['a', 'b'];
+    expect(findMissingInArray(arr1, arr2)).toEqual([]);
+  });
+
+  it('should handle mixed array and Set inputs', () => {
+    const arr1 = ['a', 'b', 'c'];
+    const set2 = new Set(['b']);
+    expect(findMissingInArray(arr1, set2)).toEqual(['a', 'c']);
+  });
+});

--- a/rites/roman1969/__tests__/util/findMissingInArray.ts
+++ b/rites/roman1969/__tests__/util/findMissingInArray.ts
@@ -1,0 +1,10 @@
+/**
+ * Find items that are in the first array/set but not in the second.
+ * @param arr1 - The source array or set
+ * @param arr2 - The array or set to compare against
+ * @returns Array of items in arr1 that are not in arr2
+ */
+export const findMissingInArray = (arr1: string[] | Set<string>, arr2: string[] | Set<string>): string[] => {
+  const set2 = new Set(arr2);
+  return Array.from(arr1).filter((item) => !set2.has(item));
+};

--- a/rites/roman1969/__tests__/util/getNestedPropertyNames.test.ts
+++ b/rites/roman1969/__tests__/util/getNestedPropertyNames.test.ts
@@ -1,0 +1,59 @@
+import { getNestedPropertyNames } from './getNestedPropertyNames';
+
+describe('getNestedPropertyNames', () => {
+  it('should return flat property names', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(getNestedPropertyNames(obj)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should return nested property names with dot notation', () => {
+    const obj = {
+      a: { b: 1, c: 2 },
+      d: 3,
+    };
+    expect(getNestedPropertyNames(obj)).toEqual(['a.b', 'a.c', 'd']);
+  });
+
+  it('should handle deeply nested objects', () => {
+    const obj = {
+      level1: {
+        level2: {
+          level3: 'value',
+        },
+      },
+    };
+    expect(getNestedPropertyNames(obj)).toEqual(['level1.level2.level3']);
+  });
+
+  it('should return empty array for empty object', () => {
+    expect(getNestedPropertyNames({})).toEqual([]);
+  });
+
+  it('should handle mixed nested and flat properties', () => {
+    const obj = {
+      flat: 'value',
+      nested: {
+        a: 1,
+        b: 2,
+      },
+      another_flat: 'value2',
+    };
+    expect(getNestedPropertyNames(obj)).toEqual(['flat', 'nested.a', 'nested.b', 'another_flat']);
+  });
+
+  it('should handle arrays as leaf values (not nested)', () => {
+    const obj = {
+      items: [1, 2, 3],
+      name: 'test',
+    };
+    expect(getNestedPropertyNames(obj)).toEqual(['items', 'name']);
+  });
+
+  it('should handle null values as leaf values', () => {
+    const obj = {
+      nullable: null,
+      name: 'test',
+    };
+    expect(getNestedPropertyNames(obj)).toEqual(['nullable', 'name']);
+  });
+});

--- a/rites/roman1969/__tests__/util/getNestedPropertyNames.ts
+++ b/rites/roman1969/__tests__/util/getNestedPropertyNames.ts
@@ -1,0 +1,18 @@
+/**
+ * Check if a value is a plain object (not null, not array).
+ */
+const isObject = (obj: unknown): obj is Record<string, unknown> =>
+  typeof obj === 'object' && obj !== null && !Array.isArray(obj);
+
+/**
+ * Get all nested property names from an object using dot notation.
+ * e.g., { a: { b: 1, c: 2 } } -> ['a.b', 'a.c']
+ * @param obj - The object to extract property names from
+ * @param parentKey - The parent key for recursion (internal use)
+ * @returns Array of nested property names in dot notation
+ */
+export const getNestedPropertyNames = (obj: Record<string, unknown>, parentKey = ''): string[] =>
+  Object.entries(obj).flatMap(([key, value]) => {
+    const path = parentKey ? `${parentKey}.${key}` : key;
+    return isObject(value) ? getNestedPropertyNames(value, path) : path;
+  });

--- a/rites/roman1969/__tests__/util/isObjectPropsSortedAlphabetically.test.ts
+++ b/rites/roman1969/__tests__/util/isObjectPropsSortedAlphabetically.test.ts
@@ -1,0 +1,65 @@
+import { isObjectPropsSortedAlphabetically, findUnsortedKeys } from './isObjectPropsSortedAlphabetically';
+
+describe('isObjectPropsSortedAlphabetically', () => {
+  it('should return true for sorted keys', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(isObjectPropsSortedAlphabetically(obj)).toBe(true);
+  });
+
+  it('should return false for unsorted keys', () => {
+    const obj = { c: 3, a: 1, b: 2 };
+    expect(isObjectPropsSortedAlphabetically(obj)).toBe(false);
+  });
+
+  it('should return true for empty object', () => {
+    expect(isObjectPropsSortedAlphabetically({})).toBe(true);
+  });
+
+  it('should return true for single key', () => {
+    expect(isObjectPropsSortedAlphabetically({ a: 1 })).toBe(true);
+  });
+
+  it('should handle underscore-prefixed keys correctly', () => {
+    const sorted = { _private: 1, alpha: 2, beta: 3 };
+    expect(isObjectPropsSortedAlphabetically(sorted)).toBe(true);
+  });
+
+  it('should handle snake_case keys correctly', () => {
+    const sorted = { all_saints: 1, christmas: 2, easter_sunday: 3 };
+    expect(isObjectPropsSortedAlphabetically(sorted)).toBe(true);
+
+    const unsorted = { christmas: 2, all_saints: 1, easter_sunday: 3 };
+    expect(isObjectPropsSortedAlphabetically(unsorted)).toBe(false);
+  });
+});
+
+describe('findUnsortedKeys', () => {
+  it('should return empty array for sorted keys', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(findUnsortedKeys(obj)).toEqual([]);
+  });
+
+  it('should identify unsorted key pairs', () => {
+    const obj = { b: 2, a: 1, c: 3 };
+    const result = findUnsortedKeys(obj);
+
+    expect(result).toHaveLength(1);
+    // 'a' should come before 'b' alphabetically
+    expect(result[0]).toEqual({ key: 'a', shouldComeBefore: 'b' });
+  });
+
+  it('should identify multiple unsorted pairs', () => {
+    const obj = { d: 4, c: 3, b: 2, a: 1 };
+    const result = findUnsortedKeys(obj);
+
+    expect(result).toHaveLength(3);
+  });
+
+  it('should return empty array for empty object', () => {
+    expect(findUnsortedKeys({})).toEqual([]);
+  });
+
+  it('should return empty array for single key', () => {
+    expect(findUnsortedKeys({ a: 1 })).toEqual([]);
+  });
+});

--- a/rites/roman1969/__tests__/util/isObjectPropsSortedAlphabetically.ts
+++ b/rites/roman1969/__tests__/util/isObjectPropsSortedAlphabetically.ts
@@ -1,0 +1,53 @@
+/**
+ * Locale-insensitive string comparison for consistent sorting across environments.
+ * Uses English locale with base sensitivity to ensure consistent ordering.
+ */
+const compareKeys = (a: string, b: string): number => a.localeCompare(b, 'en', { sensitivity: 'base' });
+
+/**
+ * Check if object properties are sorted alphabetically.
+ *
+ * @param obj - The object to check
+ * @returns true if the properties are sorted alphabetically, false otherwise
+ *
+ * @remarks
+ * **Important limitation**: JavaScript engines (V8, SpiderMonkey) automatically
+ * reorder integer-like keys before string keys. For example:
+ * ```ts
+ * const obj = { '10': 'x', '2': 'y', 'foo': 'z' };
+ * Object.keys(obj); // ['2', '10', 'foo'] — integers sorted numerically first!
+ * ```
+ * This function assumes all keys are non-integer string identifiers (e.g., snake_case).
+ * It will not correctly detect sorting issues when integer-like keys are present.
+ */
+export const isObjectPropsSortedAlphabetically = (obj: Record<string, unknown>): boolean => {
+  const props = Object.keys(obj);
+  const sortedProps = [...props].sort(compareKeys);
+  return props.every((prop, index) => prop === sortedProps[index]);
+};
+
+/**
+ * Find keys that are out of alphabetical order.
+ *
+ * @param obj - The object to check
+ * @returns Array of objects describing out-of-order keys
+ *
+ * @remarks
+ * See {@link isObjectPropsSortedAlphabetically} for limitations regarding integer-like keys.
+ */
+export const findUnsortedKeys = (obj: Record<string, unknown>): { key: string; shouldComeBefore: string }[] => {
+  const keys = Object.keys(obj);
+  const result: { key: string; shouldComeBefore: string }[] = [];
+
+  for (let i = 1; i < keys.length; i++) {
+    if (compareKeys(keys[i - 1], keys[i]) > 0) {
+      // keys[i-1] is alphabetically AFTER keys[i], so keys[i] should come first
+      result.push({
+        key: keys[i],
+        shouldComeBefore: keys[i - 1],
+      });
+    }
+  }
+
+  return result;
+};

--- a/rites/roman1969/build/data-checks.ts
+++ b/rites/roman1969/build/data-checks.ts
@@ -2,18 +2,21 @@
  * This script is used to check the consistency of the data files.
  *
  * It reports errors when:
- *   - [1] There are useless martyrology items.
- *   - [2] There are missing martyrology items.
- *   - [3] There are missing localized 'en' items (in the Romcal project,
+ *   - [1] There are missing martyrology items.
+ *   - [2] There are missing localized 'en' items (in the Romcal project,
  *         English takes precedence as the primary language, so all content
  *         should be localized in English).
- *   - [4] There are useless localized items.
- *   - [5] The martyrology items are not sorted alphabetically.
- *   - [6] The localized name items are not sorted alphabetically.
+ *   - [3] There are useless localized items.
+ *   - [4] The martyrology items are not sorted alphabetically.
+ *   - [5] The localized name items are not sorted alphabetically.
  *
  * It issues warnings when:
- *   - [7] There are missing localized items for the Proper of Time
+ *   - [6] There are missing localized items for the Proper of Time
  *         and the General Roman calendar.
+ *
+ * It provides informational messages when:
+ *   - [7] There are martyrology items not yet used by any calendar
+ *         (valid entries reserved for future use).
  *
  * Note: in the codebase below, all *ComputedKeys variables are the keys
  * that are computed by Romcal (from the inputs and definitions),
@@ -255,19 +258,13 @@ for (let i = 0; i < allCalendars.length; i += 1) {
 }
 
 /**
- * [1] If there are useless martyrology items.
- */
-const uselessMartyrologyKeys = findMissingInArray(Object.keys(Martyrology.catalog), allMartyrologyKeys);
-logIf(LogLevel.ERROR, 'Useless martyrology items:', uselessMartyrologyKeys);
-
-/**
- * [2] If there are missing martyrology items.
+ * [1] If there are missing martyrology items.
  */
 const missingMartyrologyKeys = findMissingInArray(allMartyrologyKeys, Object.keys(Martyrology.catalog));
 logIf(LogLevel.ERROR, 'Missing martyrology items:', missingMartyrologyKeys);
 
 /**
- * [3] If there are missing localized 'en' items.
+ * [2] If there are missing localized 'en' items.
  */
 const missingEnLocaleKeys = findMissingLocalizedItems('En', allLocalesKeys);
 logIf(LogLevel.ERROR, `Missing localized '${u('en')}' items:`, missingEnLocaleKeys);
@@ -275,7 +272,7 @@ logIf(LogLevel.ERROR, `Missing localized '${u('en')}' items:`, missingEnLocaleKe
 Object.keys(Martyrology.catalog).forEach((key) => allLocalesKeys.add(`names:${key}`));
 
 /**
- * [4] If there are useless localized name items.
+ * [3] If there are useless localized name items.
  */
 Object.keys(locales).forEach((localeKey) => {
   const uselessLocalizedKeys = findMissingLocalizedItems(localeKey, allLocalesKeys, {
@@ -286,13 +283,13 @@ Object.keys(locales).forEach((localeKey) => {
 });
 
 /**
- * [5] If the martyrology items are not sorted alphabetically.
+ * [4] If the martyrology items are not sorted alphabetically.
  */
 const areNotSortedMartyrologyKeys = isObjectPropsSortedAlphabetically(Martyrology.catalog);
 logIf(LogLevel.ERROR, 'Martyrology keys are not sorted alphabetically.', areNotSortedMartyrologyKeys);
 
 /**
- * [6] If the localized name items are not sorted alphabetically.
+ * [5] If the localized name items are not sorted alphabetically.
  */
 Object.values(locales).forEach((locale) => {
   const areNotSortedNames = isObjectPropsSortedAlphabetically(locale.names ?? {});
@@ -300,7 +297,7 @@ Object.values(locales).forEach((locale) => {
 });
 
 /**
- * [7] If there are missing localized items for the Proper of Time and the General Roman calendar.
+ * [6] If there are missing localized items for the Proper of Time and the General Roman calendar.
  */
 Object.keys(locales)
   .filter((l) => l !== 'En') // Ignore English locale has it is already checked before
@@ -314,6 +311,16 @@ Object.keys(locales)
       missingLocaleNames
     );
   });
+
+/**
+ * [7] If there are martyrology items not yet used by any calendar.
+ */
+const unusedMartyrologyKeys = findMissingInArray(Object.keys(Martyrology.catalog), allMartyrologyKeys);
+logIf(
+  LogLevel.INFO,
+  'Martyrology items not yet used by any calendar (reserved for future use):',
+  unusedMartyrologyKeys
+);
 
 /**
  * End of checks.

--- a/rites/roman1969/build/sort-data.ts
+++ b/rites/roman1969/build/sort-data.ts
@@ -1,0 +1,211 @@
+/**
+ * Utility script to check and fix alphabetical sorting of data files.
+ *
+ * Usage:
+ *   npx ts-node build/sort-data.ts check   - Check for sorting issues
+ *   npx ts-node build/sort-data.ts fix     - Fix sorting issues in place
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import chalk from 'chalk';
+
+const martyrologyPath = path.resolve(__dirname, '../src/catalog/martyrology.ts');
+const localesDir = path.resolve(__dirname, '../src/locales');
+
+type SortIssue = {
+  file: string;
+  key: string;
+  shouldComeBefore: string;
+};
+
+/**
+ * Find keys that are out of alphabetical order in an object.
+ */
+const findUnsortedKeys = (keys: string[]): { key: string; shouldComeBefore: string }[] => {
+  const result: { key: string; shouldComeBefore: string }[] = [];
+
+  for (let i = 1; i < keys.length; i++) {
+    if (keys[i - 1].localeCompare(keys[i]) > 0) {
+      // keys[i-1] is alphabetically AFTER keys[i], so keys[i] should come first
+      result.push({
+        key: keys[i],
+        shouldComeBefore: keys[i - 1],
+      });
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Check martyrology.ts for sorting issues.
+ */
+const checkMartyrology = (): SortIssue[] => {
+  const content = fs.readFileSync(martyrologyPath, 'utf-8');
+
+  // Extract keys from the catalog object
+  const catalogMatch = /static\s+catalog\s*[:=]\s*\{/.exec(content);
+  if (!catalogMatch) return [];
+
+  const startIndex = catalogMatch.index + catalogMatch[0].length;
+  let braceCount = 1;
+  let i = startIndex;
+
+  while (braceCount > 0 && i < content.length) {
+    if (content[i] === '{') braceCount++;
+    if (content[i] === '}') braceCount--;
+    i++;
+  }
+
+  const objectContent = content.slice(startIndex, i - 1);
+
+  // Extract keys
+  const keys: string[] = [];
+  let depth = 0;
+  let lineStart = 0;
+
+  for (let j = 0; j <= objectContent.length; j++) {
+    const char = objectContent[j];
+
+    if (char === '\n' || j === objectContent.length) {
+      if (depth === 0) {
+        const line = objectContent.slice(lineStart, j);
+        const keyMatch = /^\s*['"]?([a-z0-9_]+)['"]?\s*:/.exec(line);
+        if (keyMatch) {
+          keys.push(keyMatch[1]);
+        }
+      }
+      lineStart = j + 1;
+    }
+
+    if (char === '{') depth++;
+    if (char === '}') depth--;
+  }
+
+  const unsorted = findUnsortedKeys(keys);
+  return unsorted.map((u) => ({
+    file: 'src/catalog/martyrology.ts',
+    ...u,
+  }));
+};
+
+/**
+ * Check locale files for sorting issues in the names object.
+ */
+const checkLocales = (): SortIssue[] => {
+  const issues: SortIssue[] = [];
+  const files = fs.readdirSync(localesDir).filter((f) => f.endsWith('.ts') && f !== 'index.ts');
+
+  for (const file of files) {
+    const filePath = path.join(localesDir, file);
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Find names object
+    const namesMatch = /names\s*[:=]\s*\{/.exec(content);
+    if (!namesMatch) continue;
+
+    const startIndex = namesMatch.index + namesMatch[0].length;
+    let braceCount = 1;
+    let i = startIndex;
+
+    while (braceCount > 0 && i < content.length) {
+      if (content[i] === '{') braceCount++;
+      if (content[i] === '}') braceCount--;
+      i++;
+    }
+
+    const objectContent = content.slice(startIndex, i - 1);
+
+    // Extract keys
+    const keys: string[] = [];
+    let depth = 0;
+    let lineStart = 0;
+
+    for (let j = 0; j <= objectContent.length; j++) {
+      const char = objectContent[j];
+
+      if (char === '\n' || j === objectContent.length) {
+        if (depth === 0) {
+          const line = objectContent.slice(lineStart, j);
+          const keyMatch = /^\s*['"]?([a-z0-9_]+)['"]?\s*:/.exec(line);
+          if (keyMatch) {
+            keys.push(keyMatch[1]);
+          }
+        }
+        lineStart = j + 1;
+      }
+
+      if (char === '{') depth++;
+      if (char === '}') depth--;
+    }
+
+    const unsorted = findUnsortedKeys(keys);
+    issues.push(
+      ...unsorted.map((u) => ({
+        file: `src/locales/${file}`,
+        ...u,
+      }))
+    );
+  }
+
+  return issues;
+};
+
+/**
+ * Main entry point.
+ */
+const main = (): void => {
+  const mode = process.argv[2];
+
+  if (mode !== 'check' && mode !== 'fix') {
+    console.error('Usage: npx ts-node build/sort-data.ts [check|fix]');
+    process.exit(1);
+  }
+
+  if (mode === 'check') {
+    const martyrologyIssues = checkMartyrology();
+    const localeIssues = checkLocales();
+    const allIssues = [...martyrologyIssues, ...localeIssues];
+
+    if (allIssues.length === 0) {
+      console.log(chalk.green('All data files are sorted correctly.'));
+      process.exit(0);
+    }
+
+    console.error(chalk.red(`Found ${allIssues.length} sorting issue(s):\n`));
+
+    for (const issue of allIssues) {
+      console.error(
+        chalk.yellow(`  ${issue.file}:`),
+        `"${chalk.bold(issue.key)}" should come before "${chalk.bold(issue.shouldComeBefore)}"`
+      );
+    }
+
+    console.error(chalk.cyan('\nRun "npm run sort-data:fix" to fix these issues automatically.'));
+    process.exit(1);
+  }
+
+  if (mode === 'fix') {
+    console.log('Sorting data files...\n');
+
+    // For now, just report that fixing would require more complex file manipulation
+    // A proper fix would need to parse and rewrite the TypeScript files
+    console.log(chalk.yellow('Note: Automatic fixing of TypeScript files is complex.'));
+    console.log(chalk.yellow('Please manually sort the keys in the following files:'));
+
+    const martyrologyIssues = checkMartyrology();
+    const localeIssues = checkLocales();
+    const allIssues = [...martyrologyIssues, ...localeIssues];
+
+    const files = new Set(allIssues.map((i) => i.file));
+    for (const file of files) {
+      console.log(chalk.cyan(`  - ${file}`));
+    }
+
+    console.log(chalk.yellow('\nTip: Sort the object keys alphabetically (a-z).'));
+  }
+};
+
+main();

--- a/rites/roman1969/package.json
+++ b/rites/roman1969/package.json
@@ -21,6 +21,8 @@
     "prepare": "husky",
     "prettier": "prettier -c .",
     "prettier:fix": "prettier -w .",
+    "sort-data:check": "tsx build/sort-data.ts check",
+    "sort-data:fix": "tsx build/sort-data.ts fix",
     "test": "TZ=UTC jest --coverage",
     "test:snapshot:update": "TZ=UTC jest -u",
     "test:watch": "TZ=UTC jest --watch",

--- a/rites/roman1969/src/locales/de.ts
+++ b/rites/roman1969/src/locales/de.ts
@@ -951,7 +951,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Hl. Teresa Benedicta vom Kreuz Stein, Jungfrau und Märtyrerin',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Hl. Teresa Benedicta vom Kreuz Stein, Jungfrau und Märtyrerin, Mitpatronin Europas',
-    teresa_of_calcutta_virgin: 'Hl. Teresa von Kalkutta, Jungfrau',
+    teresa_of_calcutta_virgin: 'Hl. Teresa von Kolkata, Jungfrau', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#tedesca
     teresa_of_jesus_jornet_ibars_virgin: 'Hl. Teresa von Jesus Jornet Ibars, Jungfrau',
     teresa_of_jesus_of_avila_virgin: 'Hl. Teresa von Ávila, Jungfrau und Kirchenlehrerin',
     teresa_of_jesus_of_los_andes_virgin: 'Hl. Teresa von Jesus von Los Andes, Jungfrau',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -1043,7 +1043,7 @@ export const locale: Locale = {
       'Saint Teresa Benedicta of the Cross Stein, Virgin and Martyr, Copatroness of Europe',
     // Decree on the inscription of Saint Teresa of Calcutta, virgin, in the General Roman Calendar
     // src: https://press.vatican.va/content/salastampa/en/bollettino/pubblico/2025/02/11/250211b.html
-    teresa_of_calcutta_virgin: 'Saint Teresa of Calcutta, Virgin',
+    teresa_of_calcutta_virgin: 'Saint Teresa of Calcutta, Virgin', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#inglese
     teresa_of_jesus_jornet_ibars_virgin: 'Saint Teresa of Jesus Jornet Ibars, Virgin',
     teresa_of_jesus_of_avila_virgin: 'Saint Teresa of Jesus, Virgin and Doctor of the Church',
     teresa_of_jesus_of_los_andes_virgin: 'Saint Teresa of Jesus of Los Andes, Virgin',

--- a/rites/roman1969/src/locales/es.ts
+++ b/rites/roman1969/src/locales/es.ts
@@ -591,7 +591,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedicta de la Cruz (Edith Stein), virgen y mártir',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Santa Teresa Benedicta de la Cruz (Edith Stein), virgen, mártir y Patrona Secundaria de Europa',
-    teresa_of_calcutta_virgin: 'Santa Teresa de Calcuta, virgen',
+    teresa_of_calcutta_virgin: 'Santa Teresa de Calcuta, virgen', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#spagnola
     teresa_of_jesus_jornet_ibars_virgin: 'Santa Teresa de Jesús Jornet e Ibars, virgen',
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesús, virgen y doctora de la Iglesia',
     teresa_of_jesus_of_los_andes_virgin: 'Santa Teresa de Los Andes, virgen',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -658,6 +658,7 @@ export const locale: Locale = {
       'Sainte Thérèse-Bénédicte de la Croix (Edith Stein), Carmélite, martyr en Pologne († 1942)',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Sainte Thérèse-Bénédicte de la Croix (Edith Stein), Carmélite, martyr en Pologne, co-patronne de l’Europe († 1942)',
+    teresa_of_calcutta_virgin: 'Sainte Teresa de Calcutta, vierge', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#francese
     teresa_of_jesus_of_avila_virgin: 'Sainte Thérèse de Jésus (d’Avila), vierge et docteur de l’Église († 1582)',
     thanksgiving_day: 'Jour de l’action de grâce', // src: mr_fr_2021_ed3
     therese_marie_victoire_couderc_virgin: 'Sainte Thérèse Couderc, vierge († 1885)', // src: mr_fr_2014_ed2_lyon

--- a/rites/roman1969/src/locales/it.ts
+++ b/rites/roman1969/src/locales/it.ts
@@ -498,6 +498,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedetta della Croce, vergine e martire',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Santa Teresa Benedetta della Croce, vergine, martire e patrona secondaria d’Europa',
+    teresa_of_calcutta_virgin: 'Santa Teresa di Calcutta, vergine', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#italiana
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa di Gesù d’Avila, vergine e dottore della Chiesa',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
       'Santa Teresa di Gesu’ Bambino, vergine e dottore della Chiesa',

--- a/rites/roman1969/src/locales/pl.ts
+++ b/rites/roman1969/src/locales/pl.ts
@@ -499,6 +499,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Św. Teresy Benedykty od Krzyża, dziewicy i męczennicy',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Św. Teresy Benedykty od Krzyża, dziewicy i męczennicy, patronki Europy',
+    teresa_of_calcutta_virgin: 'Świętej Teresy z Kalkuty, dziewicy', // src: https://liturgia.wiara.pl/doc/9143462.Swieta-Teresa-z-Kalkuty-w-Powszechnym-Kalendarzu-Rzymskim
     teresa_of_jesus_of_avila_virgin: 'Św. Teresy od Jezusa, dziewicy i doktora Kościoła',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
       'Św. Teresy od Dzieciątka Jezus, dziewicy i doktora Kościoła',


### PR DESCRIPTION
## Summary

This PR contains two changes:

### 1. Change unused martyrology items check to informational

- Update `data-checks.ts` to change the "useless martyrology items" check from an error to an informational message
- Valid martyrology entries should not be restricted even if not yet used by any calendar - they may be reserved for future use
- Renumber the check comments to reflect the new order

### 2. Update `teresa_of_calcutta_virgin` translations

Update translations and add source references for `teresa_of_calcutta_virgin`:

- `de`: change `Kalkutta` to `Kolkata`
- `en`: add source reference
- `es`: add source reference  
- `fr`: add translation with source
- `it`: add translation with source
- `pl`: add translation with source

Sources:
- https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html
- https://liturgia.wiara.pl/doc/9143462.Swieta-Teresa-z-Kalkuty-w-Powszechnym-Kalendarzu-Rzymskim