### PR TITLE
feat(calendar): add Lunar New Year date computation (#1083)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,6 +109,7 @@ export default [
         project: [
           './tsconfig.base.json',
           './packages/easter/tsconfig.json',
+          './packages/lunar-new-year/tsconfig.json',
           './rites/roman1962/tsconfig.json',
           './rites/roman1969/tsconfig.json',
         ],
@@ -138,6 +139,7 @@ export default [
         project: [
           './tsconfig.base.json',
           './packages/easter/tsconfig.json',
+          './packages/lunar-new-year/tsconfig.json',
           './rites/roman1962/tsconfig.json',
           './rites/roman1969/tsconfig.json',
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -920,7 +921,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
         "tslib": "^2.4.0"
@@ -933,7 +933,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -945,7 +944,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1674,6 +1672,10 @@
     },
     "node_modules/@internal/easter": {
       "resolved": "packages/easter",
+      "link": true
+    },
+    "node_modules/@internal/lunar-new-year": {
+      "resolved": "packages/lunar-new-year",
       "link": true
     },
     "node_modules/@internal/rite-roman1962": {
@@ -2978,7 +2980,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
@@ -3020,7 +3021,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3077,7 +3077,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3226,6 +3225,7 @@
       "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3270,6 +3270,7 @@
       "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -3309,6 +3310,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3565,8 +3567,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
       "version": "1.11.1",
@@ -3580,8 +3581,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
@@ -3595,8 +3595,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
       "version": "1.11.1",
@@ -3610,8 +3609,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
       "version": "1.11.1",
@@ -3625,8 +3623,7 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
       "version": "1.11.1",
@@ -3640,8 +3637,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
       "version": "1.11.1",
@@ -3655,8 +3651,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
       "version": "1.11.1",
@@ -3670,8 +3665,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
       "version": "1.11.1",
@@ -3685,8 +3679,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
       "version": "1.11.1",
@@ -3700,8 +3693,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
       "version": "1.11.1",
@@ -3715,8 +3707,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
       "version": "1.11.1",
@@ -3730,8 +3721,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
       "version": "1.11.1",
@@ -3745,8 +3735,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
       "version": "1.11.1",
@@ -3760,8 +3749,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
       "version": "1.11.1",
@@ -3775,8 +3763,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
       "version": "1.11.1",
@@ -3788,7 +3775,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "^0.2.11"
       },
@@ -3808,8 +3794,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
       "version": "1.11.1",
@@ -3823,8 +3808,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
       "version": "1.11.1",
@@ -3838,8 +3822,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -3847,6 +3830,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4341,6 +4325,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5365,6 +5350,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5440,6 +5426,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5500,6 +5487,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7886,6 +7874,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -11695,6 +11684,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13280,6 +13270,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13431,8 +13422,7 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -13583,6 +13573,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14335,6 +14326,14 @@
         "@internal/config": "file:../../packages/config"
       }
     },
+    "packages/lunar-new-year": {
+      "name": "@internal/lunar-new-year",
+      "version": "0.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@internal/config": "file:../../packages/config"
+      }
+    },
     "rites/roman1962": {
       "name": "@internal/rite-roman1962",
       "version": "0.0.0",
@@ -14349,6 +14348,7 @@
       "license": "MIT",
       "dependencies": {
         "@internal/easter": "file:../../packages/easter",
+        "@internal/lunar-new-year": "file:../../packages/lunar-new-year",
         "i18next": "^25.8.13",
         "ts-deepmerge": "^7.0.3"
       },

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   ],
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "npm run build -w=@internal/easter -w=@internal/rite-roman1969",
-    "clean": "rimraf coverage dist tmp && npm run clean -w=@internal/easter -w=@internal/rite-roman1969",
+    "build": "npm run build -w=@internal/easter -w=@internal/lunar-new-year -w=@internal/rite-roman1969",
+    "clean": "rimraf coverage dist tmp && npm run clean -w=@internal/easter -w=@internal/lunar-new-year -w=@internal/rite-roman1969",
     "data:checks": "npm run data:checks -w=@internal/rite-roman1969",
     "doc": "npm run doc -w=@internal/rite-roman1969",
     "docs:check-links": "npm run docs:check-links -w=@internal/rite-roman1969",

--- a/packages/lunar-new-year/README.md
+++ b/packages/lunar-new-year/README.md
@@ -1,0 +1,19 @@
+# Lunar New Year Date Calculator
+
+This package provides a utility to calculate the date of Lunar New Year using Jean Meeus's astronomical algorithms (winter solstice + new moon phases).
+
+## Usage
+
+```ts
+import { calculateLunarNewYear } from '@internal/lunar-new-year';
+
+// UTC+8 for China/Hong Kong/Taiwan
+const date = calculateLunarNewYear(2025, 8);
+// { year: 2025, month: 1, day: 29 }
+
+// UTC+7 for Vietnam
+const dateVietnam = calculateLunarNewYear(2025, 7);
+
+// UTC+9 for Korea/Japan
+const dateKorea = calculateLunarNewYear(2025, 9);
+```

--- a/packages/lunar-new-year/jest.config.mjs
+++ b/packages/lunar-new-year/jest.config.mjs
@@ -1,0 +1,3 @@
+import config from '@internal/config/jest.config.mjs';
+
+export default config;

--- a/packages/lunar-new-year/package.json
+++ b/packages/lunar-new-year/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@internal/lunar-new-year",
+  "version": "0.0.0",
+  "description": "Calculate the date of Lunar New Year using Meeus's astronomical algorithms.",
+  "license": "MIT",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "build": "tsc --project tsconfig.release.json",
+    "clean": "rimraf coverage dist",
+    "prettier": "prettier -c .",
+    "test": "TZ=UTC jest"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@internal/config": "file:../../packages/config"
+  }
+}

--- a/packages/lunar-new-year/src/index.ts
+++ b/packages/lunar-new-year/src/index.ts
@@ -1,10 +1,7 @@
 /**
  * Lunar New Year date computation based on:
- * Jean Meeus, "Astronomical Algorithms", 2nd ed., Willmann-Bell, 1998.
- * ISBN 0-943396-61-1
- *
+ * Jean Meeus, "Astronomical Algorithms", Willmann-Bell, 1991.
  * https://archive.org/details/astronomicalalgorithmsjeanmeeus1991
- * Reference implementation: https://github.com/soniakeys/meeus
  */
 
 export type LunarNewYearDate = { year: number; month: number; day: number };
@@ -53,7 +50,7 @@ const jdeToDate = (jde: number, utcOffset: number): LunarNewYearDate => {
 
 /**
  * Compute the Julian Ephemeris Day of the December solstice for a given year.
- * Meeus, Ch. 27 (2nd ed.) / Ch. 26 (1st ed.).
+ * Meeus, Ch. 26.
  */
 const winterSolsticeJDE = (year: number): number => {
   const Y = (year - 2000) / 1000;
@@ -96,7 +93,7 @@ const winterSolsticeJDE = (year: number): number => {
 /**
  * Compute the JDE of the new moon for lunation cycle k.
  * k = 0 corresponds to the new moon of 2000 Jan 6.
- * Meeus, Ch. 49 (2nd ed.) / Ch. 47 (1st ed.).
+ * Meeus, Ch. 47.
  */
 const newMoonJDE = (k: number): number => {
   const T = k / 1236.85;

--- a/packages/lunar-new-year/src/index.ts
+++ b/packages/lunar-new-year/src/index.ts
@@ -1,0 +1,221 @@
+/**
+ * Lunar New Year date computation based on:
+ * Jean Meeus, "Astronomical Algorithms", 2nd ed., Willmann-Bell, 1998.
+ * ISBN 0-943396-61-1
+ *
+ * https://archive.org/details/astronomicalalgorithmsjeanmeeus1991
+ * Reference implementation: https://github.com/soniakeys/meeus
+ */
+
+export type LunarNewYearDate = { year: number; month: number; day: number };
+
+/** Convert degrees to radians and return the sine */
+const sin = (degrees: number): number => Math.sin((degrees * Math.PI) / 180);
+
+/** Convert degrees to radians and return the cosine */
+const cos = (degrees: number): number => Math.cos((degrees * Math.PI) / 180);
+
+/** Convert a JDE to a Julian Day Number (integer date identifier) at the given UTC offset. */
+const jdeToJulianDayNumber = (jde: number, utcOffset: number): number => {
+  return Math.floor(jde + utcOffset / 24 + 0.5);
+};
+
+/**
+ * Convert a Julian Ephemeris Day to a Gregorian calendar date at a given UTC offset.
+ */
+const jdeToDate = (jde: number, utcOffset: number): LunarNewYearDate => {
+  // Apply UTC offset: shift JDE by the offset in days
+  const adjustedJDE = jde + utcOffset / 24;
+
+  // Algorithm to convert JDE to Gregorian calendar date
+  // Meeus, Ch. 7
+  const z = Math.floor(adjustedJDE + 0.5);
+
+  let A: number;
+  if (z < 2299161) {
+    A = z;
+  } else {
+    const alpha = Math.floor((z - 1867216.25) / 36524.25);
+    A = z + 1 + alpha - Math.floor(alpha / 4);
+  }
+
+  const B = A + 1524;
+  const C = Math.floor((B - 122.1) / 365.25);
+  const D = Math.floor(365.25 * C);
+  const E = Math.floor((B - D) / 30.6001);
+
+  const day = B - D - Math.floor(30.6001 * E);
+  const month = E < 14 ? E - 1 : E - 13;
+  const year = month > 2 ? C - 4716 : C - 4715;
+
+  return { year, month, day };
+};
+
+/**
+ * Compute the Julian Ephemeris Day of the December solstice for a given year.
+ * Meeus, Ch. 27 (2nd ed.) / Ch. 26 (1st ed.).
+ */
+const winterSolsticeJDE = (year: number): number => {
+  const Y = (year - 2000) / 1000;
+
+  // JDE₀ polynomial for December solstice (Table 27.A)
+  const JDE0 = 2451900.05952 + 365242.74049 * Y - 0.06223 * Y * Y - 0.00823 * Y * Y * Y + 0.00032 * Y * Y * Y * Y;
+
+  const T = (JDE0 - 2451545.0) / 36525;
+
+  // Periodic correction terms (Table 27.C)
+  const S =
+    485 * cos(324.96 + 1934.136 * T) +
+    203 * cos(337.23 + 32964.467 * T) +
+    199 * cos(342.08 + 20.186 * T) +
+    182 * cos(27.85 + 445267.112 * T) +
+    156 * cos(73.14 + 45036.886 * T) +
+    136 * cos(171.52 + 22518.443 * T) +
+    77 * cos(222.54 + 65928.934 * T) +
+    74 * cos(296.72 + 3034.906 * T) +
+    70 * cos(243.58 + 9037.513 * T) +
+    58 * cos(119.81 + 33718.147 * T) +
+    52 * cos(297.17 + 150.678 * T) +
+    50 * cos(21.02 + 2281.226 * T) +
+    45 * cos(247.54 + 29929.562 * T) +
+    44 * cos(325.15 + 31555.956 * T) +
+    29 * cos(60.93 + 4443.417 * T) +
+    18 * cos(155.12 + 67555.328 * T) +
+    17 * cos(288.79 + 4562.452 * T) +
+    16 * cos(198.04 + 62894.029 * T) +
+    14 * cos(199.76 + 31436.921 * T) +
+    12 * cos(95.39 + 14577.848 * T) +
+    12 * cos(287.11 + 31931.756 * T) +
+    12 * cos(320.81 + 34777.259 * T) +
+    9 * cos(227.73 + 1222.114 * T) +
+    8 * cos(15.45 + 16859.074 * T);
+
+  return JDE0 + S * 0.00001;
+};
+
+/**
+ * Compute the JDE of the new moon for lunation cycle k.
+ * k = 0 corresponds to the new moon of 2000 Jan 6.
+ * Meeus, Ch. 49 (2nd ed.) / Ch. 47 (1st ed.).
+ */
+const newMoonJDE = (k: number): number => {
+  const T = k / 1236.85;
+  const T2 = T * T;
+  const T3 = T2 * T;
+  const T4 = T3 * T;
+
+  // Mean phase JDE (Eq. 49.1)
+  let JDE = 2451550.09766 + 29.530588861 * k + 0.00015437 * T2 - 0.00000015 * T3 + 0.00000000073 * T4;
+
+  // Eccentricity correction factor
+  const E = 1 - 0.002516 * T - 0.0000074 * T2;
+
+  // Sun's mean anomaly (Eq. 49.4)
+  const M = 2.5534 + 29.1053567 * k - 0.0000014 * T2 - 0.00000011 * T3;
+
+  // Moon's mean anomaly (Eq. 49.5)
+  const Mp = 201.5643 + 385.81693528 * k + 0.0107582 * T2 + 0.00001238 * T3 - 0.000000058 * T4;
+
+  // Moon's argument of latitude (Eq. 49.6)
+  const F = 160.7108 + 390.67050284 * k - 0.0016118 * T2 - 0.00000227 * T3 + 0.000000011 * T4;
+
+  // Longitude of ascending node (Eq. 49.7)
+  const Omega = 124.7746 - 1.56375588 * k + 0.0020672 * T2 + 0.00000215 * T3;
+
+  // Correction terms for new moon (Table 49.A)
+  const correction =
+    -0.4072 * sin(Mp) +
+    0.17241 * E * sin(M) +
+    0.01608 * sin(2 * Mp) +
+    0.01039 * sin(2 * F) +
+    0.00739 * E * sin(Mp - M) +
+    -0.00514 * E * sin(Mp + M) +
+    0.00208 * E * E * sin(2 * M) +
+    -0.00111 * sin(Mp - 2 * F) +
+    -0.00057 * sin(Mp + 2 * F) +
+    0.00056 * E * sin(2 * Mp + M) +
+    -0.00042 * sin(3 * Mp) +
+    0.00042 * E * sin(M + 2 * F) +
+    0.00038 * E * sin(M - 2 * F) +
+    -0.00024 * E * sin(2 * Mp - M) +
+    -0.00017 * sin(Omega) +
+    -0.00007 * sin(Mp + 2 * M) +
+    0.00004 * sin(2 * Mp - 2 * F) +
+    0.00004 * sin(3 * M) +
+    0.00003 * sin(Mp + M - 2 * F) +
+    0.00003 * sin(2 * Mp + 2 * F) +
+    -0.00003 * sin(Mp + M + 2 * F) +
+    0.00003 * sin(Mp - M + 2 * F) +
+    -0.00002 * sin(Mp - M - 2 * F) +
+    -0.00002 * sin(3 * Mp + M) +
+    0.00002 * sin(4 * Mp);
+
+  JDE += correction;
+
+  // Additional corrections (Table 49.B — planetary arguments)
+  const A1 = 299.77 + 132.8475848 * k - 0.009173 * T2;
+  const A2 = 251.88 + 92.517136 * k;
+  const A3 = 251.83 + 360.58068 * k;
+  const A4 = 349.42 + 450.37168 * k;
+  const A5 = 84.66 + 966.20036 * k;
+  const A6 = 141.74 + 1361.55178 * k;
+  const A7 = 207.14 + 1759.87848 * k;
+  const A8 = 154.84 + 7.30686 * k;
+  const A9 = 34.52 + 27.261239 * k;
+  const A10 = 207.19 + 1154.8622 * k;
+  const A11 = 291.34 + 0.09133 * k;
+  const A12 = 161.72 + 31.85958 * k;
+  const A13 = 239.56 + 25.13124 * k;
+  const A14 = 331.55 + 481.75148 * k;
+
+  JDE +=
+    0.000325 * sin(A1) +
+    0.000165 * sin(A2) +
+    0.000164 * sin(A3) +
+    0.000126 * sin(A4) +
+    0.00011 * sin(A5) +
+    0.000062 * sin(A6) +
+    0.00006 * sin(A7) +
+    0.000056 * sin(A8) +
+    0.000047 * sin(A9) +
+    0.000042 * sin(A10) +
+    0.00004 * sin(A11) +
+    0.000037 * sin(A12) +
+    0.000035 * sin(A13) +
+    0.000023 * sin(A14);
+
+  return JDE;
+};
+
+/**
+ * Calculate the date of Lunar New Year for a given Gregorian year.
+ *
+ * Lunar New Year falls on the 2nd new moon after the December solstice
+ * of the previous year. Uses Jean Meeus's astronomical algorithms
+ * ("Astronomical Algorithms", 2nd ed.) for solstice and new moon computation.
+ *
+ * @param year The Gregorian year of the Lunar New Year
+ * @param utcOffset UTC offset in hours for the target timezone (e.g. 8 for China/HK/Taiwan, 9 for Korea/Japan, 7 for Vietnam)
+ */
+export const calculateLunarNewYear = (year: number, utcOffset: number): LunarNewYearDate => {
+  // 1. Compute winter solstice JDE for December of (year - 1)
+  const solsticeJDE = winterSolsticeJDE(year - 1);
+  const solsticeDay = jdeToJulianDayNumber(solsticeJDE, utcOffset);
+
+  // 2. Estimate lunation number k near the solstice
+  const decimalYear = year - 1 + 11.5 / 12; // approximate December of previous year
+  let k = Math.floor((decimalYear - 2000) * 12.3685);
+
+  // 3. Find the new moon that starts month 11 (the month containing the solstice).
+  //    In the Chinese calendar, month 11 always contains the winter solstice.
+  //    We find the last new moon whose local date <= the solstice local date.
+  while (jdeToJulianDayNumber(newMoonJDE(k + 1), utcOffset) <= solsticeDay) {
+    k++;
+  }
+
+  // 4. CNY is the 2nd new moon after the month-11 new moon
+  const lnyJDE = newMoonJDE(k + 2);
+
+  // 5. Convert to date at the given UTC offset
+  return jdeToDate(lnyJDE, utcOffset);
+};

--- a/packages/lunar-new-year/src/lunar-new-year.spec.ts
+++ b/packages/lunar-new-year/src/lunar-new-year.spec.ts
@@ -1,0 +1,148 @@
+import { LunarNewYearDate, calculateLunarNewYear } from '.';
+
+describe('Lunar New Year calculation', () => {
+  // Reference: https://pinyin.info/chinese_new_year/cny2000-2099.html
+  describe('calculateLunarNewYear (UTC+8, China/Hong Kong/Taiwan)', () => {
+    const expectedDates: Record<string, LunarNewYearDate> = {
+      '2000': { year: 2000, month: 2, day: 5 },
+      '2001': { year: 2001, month: 1, day: 24 },
+      '2002': { year: 2002, month: 2, day: 12 },
+      '2003': { year: 2003, month: 2, day: 1 },
+      '2004': { year: 2004, month: 1, day: 22 },
+      '2005': { year: 2005, month: 2, day: 9 },
+      '2006': { year: 2006, month: 1, day: 29 },
+      '2007': { year: 2007, month: 2, day: 18 },
+      '2008': { year: 2008, month: 2, day: 7 },
+      '2009': { year: 2009, month: 1, day: 26 },
+      '2010': { year: 2010, month: 2, day: 14 },
+      '2011': { year: 2011, month: 2, day: 3 },
+      '2012': { year: 2012, month: 1, day: 23 },
+      '2013': { year: 2013, month: 2, day: 10 },
+      '2014': { year: 2014, month: 1, day: 31 },
+      '2015': { year: 2015, month: 2, day: 19 },
+      '2016': { year: 2016, month: 2, day: 8 },
+      '2017': { year: 2017, month: 1, day: 28 },
+      '2018': { year: 2018, month: 2, day: 16 },
+      '2019': { year: 2019, month: 2, day: 5 },
+      '2020': { year: 2020, month: 1, day: 25 },
+      '2021': { year: 2021, month: 2, day: 12 },
+      '2022': { year: 2022, month: 2, day: 1 },
+      '2023': { year: 2023, month: 1, day: 22 },
+      '2024': { year: 2024, month: 2, day: 10 },
+      '2025': { year: 2025, month: 1, day: 29 },
+      '2026': { year: 2026, month: 2, day: 17 },
+      '2027': { year: 2027, month: 2, day: 6 },
+      '2028': { year: 2028, month: 1, day: 26 },
+      '2029': { year: 2029, month: 2, day: 13 },
+      '2030': { year: 2030, month: 2, day: 3 },
+      '2031': { year: 2031, month: 1, day: 23 },
+      '2032': { year: 2032, month: 2, day: 11 },
+      '2033': { year: 2033, month: 1, day: 31 },
+      '2034': { year: 2034, month: 2, day: 19 },
+      '2035': { year: 2035, month: 2, day: 8 },
+      '2036': { year: 2036, month: 1, day: 28 },
+      '2037': { year: 2037, month: 2, day: 15 },
+      '2038': { year: 2038, month: 2, day: 4 },
+      '2039': { year: 2039, month: 1, day: 24 },
+      '2040': { year: 2040, month: 2, day: 12 },
+      '2041': { year: 2041, month: 2, day: 1 },
+      '2042': { year: 2042, month: 1, day: 22 },
+      '2043': { year: 2043, month: 2, day: 10 },
+      '2044': { year: 2044, month: 1, day: 30 },
+      '2045': { year: 2045, month: 2, day: 17 },
+      '2046': { year: 2046, month: 2, day: 6 },
+      '2047': { year: 2047, month: 1, day: 26 },
+      '2048': { year: 2048, month: 2, day: 14 },
+      '2049': { year: 2049, month: 2, day: 2 },
+      '2050': { year: 2050, month: 1, day: 23 },
+      '2051': { year: 2051, month: 2, day: 11 },
+      '2052': { year: 2052, month: 2, day: 1 },
+      '2053': { year: 2053, month: 2, day: 19 },
+      '2054': { year: 2054, month: 2, day: 8 },
+      '2055': { year: 2055, month: 1, day: 28 },
+      '2056': { year: 2056, month: 2, day: 15 },
+      '2057': { year: 2057, month: 2, day: 4 },
+      '2058': { year: 2058, month: 1, day: 24 },
+      '2059': { year: 2059, month: 2, day: 12 },
+      '2060': { year: 2060, month: 2, day: 2 },
+      '2061': { year: 2061, month: 1, day: 21 },
+      '2062': { year: 2062, month: 2, day: 9 },
+      '2063': { year: 2063, month: 1, day: 29 },
+      '2064': { year: 2064, month: 2, day: 17 },
+      '2065': { year: 2065, month: 2, day: 5 },
+      '2066': { year: 2066, month: 1, day: 26 },
+      '2067': { year: 2067, month: 2, day: 14 },
+      '2068': { year: 2068, month: 2, day: 3 },
+      '2069': { year: 2069, month: 1, day: 23 },
+      '2070': { year: 2070, month: 2, day: 11 },
+      '2071': { year: 2071, month: 1, day: 31 },
+      '2072': { year: 2072, month: 2, day: 19 },
+      '2073': { year: 2073, month: 2, day: 7 },
+      '2074': { year: 2074, month: 1, day: 27 },
+      '2075': { year: 2075, month: 2, day: 15 },
+      '2076': { year: 2076, month: 2, day: 5 },
+      '2077': { year: 2077, month: 1, day: 24 },
+      '2078': { year: 2078, month: 2, day: 12 },
+      '2079': { year: 2079, month: 2, day: 2 },
+      '2080': { year: 2080, month: 1, day: 22 },
+      '2081': { year: 2081, month: 2, day: 9 },
+      '2082': { year: 2082, month: 1, day: 29 },
+      '2083': { year: 2083, month: 2, day: 17 },
+      '2084': { year: 2084, month: 2, day: 6 },
+      '2085': { year: 2085, month: 1, day: 26 },
+      '2086': { year: 2086, month: 2, day: 14 },
+      '2087': { year: 2087, month: 2, day: 3 },
+      '2088': { year: 2088, month: 1, day: 24 },
+      '2089': { year: 2089, month: 2, day: 10 },
+      '2090': { year: 2090, month: 1, day: 30 },
+      '2091': { year: 2091, month: 2, day: 18 },
+      '2092': { year: 2092, month: 2, day: 7 },
+      '2093': { year: 2093, month: 1, day: 27 },
+      '2094': { year: 2094, month: 2, day: 15 },
+      '2095': { year: 2095, month: 2, day: 5 },
+      '2096': { year: 2096, month: 1, day: 25 },
+      '2097': { year: 2097, month: 2, day: 12 },
+      '2098': { year: 2098, month: 2, day: 1 },
+      '2099': { year: 2099, month: 1, day: 21 },
+    };
+
+    Object.entries(expectedDates).forEach(([year, expected]) => {
+      it(`should calculate Lunar New Year date for year ${year}`, () => {
+        expect(calculateLunarNewYear(parseInt(year, 10), 8)).toEqual(expected);
+      });
+    });
+  });
+
+  describe('Date range validation', () => {
+    it('Lunar New Year always falls between January 21 and February 20', () => {
+      for (let year = 2000; year <= 2099; year++) {
+        const result = calculateLunarNewYear(year, 8);
+        const dayOfYear = result.month === 1 ? result.day : 31 + result.day;
+        // Jan 21 = day 21, Feb 20 = day 51
+        expect(dayOfYear).toBeGreaterThanOrEqual(21);
+        expect(dayOfYear).toBeLessThanOrEqual(51);
+      }
+    });
+  });
+
+  describe('UTC offset variations', () => {
+    it('In 2026, all offsets (UTC+7/+8/+9) give the same date', () => {
+      const expected = { year: 2026, month: 2, day: 17 };
+      expect(calculateLunarNewYear(2026, 7)).toEqual(expected);
+      expect(calculateLunarNewYear(2026, 8)).toEqual(expected);
+      expect(calculateLunarNewYear(2026, 9)).toEqual(expected);
+    });
+
+    it('In 2028, UTC+9 diverges from UTC+7/+8', () => {
+      expect(calculateLunarNewYear(2028, 7)).toEqual({ year: 2028, month: 1, day: 26 });
+      expect(calculateLunarNewYear(2028, 8)).toEqual({ year: 2028, month: 1, day: 26 });
+      expect(calculateLunarNewYear(2028, 9)).toEqual({ year: 2028, month: 1, day: 27 });
+    });
+
+    it('In 2030, UTC+7 diverges from UTC+8/+9', () => {
+      expect(calculateLunarNewYear(2030, 7)).toEqual({ year: 2030, month: 2, day: 2 });
+      expect(calculateLunarNewYear(2030, 8)).toEqual({ year: 2030, month: 2, day: 3 });
+      expect(calculateLunarNewYear(2030, 9)).toEqual({ year: 2030, month: 2, day: 3 });
+    });
+  });
+});

--- a/packages/lunar-new-year/tsconfig.json
+++ b/packages/lunar-new-year/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["build", "src"]
+}

--- a/packages/lunar-new-year/tsconfig.release.json
+++ b/packages/lunar-new-year/tsconfig.release.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "node",
+    "rootDir": ".",
+    "removeComments": true,
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/rites/roman1969/__tests__/calendar-builder.test.ts
+++ b/rites/roman1969/__tests__/calendar-builder.test.ts
@@ -13,6 +13,7 @@ import {
   LiturgicalDayDef,
   Period,
   Romcal,
+  RomcalBundleObject,
   Season,
 } from '@src/rite-roman1969';
 
@@ -515,6 +516,52 @@ describe('Testing the Elevated Memorial option', () => {
     expect(optionalMemorials.length).toBe(0);
     expect(memorials.length).toBe(1);
     expect(memorials[0].id).toBe('hedwig_of_silesia_religious');
+  });
+
+  describe('Lunar New Year dateFn resolution (2028)', () => {
+    const makeTestBundle = (utcOffset: number): RomcalBundleObject => ({
+      ...GeneralRoman_En,
+      calendarName: 'test_lunar_new_year',
+      inputs: {
+        ...GeneralRoman_En.inputs,
+        lunar_new_year_test: [
+          {
+            dateDef: { dateFn: 'lunarNewYear', dateArgs: [utcOffset] },
+            precedence: 'PROPER_FEAST_8F',
+            commonsDef: 'None',
+            fromCalendarId: 'test_lunar_new_year',
+          },
+        ],
+      },
+      i18n: {
+        ...GeneralRoman_En.i18n,
+        names: {
+          ...GeneralRoman_En.i18n.names,
+          lunar_new_year_test: 'Lunar New Year Test',
+        },
+      },
+    });
+
+    test('UTC+7 resolves to January 26', async () => {
+      const calendar = await new Romcal({ localizedCalendar: makeTestBundle(7) }).generateCalendar(2028);
+      const entry = calendar['2028-01-26'].find((d) => d.id === 'lunar_new_year_test');
+      expect(entry).toBeDefined();
+      expect(entry!.name).toBe('Lunar New Year Test');
+    });
+
+    test('UTC+8 resolves to January 26', async () => {
+      const calendar = await new Romcal({ localizedCalendar: makeTestBundle(8) }).generateCalendar(2028);
+      const entry = calendar['2028-01-26'].find((d) => d.id === 'lunar_new_year_test');
+      expect(entry).toBeDefined();
+      expect(entry!.name).toBe('Lunar New Year Test');
+    });
+
+    test('UTC+9 resolves to January 27', async () => {
+      const calendar = await new Romcal({ localizedCalendar: makeTestBundle(9) }).generateCalendar(2028);
+      const entry = calendar['2028-01-27'].find((d) => d.id === 'lunar_new_year_test');
+      expect(entry).toBeDefined();
+      expect(entry!.name).toBe('Lunar New Year Test');
+    });
   });
 });
 

--- a/rites/roman1969/__tests__/dates.test.ts
+++ b/rites/roman1969/__tests__/dates.test.ts
@@ -884,4 +884,69 @@ describe('Testing specific liturgical date functions', () => {
       }
     });
   });
+
+  describe('Lunar New Year', () => {
+    test('In 2026, Lunar New Year (UTC+7, Vietnam) is February 17', () => {
+      const date = new Romcal().dates().lunarNewYear(7, 2026);
+      expect(date.getUTCFullYear()).toEqual(2026);
+      expect(date.getUTCMonth()).toEqual(1);
+      expect(date.getUTCDate()).toEqual(17);
+    });
+
+    test('In 2026, Lunar New Year (UTC+8, China/Hong Kong/Taiwan) is February 17', () => {
+      const date = new Romcal().dates().lunarNewYear(8, 2026);
+      expect(date.getUTCFullYear()).toEqual(2026);
+      expect(date.getUTCMonth()).toEqual(1);
+      expect(date.getUTCDate()).toEqual(17);
+    });
+
+    test('In 2026, Lunar New Year (UTC+9, Korea/Japan) is February 17', () => {
+      const date = new Romcal().dates().lunarNewYear(9, 2026);
+      expect(date.getUTCFullYear()).toEqual(2026);
+      expect(date.getUTCMonth()).toEqual(1);
+      expect(date.getUTCDate()).toEqual(17);
+    });
+
+    test('In 2028, Lunar New Year (UTC+7, Vietnam) is January 26', () => {
+      const date = new Romcal().dates().lunarNewYear(7, 2028);
+      expect(date.getUTCFullYear()).toEqual(2028);
+      expect(date.getUTCMonth()).toEqual(0);
+      expect(date.getUTCDate()).toEqual(26);
+    });
+
+    test('In 2028, Lunar New Year (UTC+8, China/Hong Kong/Taiwan) is January 26', () => {
+      const date = new Romcal().dates().lunarNewYear(8, 2028);
+      expect(date.getUTCFullYear()).toEqual(2028);
+      expect(date.getUTCMonth()).toEqual(0);
+      expect(date.getUTCDate()).toEqual(26);
+    });
+
+    test('In 2028, Lunar New Year (UTC+9, Korea/Japan) is January 27', () => {
+      const date = new Romcal().dates().lunarNewYear(9, 2028);
+      expect(date.getUTCFullYear()).toEqual(2028);
+      expect(date.getUTCMonth()).toEqual(0);
+      expect(date.getUTCDate()).toEqual(27);
+    });
+
+    test('In 2030, Lunar New Year (UTC+7, Vietnam) is February 2', () => {
+      const date = new Romcal().dates().lunarNewYear(7, 2030);
+      expect(date.getUTCFullYear()).toEqual(2030);
+      expect(date.getUTCMonth()).toEqual(1);
+      expect(date.getUTCDate()).toEqual(2);
+    });
+
+    test('In 2030, Lunar New Year (UTC+8, China/Hong Kong/Taiwan) is February 3', () => {
+      const date = new Romcal().dates().lunarNewYear(8, 2030);
+      expect(date.getUTCFullYear()).toEqual(2030);
+      expect(date.getUTCMonth()).toEqual(1);
+      expect(date.getUTCDate()).toEqual(3);
+    });
+
+    test('In 2030, Lunar New Year (UTC+9, Korea/Japan) is February 3', () => {
+      const date = new Romcal().dates().lunarNewYear(9, 2030);
+      expect(date.getUTCFullYear()).toEqual(2030);
+      expect(date.getUTCMonth()).toEqual(1);
+      expect(date.getUTCDate()).toEqual(3);
+    });
+  });
 });

--- a/rites/roman1969/package.json
+++ b/rites/roman1969/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@internal/easter": "file:../../packages/easter",
+    "@internal/lunar-new-year": "file:../../packages/lunar-new-year",
     "i18next": "^25.8.13",
     "ts-deepmerge": "^7.0.3"
   },

--- a/rites/roman1969/src/index.ts
+++ b/rites/roman1969/src/index.ts
@@ -373,6 +373,8 @@ class Romcal {
 
   static computeJulianEasterDate = calculateJulianEasterDateToGregorianDate;
 
+  static computeLunarNewYear = Dates.lunarNewYear;
+
   static rangeContainsDate = rangeContainsDate;
 
   static rangeOfDays = rangeOfDays;

--- a/rites/roman1969/src/utils/dates.ts
+++ b/rites/roman1969/src/utils/dates.ts
@@ -1,4 +1,5 @@
 import { calculateGregorianEasterDate, calculateJulianEasterDateToGregorianDate } from '@internal/easter';
+import { calculateLunarNewYear } from '@internal/lunar-new-year';
 
 import { Season } from '../constants/seasons';
 import { RomcalConfig } from '../models/config';
@@ -1243,6 +1244,24 @@ export class Dates {
   };
 
   #exaltationOfTheHolyCross: Record<string, Date> = {};
+
+  /**
+   * Get the date of Lunar New Year for the given year.
+   * @param utcOffset UTC offset for the target timezone (e.g. 8 for China/HK/Taiwan, 9 for Korea/Japan, 7 for Vietnam)
+   * @param year Gregorian year
+   */
+  lunarNewYear = (utcOffset: number, year = this.#year): Date => {
+    const id = `${utcOffset}:${year}`;
+    if (this.#lunarNewYear[id]) return this.#lunarNewYear[id];
+    return (this.#lunarNewYear[id] = Dates.lunarNewYear(utcOffset, year));
+  };
+
+  #lunarNewYear: Record<string, Date> = {};
+
+  static lunarNewYear = (utcOffset: number, year: number): Date => {
+    const { month, day } = calculateLunarNewYear(year, utcOffset);
+    return getUtcDate(year, month, day);
+  };
 
   startOfSeasons = (year = this.#year): Record<Season, Date> => {
     if (this.#startOfSeasons[year]) return this.#startOfSeasons[year];

--- a/rites/roman1969/src/utils/dates.ts
+++ b/rites/roman1969/src/utils/dates.ts
@@ -1259,7 +1259,7 @@ export class Dates {
   #lunarNewYear: Record<string, Date> = {};
 
   static lunarNewYear = (utcOffset: number, year: number): Date => {
-    const { month, day } = calculateLunarNewYear(year, utcOffset);
+    const { day, month } = calculateLunarNewYear(year, utcOffset);
     return getUtcDate(year, month, day);
   };
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,6 +25,7 @@
       "@src/rite-roman1969": ["./rites/roman1969/src"],
       "@internal/config": ["./packages/config"],
       "@internal/easter": ["./packages/easter"],
+      "@internal/lunar-new-year": ["./packages/lunar-new-year"],
       "@internal/package.json": ["./package.json"]
     }
   },


### PR DESCRIPTION
## What is the purpose of this pull request?

Add Lunar New Year date computation so that dioceses (e.g. Hong Kong) can define liturgical celebrations relative to the Lunar New Year using `dateFn: 'lunarNewYear'` in their calendar definitions.

Closes #1083

## Concept

  - Calendar Definition
  - Infrastructure

##  Changes

- New `@internal/lunar-new-year` package using Jean Meeus's astronomical algorithms (winter solstice + new moon phases)
- `calculateLunarNewYear(year, utcOffset)` accepts a UTC offset for regional variations:
    - UTC+7 (Vietnam, Thailand, Cambodia, Laos...)
    - UTC+8 (China/Hong Kong/Taiwan)
    - UTC+9 (Korea/Japan)
- Integrated into the `Dates` class as `lunarNewYear(utcOffset, year)` and exposed as `Romcal.computeLunarNewYear`
- Available in calendar definitions via `dateDef: { dateFn: 'lunarNewYear', dateArgs: [8] }`
- Verified against [pinyin.info](https://pinyin.info/chinese_new_year/cny2000-2099.html) reference data for 2000–2099

## Example code

```typescript
// In a calendar definition
dateDef: { dateFn: 'lunarNewYear', dateArgs: [8] }             // Lunar New Year (UTC+8)
dateDef: { dateFn: 'lunarNewYear', dateArgs: [8], addDay: 4 }  // 4 days after (UTC+8)
dateDef: { dateFn: 'lunarNewYear', dateArgs: [7] }             // UTC+7 (Vietnam)

// Direct usage
Romcal.computeLunarNewYear(8, 2025); // 2025-01-29T00:00:00.000Z
```

- [x] By submitting this pull request, I confirm that I have read and agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
