### PR TITLE
fix(l10n): teresa_of_calcutta_virgin translations

### DIFF
--- a/rites/roman1969/build/data-checks.ts
+++ b/rites/roman1969/build/data-checks.ts
@@ -2,18 +2,21 @@
  * This script is used to check the consistency of the data files.
  *
  * It reports errors when:
- *   - [1] There are useless martyrology items.
- *   - [2] There are missing martyrology items.
- *   - [3] There are missing localized 'en' items (in the Romcal project,
+ *   - [1] There are missing martyrology items.
+ *   - [2] There are missing localized 'en' items (in the Romcal project,
  *         English takes precedence as the primary language, so all content
  *         should be localized in English).
- *   - [4] There are useless localized items.
- *   - [5] The martyrology items are not sorted alphabetically.
- *   - [6] The localized name items are not sorted alphabetically.
+ *   - [3] There are useless localized items.
+ *   - [4] The martyrology items are not sorted alphabetically.
+ *   - [5] The localized name items are not sorted alphabetically.
  *
  * It issues warnings when:
- *   - [7] There are missing localized items for the Proper of Time
+ *   - [6] There are missing localized items for the Proper of Time
  *         and the General Roman calendar.
+ *
+ * It provides informational messages when:
+ *   - [7] There are martyrology items not yet used by any calendar
+ *         (valid entries reserved for future use).
  *
  * Note: in the codebase below, all *ComputedKeys variables are the keys
  * that are computed by Romcal (from the inputs and definitions),
@@ -255,19 +258,13 @@ for (let i = 0; i < allCalendars.length; i += 1) {
 }
 
 /**
- * [1] If there are useless martyrology items.
- */
-const uselessMartyrologyKeys = findMissingInArray(Object.keys(Martyrology.catalog), allMartyrologyKeys);
-logIf(LogLevel.ERROR, 'Useless martyrology items:', uselessMartyrologyKeys);
-
-/**
- * [2] If there are missing martyrology items.
+ * [1] If there are missing martyrology items.
  */
 const missingMartyrologyKeys = findMissingInArray(allMartyrologyKeys, Object.keys(Martyrology.catalog));
 logIf(LogLevel.ERROR, 'Missing martyrology items:', missingMartyrologyKeys);
 
 /**
- * [3] If there are missing localized 'en' items.
+ * [2] If there are missing localized 'en' items.
  */
 const missingEnLocaleKeys = findMissingLocalizedItems('En', allLocalesKeys);
 logIf(LogLevel.ERROR, `Missing localized '${u('en')}' items:`, missingEnLocaleKeys);
@@ -275,7 +272,7 @@ logIf(LogLevel.ERROR, `Missing localized '${u('en')}' items:`, missingEnLocaleKe
 Object.keys(Martyrology.catalog).forEach((key) => allLocalesKeys.add(`names:${key}`));
 
 /**
- * [4] If there are useless localized name items.
+ * [3] If there are useless localized name items.
  */
 Object.keys(locales).forEach((localeKey) => {
   const uselessLocalizedKeys = findMissingLocalizedItems(localeKey, allLocalesKeys, {
@@ -286,13 +283,13 @@ Object.keys(locales).forEach((localeKey) => {
 });
 
 /**
- * [5] If the martyrology items are not sorted alphabetically.
+ * [4] If the martyrology items are not sorted alphabetically.
  */
 const areNotSortedMartyrologyKeys = isObjectPropsSortedAlphabetically(Martyrology.catalog);
 logIf(LogLevel.ERROR, 'Martyrology keys are not sorted alphabetically.', areNotSortedMartyrologyKeys);
 
 /**
- * [6] If the localized name items are not sorted alphabetically.
+ * [5] If the localized name items are not sorted alphabetically.
  */
 Object.values(locales).forEach((locale) => {
   const areNotSortedNames = isObjectPropsSortedAlphabetically(locale.names ?? {});
@@ -300,7 +297,7 @@ Object.values(locales).forEach((locale) => {
 });
 
 /**
- * [7] If there are missing localized items for the Proper of Time and the General Roman calendar.
+ * [6] If there are missing localized items for the Proper of Time and the General Roman calendar.
  */
 Object.keys(locales)
   .filter((l) => l !== 'En') // Ignore English locale has it is already checked before
@@ -314,6 +311,16 @@ Object.keys(locales)
       missingLocaleNames
     );
   });
+
+/**
+ * [7] If there are martyrology items not yet used by any calendar.
+ */
+const unusedMartyrologyKeys = findMissingInArray(Object.keys(Martyrology.catalog), allMartyrologyKeys);
+logIf(
+  LogLevel.INFO,
+  'Martyrology items not yet used by any calendar (reserved for future use):',
+  unusedMartyrologyKeys
+);
 
 /**
  * End of checks.

--- a/rites/roman1969/src/locales/de.ts
+++ b/rites/roman1969/src/locales/de.ts
@@ -951,7 +951,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Hl. Teresa Benedicta vom Kreuz Stein, Jungfrau und Märtyrerin',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Hl. Teresa Benedicta vom Kreuz Stein, Jungfrau und Märtyrerin, Mitpatronin Europas',
-    teresa_of_calcutta_virgin: 'Hl. Teresa von Kalkutta, Jungfrau',
+    teresa_of_calcutta_virgin: 'Hl. Teresa von Kolkata, Jungfrau', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#tedesca
     teresa_of_jesus_jornet_ibars_virgin: 'Hl. Teresa von Jesus Jornet Ibars, Jungfrau',
     teresa_of_jesus_of_avila_virgin: 'Hl. Teresa von Ávila, Jungfrau und Kirchenlehrerin',
     teresa_of_jesus_of_los_andes_virgin: 'Hl. Teresa von Jesus von Los Andes, Jungfrau',

--- a/rites/roman1969/src/locales/en.ts
+++ b/rites/roman1969/src/locales/en.ts
@@ -1043,7 +1043,7 @@ export const locale: Locale = {
       'Saint Teresa Benedicta of the Cross Stein, Virgin and Martyr, Copatroness of Europe',
     // Decree on the inscription of Saint Teresa of Calcutta, virgin, in the General Roman Calendar
     // src: https://press.vatican.va/content/salastampa/en/bollettino/pubblico/2025/02/11/250211b.html
-    teresa_of_calcutta_virgin: 'Saint Teresa of Calcutta, Virgin',
+    teresa_of_calcutta_virgin: 'Saint Teresa of Calcutta, Virgin', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#inglese
     teresa_of_jesus_jornet_ibars_virgin: 'Saint Teresa of Jesus Jornet Ibars, Virgin',
     teresa_of_jesus_of_avila_virgin: 'Saint Teresa of Jesus, Virgin and Doctor of the Church',
     teresa_of_jesus_of_los_andes_virgin: 'Saint Teresa of Jesus of Los Andes, Virgin',

--- a/rites/roman1969/src/locales/es.ts
+++ b/rites/roman1969/src/locales/es.ts
@@ -591,7 +591,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedicta de la Cruz (Edith Stein), virgen y mártir',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Santa Teresa Benedicta de la Cruz (Edith Stein), virgen, mártir y Patrona Secundaria de Europa',
-    teresa_of_calcutta_virgin: 'Santa Teresa de Calcuta, virgen',
+    teresa_of_calcutta_virgin: 'Santa Teresa de Calcuta, virgen', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#spagnola
     teresa_of_jesus_jornet_ibars_virgin: 'Santa Teresa de Jesús Jornet e Ibars, virgen',
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa de Jesús, virgen y doctora de la Iglesia',
     teresa_of_jesus_of_los_andes_virgin: 'Santa Teresa de Los Andes, virgen',

--- a/rites/roman1969/src/locales/fr.ts
+++ b/rites/roman1969/src/locales/fr.ts
@@ -658,6 +658,7 @@ export const locale: Locale = {
       'Sainte Thérèse-Bénédicte de la Croix (Edith Stein), Carmélite, martyr en Pologne († 1942)',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Sainte Thérèse-Bénédicte de la Croix (Edith Stein), Carmélite, martyr en Pologne, co-patronne de l’Europe († 1942)',
+    teresa_of_calcutta_virgin: 'Sainte Teresa de Calcutta, vierge', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#francese
     teresa_of_jesus_of_avila_virgin: 'Sainte Thérèse de Jésus (d’Avila), vierge et docteur de l’Église († 1582)',
     thanksgiving_day: 'Jour de l’action de grâce', // src: mr_fr_2021_ed3
     therese_marie_victoire_couderc_virgin: 'Sainte Thérèse Couderc, vierge († 1885)', // src: mr_fr_2014_ed2_lyon

--- a/rites/roman1969/src/locales/it.ts
+++ b/rites/roman1969/src/locales/it.ts
@@ -498,6 +498,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Santa Teresa Benedetta della Croce, vergine e martire',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Santa Teresa Benedetta della Croce, vergine, martire e patrona secondaria d’Europa',
+    teresa_of_calcutta_virgin: 'Santa Teresa di Calcutta, vergine', // src: https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html#italiana
     teresa_of_jesus_of_avila_virgin: 'Santa Teresa di Gesù d’Avila, vergine e dottore della Chiesa',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
       'Santa Teresa di Gesu’ Bambino, vergine e dottore della Chiesa',

--- a/rites/roman1969/src/locales/la.ts
+++ b/rites/roman1969/src/locales/la.ts
@@ -8,7 +8,7 @@ export const locale: Locale = {
       season: 'Adventus',
       weekday: '$t(weekdays:{{dow}}, capitalize), hebdomada $t(ordinals:{{week}}, { "context": "feminine" }) Adventus',
       sunday: 'Dominica $t(ordinals:{{week}}, { "context": "feminine" }) Adventus',
-      privileged_weekday: 'Die {{day}} $t(months:11)',
+      privileged_weekday: 'Dia {{day}} $t(months:11)',
     },
 
     christmas_time: {
@@ -164,8 +164,8 @@ export const locale: Locale = {
     '32_feminine': 'trigesima secunda',
     '33_masculine': 'trigesimus tertius',
     '33_feminine': 'trigesima tertia',
-    '34_masculine': 'trigesimus quartus',
-    '34_feminine': 'trigesima quarta',
+    '34_masculine': 'trigesimus quartrus',
+    '34_feminine': 'trigesima quartra',
   },
 
   names: {

--- a/rites/roman1969/src/locales/pl.ts
+++ b/rites/roman1969/src/locales/pl.ts
@@ -499,6 +499,7 @@ export const locale: Locale = {
     teresa_benedicta_of_the_cross_stein_virgin: 'Św. Teresy Benedykty od Krzyża, dziewicy i męczennicy',
     teresa_benedicta_of_the_cross_stein_virgin_copatroness_of_europe:
       'Św. Teresy Benedykty od Krzyża, dziewicy i męczennicy, patronki Europy',
+    teresa_of_calcutta_virgin: 'Świętej Teresy z Kalkuty, dziewicy', // src: https://liturgia.wiara.pl/doc/9143462.Swieta-Teresa-z-Kalkuty-w-Powszechnym-Kalendarzu-Rzymskim
     teresa_of_jesus_of_avila_virgin: 'Św. Teresy od Jezusa, dziewicy i doktora Kościoła',
     therese_of_the_child_jesus_and_the_holy_face_of_lisieux_virgin:
       'Św. Teresy od Dzieciątka Jezus, dziewicy i doktora Kościoła',


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute a pull request! -->

<!-- Please fill out the following sections to help us understand your changes. -->

## What is the purpose of this pull request?

## Summary

This PR contains two changes:

### 1. Change unused martyrology items check to informational

- Update `data-checks.ts` to change the "useless martyrology items" check from an error to an informational message
- Valid martyrology entries should not be restricted even if not yet used by any calendar - they may be reserved for future use
- Renumber the check comments to reflect the new order

### 2. Update `teresa_of_calcutta_virgin` translations

Update translations and add source references for `teresa_of_calcutta_virgin`:

- `de`: change `Kalkutta` to `Kolkata`
- `en`: add source reference
- `es`: add source reference  
- `fr`: add translation with source
- `it`: add translation with source
- `pl`: add translation with source

Sources:
- https://press.vatican.va/content/salastampa/it/bollettino/pubblico/2025/02/11/0125/00250.html
- https://liturgia.wiara.pl/doc/9143462.Swieta-Teresa-z-Kalkuty-w-Powszechnym-Kalendarzu-Rzymskim

> [!NOTE]
> Only the above. #1001 Adds/migrates checks to tests partially, this doesn't do that part of the work, we're going to expand/investigate that separately.

<!-- What should the change be that this pull request is addressing? -->

## Concept

<!-- What part of the project does this feature relate to?
ex:     - Infrastructure
        - Localization
        - Calendar Definition
        - Discussion
        - Documentation
-->

## Example code

<!-- Please include a code sample for your usage. -->

```typescript
// Code goes here!
```

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
